### PR TITLE
A few renamings and bug fixes

### DIFF
--- a/src/cuda/cuda_allocator.f90
+++ b/src/cuda/cuda_allocator.f90
@@ -1,26 +1,26 @@
-module m_cudaallocator
+module m_cuda_allocator
    use m_allocator, only: allocator_t, field_t
    implicit none
 
-   type, extends(allocator_t) :: cudaallocator_t
+   type, extends(allocator_t) :: cuda_allocator_t
    contains
       procedure :: create_block => create_cuda_block
-   end type cudaallocator_t
+   end type cuda_allocator_t
 
-   type, extends(field_t) :: cudafield_t
+   type, extends(field_t) :: cuda_field_t
       real, allocatable, device :: data_d(:, :, :)
-   end type cudafield_t
+   end type cuda_field_t
 
-   interface cudafield_t
+   interface cuda_field_t
       module procedure cuda_field_constructor
-   end interface cudafield_t
+   end interface cuda_field_t
 
 contains
 
    function cuda_field_constructor(dims, next, id) result(m)
       integer, intent(in) :: dims(3), id
-      type(cudafield_t), pointer, intent(in) :: next
-      type(cudafield_t) :: m
+      type(cuda_field_t), pointer, intent(in) :: next
+      type(cuda_field_t) :: m
 
       allocate (m%data_d(dims(1), dims(2), dims(3)))
       m%refcount = 0
@@ -29,14 +29,14 @@ contains
    end function cuda_field_constructor
 
    function create_cuda_block(self, next) result(ptr)
-      class(cudaallocator_t), intent(inout) :: self
-      type(cudafield_t), pointer, intent(in) :: next
-      type(cudafield_t), pointer :: newblock
+      class(cuda_allocator_t), intent(inout) :: self
+      type(cuda_field_t), pointer, intent(in) :: next
+      type(cuda_field_t), pointer :: newblock
       class(field_t), pointer :: ptr
       allocate (newblock)
       self%id = self%id + 1
-      newblock = cudafield_t(self%dims, next, id=self%id)
+      newblock = cuda_field_t(self%dims, next, id=self%id)
       ptr => newblock
    end function create_cuda_block
 
-end module m_cudaallocator
+end module m_cuda_allocator

--- a/src/cuda/cuda_allocator.f90
+++ b/src/cuda/cuda_allocator.f90
@@ -1,5 +1,5 @@
 module m_cudaallocator
-   use m_allocator, only: allocator_t, memblock_t
+   use m_allocator, only: allocator_t, field_t
    implicit none
 
    type, extends(allocator_t) :: cudaallocator_t
@@ -7,35 +7,35 @@ module m_cudaallocator
       procedure :: create_block => create_cuda_block
    end type cudaallocator_t
 
-   type, extends(memblock_t) :: cudamemblock_t
+   type, extends(field_t) :: cudafield_t
       real, allocatable, device :: data_d(:, :, :)
-   end type cudamemblock_t
+   end type cudafield_t
 
-   interface cudamemblock_t
-      module procedure cuda_memblock_constructor
-   end interface cudamemblock_t
+   interface cudafield_t
+      module procedure cuda_field_constructor
+   end interface cudafield_t
 
 contains
 
-   function cuda_memblock_constructor(dims, next, id) result(m)
+   function cuda_field_constructor(dims, next, id) result(m)
       integer, intent(in) :: dims(3), id
-      type(cudamemblock_t), pointer, intent(in) :: next
-      type(cudamemblock_t) :: m
+      type(cudafield_t), pointer, intent(in) :: next
+      type(cudafield_t) :: m
 
       allocate (m%data_d(dims(1), dims(2), dims(3)))
       m%refcount = 0
       m%next => next
       m%id = id
-   end function cuda_memblock_constructor
+   end function cuda_field_constructor
 
    function create_cuda_block(self, next) result(ptr)
       class(cudaallocator_t), intent(inout) :: self
-      type(cudamemblock_t), pointer, intent(in) :: next
-      type(cudamemblock_t), pointer :: newblock
-      class(memblock_t), pointer :: ptr
+      type(cudafield_t), pointer, intent(in) :: next
+      type(cudafield_t), pointer :: newblock
+      class(field_t), pointer :: ptr
       allocate (newblock)
       self%id = self%id + 1
-      newblock = cudamemblock_t(self%dims, next, id=self%id)
+      newblock = cudafield_t(self%dims, next, id=self%id)
       ptr => newblock
    end function create_cuda_block
 

--- a/src/cuda/cuda_allocator.f90
+++ b/src/cuda/cuda_allocator.f90
@@ -34,8 +34,8 @@ contains
       type(cuda_field_t), pointer :: newblock
       class(field_t), pointer :: ptr
       allocate (newblock)
-      self%id = self%id + 1
-      newblock = cuda_field_t(self%dims, next, id=self%id)
+      self%next_id = self%next_id + 1
+      newblock = cuda_field_t(self%dims, next, id=self%next_id)
       ptr => newblock
    end function create_cuda_block
 

--- a/src/vector3d.f90
+++ b/src/vector3d.f90
@@ -12,7 +12,8 @@ module m_slab
       class(field_t), pointer :: u1, u2, u3
       real :: xnu
    contains
-      procedure(field_op), deferred :: transport, div
+      procedure(field_op), deferred :: transport
+      procedure(field_op), deferred :: div
       procedure(transport_op), deferred :: transport_dir
       procedure, public :: u => get_component_ptr
    end type slab_t

--- a/src/vector3d.f90
+++ b/src/vector3d.f90
@@ -1,7 +1,7 @@
 module m_slab
    use m_stencil, only: stencil
    use m_tridiagsolv, only: tridiagsolv
-   use m_allocator, only: allocator_t, memblock_t
+   use m_allocator, only: allocator_t, field_t
 
    implicit none
 
@@ -9,7 +9,7 @@ module m_slab
       character(len=:), allocatable :: name
       integer :: rankid, nranks
       class(allocator_t), pointer :: allocator
-      class(memblock_t), pointer :: u1, u2, u3
+      class(field_t), pointer :: u1, u2, u3
       real :: xnu
    contains
       procedure(field_op), deferred :: transport, div

--- a/src/vector3d_cuda.f90
+++ b/src/vector3d_cuda.f90
@@ -1,12 +1,12 @@
 module m_slab_cuda
-   use m_allocator, only: cudaallocator_t, cudamemblock_t
+   use m_allocator, only: cudaallocator_t, cudafield_t
    use m_slab, only: slab
    use m_diffengine, only: diffengine
 
    type, extends(slab) :: slab_cuda_t
       integer :: dims(3)
       type(cudaallocator_t), pointer :: allocator
-      type(cudamemblock_t), pointer :: u1, u2, u3
+      type(cudafield_t), pointer :: u1, u2, u3
    contains
       procedure, public :: transport
       procedure, public :: div

--- a/src/vector3d_cuda.f90
+++ b/src/vector3d_cuda.f90
@@ -1,12 +1,12 @@
 module m_slab_cuda
-   use m_allocator, only: cudaallocator_t, cudafield_t
+   use m_allocator, only: cuda_allocator_t, cuda_field_t
    use m_slab, only: slab
    use m_diffengine, only: diffengine
 
    type, extends(slab) :: slab_cuda_t
       integer :: dims(3)
-      type(cudaallocator_t), pointer :: allocator
-      type(cudafield_t), pointer :: u1, u2, u3
+      type(cuda_allocator_t), pointer :: allocator
+      type(cuda_field_t), pointer :: u1, u2, u3
    contains
       procedure, public :: transport
       procedure, public :: div
@@ -20,7 +20,7 @@ module m_slab_cuda
 contains
 
    function make_slab_cuda(allocator, diffeng, diffeng2) result(self)
-      type(cudaallocator_t), pointer, intent(in) :: allocator
+      type(cuda_allocator_t), pointer, intent(in) :: allocator
       type(diffengine), intent(in) :: diffeng, diffeng2
       type(slab_cuda_t) :: self
 

--- a/src/vector3d_simd.f90
+++ b/src/vector3d_simd.f90
@@ -3,12 +3,12 @@ module m_slab_cpu
    use mpi
 
    use m_allocator, only: allocator_t, field_t
-   use m_slab, only: slab
+   use m_slab, only: slab_t
    use m_diffengine, only: diffengine_t
 
    implicit none
 
-   type, extends(slab) :: slab_cpu_t
+   type, extends(slab_t) :: slab_cpu_t
       private
       type(diffengine_t) :: diffeng, diffeng2
    contains
@@ -18,7 +18,7 @@ module m_slab_cpu
    end type slab_cpu_t
 
    interface slab_cpu_t
-      module procedure make_slab_cpu_t
+      module procedure make_slab_cpu
    end interface slab_cpu_t
 
 contains
@@ -45,7 +45,7 @@ contains
 
    function transport(self)
       class(slab_cpu_t), intent(in) :: self
-      class(vector3d), allocatable :: transport
+      class(slab_t), allocatable :: transport
       transport = slab_cpu_t(&
            & self%allocator, self%diffeng, self%diffeng2 &
            & )
@@ -95,13 +95,13 @@ contains
 
    function div(self) result(rslt)
       class(slab_cpu_t), intent(in) :: self
-      class(vector3d), allocatable :: rslt
+      class(slab_t), allocatable :: rslt
       allocate (slab_cpu_t :: rslt)
       rslt = slab_cpu_t( &
            & self%allocator, self%diffeng, self%diffeng2 &
            & )
-      rslt%u(1) = self%u(1) + 1.
-      rslt%u(2) = self%u(2) + 1.
-      rslt%u(3) = self%u(3) + 1.
+      rslt%u1%data = self%u1%data + 1.
+      rslt%u2%data = self%u2%data + 1.
+      rslt%u3%data = self%u3%data + 1.
    end function div
 end module m_slab_cpu

--- a/src/vector3d_simd.f90
+++ b/src/vector3d_simd.f90
@@ -2,7 +2,7 @@ module m_slab_cpu
 
    use mpi
 
-   use m_allocator, only: allocator_t, memblock_t
+   use m_allocator, only: allocator_t, field_t
    use m_slab, only: slab
    use m_diffengine, only: diffengine_t
 

--- a/tests/cuda/test_cuda_allocator.f90
+++ b/tests/cuda/test_cuda_allocator.f90
@@ -43,7 +43,7 @@ program test_allocator_cuda
   !! Destroy the free list and check that the list is empty again.
   call allocator%destroy()
   l = allocator%get_block_ids()
-  if (size(l) /= 1 .or. l(1) /= 0 .or. allocator%id /=0) then
+  if (size(l) /= 1 .or. l(1) /= 0 .or. allocator%next_id /=0) then
      allpass = .false.
      write(stderr, '(a)') 'Free list is correctly destroyed... failed'
   else

--- a/tests/cuda/test_cuda_allocator.f90
+++ b/tests/cuda/test_cuda_allocator.f90
@@ -1,18 +1,18 @@
 program test_allocator_cuda
   use iso_fortran_env, only: stderr => error_unit
 
-  use m_allocator, only: allocator_t, memblock_t
-  use m_cudaallocator, only: cudaallocator_t
+  use m_allocator, only: allocator_t, field_t
+  use m_cuda_allocator, only: cuda_allocator_t
 
   implicit none
 
   logical :: allpass
   integer, parameter :: dims(3) = [8, 8, 8]
   class(allocator_t), allocatable :: allocator
-  class(memblock_t), pointer :: ptr1, ptr2, ptr3
+  class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
 
-  allocator = cudaallocator_t(dims)
+  allocator = cuda_allocator_t(dims)
 
   allpass = .true.
 

--- a/tests/test_allocator.f90
+++ b/tests/test_allocator.f90
@@ -1,14 +1,14 @@
 program test_allocator
   use iso_fortran_env, only: stderr => error_unit
 
-  use m_allocator, only: allocator_t, memblock_t
+  use m_allocator, only: allocator_t, field_t
 
   implicit none
 
   logical :: allpass
   integer, parameter :: dims(3) = [8, 8, 8]
   class(allocator_t), allocatable :: allocator
-  class(memblock_t), pointer :: ptr1, ptr2, ptr3
+  class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
 
   allocator = allocator_t(dims)

--- a/tests/test_diffengine.f90
+++ b/tests/test_diffengine.f90
@@ -7,22 +7,29 @@ program test_diffengine
 
   type(diffengine_t) :: diffeng
   integer, parameter :: n = 20
-  integer :: i
-  real, allocatable :: f(:), expected(:)
+  integer :: i, j
   real, allocatable :: f_vec(:, :), expected_vec(:, :), df(:, :)
   real :: dx
-  logical :: allpass
+  logical :: allpass = .true.
   integer, parameter :: SZ = 4
   real, parameter :: tol = 0.01
 
   dx = 2. * acos(-1.) / (n - 1)
-  f = [(sin((i-1)*dx), i=1,n)]
-  f_vec = transpose(reshape(f, [n, SZ], pad = f))
-  allpass = .true.
+  allocate(f_vec(SZ,n))
+  do j = 1, n
+     do i = 1, SZ
+        f_vec(i, j) = sin((j-1)*dx)
+     end do
+  end do
 
   ! First derivative with periodic boundary conditions
-  expected = [(cos((i-1)*dx), i=1,n)]
-  expected_vec = transpose(reshape(expected, [n, SZ], pad = expected))
+  allocate(expected_vec(SZ,n))
+  do j = 1, n
+     do i = 1, SZ
+        expected_vec(i, j) = cos((j-1)*dx)
+     end do
+  end do
+
   diffeng = diffengine_t("compact6", length=n, order=1, dx=dx)
   allocate(df, source=f_vec)
   call diffeng%diff(f_vec, df)

--- a/tests/test_stencil.f90
+++ b/tests/test_stencil.f90
@@ -6,7 +6,7 @@ program test_stencil
 
   implicit none
 
-  logical :: allpass
+  logical :: allpass = .true.
   real, parameter :: tol = 0.001
 
   type(stencil) :: test_stencil_order_1, test_stencil_order_2


### PR DESCRIPTION
- memblock_t is renamed as field_t because we use allocator and memblock exclusively for allocating scalar fields.
- cudaallocator and cudafield(cudamemblock) is renamed with underscore, I think it looks better and easier to read
- The rest is just few small bug fixes