### PR TITLE
Add a fused distributed kernel for the transport equation

### DIFF
--- a/src/cuda/kernels_dist.f90
+++ b/src/cuda/kernels_dist.f90
@@ -193,4 +193,445 @@ contains
 
    end subroutine der_univ_subs
 
+   attributes(global) subroutine transeq_3fused_dist( &
+      du, dud, d2u, &
+      send_du_s, send_du_e, send_dud_s, send_dud_e, send_d2u_s, send_d2u_e, &
+      u, u_s, u_e, v, v_s, v_e, n, &
+      d1_coeffs_s, d1_coeffs_e, d1_coeffs, d1_fw, d1_bw, d1_af, &
+      d2_coeffs_s, d2_coeffs_e, d2_coeffs, d2_fw, d2_bw, d2_af &
+      )
+      implicit none
+
+      ! Arguments
+      real(dp), device, intent(out), dimension(:, :, :) :: du, dud, d2u
+      real(dp), device, intent(out), dimension(:, :, :) :: &
+         send_du_s, send_du_e, send_dud_s, send_dud_e, send_d2u_s, send_d2u_e
+      real(dp), device, intent(in), dimension(:, :, :) :: u, u_s, u_e, &
+                                                          v, v_s, v_e
+      integer, value, intent(in) :: n
+      real(dp), device, intent(in) :: d1_coeffs_s(:, :), d1_coeffs_e(:, :), &
+                                      d1_coeffs(:)
+      real(dp), device, intent(in) :: d1_fw(:), d1_bw(:), d1_af(:)
+      real(dp), device, intent(in) :: d2_coeffs_s(:, :), d2_coeffs_e(:, :), &
+                                      d2_coeffs(:)
+      real(dp), device, intent(in) :: d2_fw(:), d2_bw(:), d2_af(:)
+
+      ! Local variables
+      integer :: i, j, b, k
+
+      real(dp) :: d1_c_m4, d1_c_m3, d1_c_m2, d1_c_m1, d1_c_j, &
+                  d1_c_p1, d1_c_p2, d1_c_p3, d1_c_p4, &
+                  d1_alpha, d1_last_r
+      real(dp) :: d2_c_m4, d2_c_m3, d2_c_m2, d2_c_m1, d2_c_j, &
+                  d2_c_p1, d2_c_p2, d2_c_p3, d2_c_p4, &
+                  d2_alpha, d2_last_r
+      real(dp) :: temp_du, temp_dud, temp_d2u
+
+      i = threadIdx%x
+      b = blockIdx%x
+
+      ! store bulk coeffs in the registers
+      d1_c_m4 = d1_coeffs(1); d1_c_m3 = d1_coeffs(2)
+      d1_c_m2 = d1_coeffs(3); d1_c_m1 = d1_coeffs(4)
+      d1_c_j = d1_coeffs(5)
+      d1_c_p1 = d1_coeffs(6); d1_c_p2 = d1_coeffs(7)
+      d1_c_p3 = d1_coeffs(8); d1_c_p4 = d1_coeffs(9)
+      d1_last_r = d1_fw(1)
+
+      d2_c_m4 = d2_coeffs(1); d2_c_m3 = d2_coeffs(2)
+      d2_c_m2 = d2_coeffs(3); d2_c_m1 = d2_coeffs(4)
+      d2_c_j = d2_coeffs(5)
+      d2_c_p1 = d2_coeffs(6); d2_c_p2 = d2_coeffs(7)
+      d2_c_p3 = d2_coeffs(8); d2_c_p4 = d2_coeffs(9)
+      d2_last_r = d2_fw(1)
+
+      ! j = 1
+      temp_du = d1_coeffs_s(1, 1)*u_s(i, 1, b) &
+                + d1_coeffs_s(2, 1)*u_s(i, 2, b) &
+                + d1_coeffs_s(3, 1)*u_s(i, 3, b) &
+                + d1_coeffs_s(4, 1)*u_s(i, 4, b) &
+                + d1_coeffs_s(5, 1)*u(i, 1, b) &
+                + d1_coeffs_s(6, 1)*u(i, 2, b) &
+                + d1_coeffs_s(7, 1)*u(i, 3, b) &
+                + d1_coeffs_s(8, 1)*u(i, 4, b) &
+                + d1_coeffs_s(9, 1)*u(i, 5, b)
+      du(i, 1, b) = temp_du*d1_af(1)
+      temp_dud = d1_coeffs_s(1, 1)*u_s(i, 1, b)*v_s(i, 1, b) &
+                 + d1_coeffs_s(2, 1)*u_s(i, 2, b)*v_s(i, 2, b) &
+                 + d1_coeffs_s(3, 1)*u_s(i, 3, b)*v_s(i, 3, b) &
+                 + d1_coeffs_s(4, 1)*u_s(i, 4, b)*v_s(i, 4, b) &
+                 + d1_coeffs_s(5, 1)*u(i, 1, b)*v(i, 1, b) &
+                 + d1_coeffs_s(6, 1)*u(i, 2, b)*v(i, 2, b) &
+                 + d1_coeffs_s(7, 1)*u(i, 3, b)*v(i, 3, b) &
+                 + d1_coeffs_s(8, 1)*u(i, 4, b)*v(i, 4, b) &
+                 + d1_coeffs_s(9, 1)*u(i, 5, b)*v(i, 5, b)
+      dud(i, 1, b) = temp_dud*d1_af(1)
+      temp_d2u = d2_coeffs_s(1, 1)*u_s(i, 1, b) &
+                 + d2_coeffs_s(2, 1)*u_s(i, 2, b) &
+                 + d2_coeffs_s(3, 1)*u_s(i, 3, b) &
+                 + d2_coeffs_s(4, 1)*u_s(i, 4, b) &
+                 + d2_coeffs_s(5, 1)*u(i, 1, b) &
+                 + d2_coeffs_s(6, 1)*u(i, 2, b) &
+                 + d2_coeffs_s(7, 1)*u(i, 3, b) &
+                 + d2_coeffs_s(8, 1)*u(i, 4, b) &
+                 + d2_coeffs_s(9, 1)*u(i, 5, b)
+      d2u(i, 1, b) = temp_d2u*d2_af(1)
+      ! j = 2
+      temp_du = d1_coeffs_s(1, 2)*u_s(i, 2, b) &
+                + d1_coeffs_s(2, 2)*u_s(i, 3, b) &
+                + d1_coeffs_s(3, 2)*u_s(i, 4, b) &
+                + d1_coeffs_s(4, 2)*u(i, 1, b) &
+                + d1_coeffs_s(5, 2)*u(i, 2, b) &
+                + d1_coeffs_s(6, 2)*u(i, 3, b) &
+                + d1_coeffs_s(7, 2)*u(i, 4, b) &
+                + d1_coeffs_s(8, 2)*u(i, 5, b) &
+                + d1_coeffs_s(9, 2)*u(i, 6, b)
+      du(i, 2, b) = temp_du*d1_af(2)
+      temp_dud = d1_coeffs_s(1, 2)*u_s(i, 2, b)*v_s(i, 2, b) &
+                 + d1_coeffs_s(2, 2)*u_s(i, 3, b)*v_s(i, 3, b) &
+                 + d1_coeffs_s(3, 2)*u_s(i, 4, b)*v_s(i, 4, b) &
+                 + d1_coeffs_s(4, 2)*u(i, 1, b)*v(i, 1, b) &
+                 + d1_coeffs_s(5, 2)*u(i, 2, b)*v(i, 2, b) &
+                 + d1_coeffs_s(6, 2)*u(i, 3, b)*v(i, 3, b) &
+                 + d1_coeffs_s(7, 2)*u(i, 4, b)*v(i, 4, b) &
+                 + d1_coeffs_s(8, 2)*u(i, 5, b)*v(i, 5, b) &
+                 + d1_coeffs_s(9, 2)*u(i, 6, b)*v(i, 6, b)
+      dud(i, 2, b) = temp_dud*d1_af(2)
+      temp_d2u = d2_coeffs_s(1, 2)*u_s(i, 2, b) &
+                 + d2_coeffs_s(2, 2)*u_s(i, 3, b) &
+                 + d2_coeffs_s(3, 2)*u_s(i, 4, b) &
+                 + d2_coeffs_s(4, 2)*u(i, 1, b) &
+                 + d2_coeffs_s(5, 2)*u(i, 2, b) &
+                 + d2_coeffs_s(6, 2)*u(i, 3, b) &
+                 + d2_coeffs_s(7, 2)*u(i, 4, b) &
+                 + d2_coeffs_s(8, 2)*u(i, 5, b) &
+                 + d2_coeffs_s(9, 2)*u(i, 6, b)
+      d2u(i, 2, b) = temp_d2u*d2_af(2)
+      ! j = 3
+      temp_du = d1_coeffs_s(1, 3)*u_s(i, 3, b) &
+                + d1_coeffs_s(2, 3)*u_s(i, 4, b) &
+                + d1_coeffs_s(3, 3)*u(i, 1, b) &
+                + d1_coeffs_s(4, 3)*u(i, 2, b) &
+                + d1_coeffs_s(5, 3)*u(i, 3, b) &
+                + d1_coeffs_s(6, 3)*u(i, 4, b) &
+                + d1_coeffs_s(7, 3)*u(i, 5, b) &
+                + d1_coeffs_s(8, 3)*u(i, 6, b) &
+                + d1_coeffs_s(9, 3)*u(i, 7, b)
+      du(i, 3, b) = d1_fw(3)*(temp_du - d1_af(3)*du(i, 2, b))
+      temp_dud = d1_coeffs_s(1, 3)*u_s(i, 3, b)*v_s(i, 3, b) &
+                 + d1_coeffs_s(2, 3)*u_s(i, 4, b)*v_s(i, 4, b) &
+                 + d1_coeffs_s(3, 3)*u(i, 1, b)*v(i, 1, b) &
+                 + d1_coeffs_s(4, 3)*u(i, 2, b)*v(i, 2, b) &
+                 + d1_coeffs_s(5, 3)*u(i, 3, b)*v(i, 3, b) &
+                 + d1_coeffs_s(6, 3)*u(i, 4, b)*v(i, 4, b) &
+                 + d1_coeffs_s(7, 3)*u(i, 5, b)*v(i, 5, b) &
+                 + d1_coeffs_s(8, 3)*u(i, 6, b)*v(i, 6, b) &
+                 + d1_coeffs_s(9, 3)*u(i, 7, b)*v(i, 7, b)
+      dud(i, 3, b) = d1_fw(3)*(temp_dud - d1_af(3)*dud(i, 2, b))
+      temp_d2u = d2_coeffs_s(1, 3)*u_s(i, 3, b) &
+                + d2_coeffs_s(2, 3)*u_s(i, 4, b) &
+                + d2_coeffs_s(3, 3)*u(i, 1, b) &
+                + d2_coeffs_s(4, 3)*u(i, 2, b) &
+                + d2_coeffs_s(5, 3)*u(i, 3, b) &
+                + d2_coeffs_s(6, 3)*u(i, 4, b) &
+                + d2_coeffs_s(7, 3)*u(i, 5, b) &
+                + d2_coeffs_s(8, 3)*u(i, 6, b) &
+                + d2_coeffs_s(9, 3)*u(i, 7, b)
+      d2u(i, 3, b) = d2_fw(3)*(temp_d2u - d2_af(3)*d2u(i, 2, b))
+      ! j = 4
+      temp_du = d1_coeffs_s(1, 4)*u_s(i, 4, b) &
+                + d1_coeffs_s(2, 4)*u(i, 1, b) &
+                + d1_coeffs_s(3, 4)*u(i, 2, b) &
+                + d1_coeffs_s(4, 4)*u(i, 3, b) &
+                + d1_coeffs_s(5, 4)*u(i, 4, b) &
+                + d1_coeffs_s(6, 4)*u(i, 5, b) &
+                + d1_coeffs_s(7, 4)*u(i, 6, b) &
+                + d1_coeffs_s(8, 4)*u(i, 7, b) &
+                + d1_coeffs_s(9, 4)*u(i, 8, b)
+      du(i, 4, b) = d1_fw(4)*(temp_du - d1_af(3)*du(i, 3, b))
+      temp_dud = d1_coeffs_s(1, 4)*u_s(i, 4, b)*v_s(i, 4, b) &
+                 + d1_coeffs_s(2, 4)*u(i, 1, b)*v(i, 1, b) &
+                 + d1_coeffs_s(3, 4)*u(i, 2, b)*v(i, 2, b) &
+                 + d1_coeffs_s(4, 4)*u(i, 3, b)*v(i, 3, b) &
+                 + d1_coeffs_s(5, 4)*u(i, 4, b)*v(i, 4, b) &
+                 + d1_coeffs_s(6, 4)*u(i, 5, b)*v(i, 5, b) &
+                 + d1_coeffs_s(7, 4)*u(i, 6, b)*v(i, 6, b) &
+                 + d1_coeffs_s(8, 4)*u(i, 7, b)*v(i, 7, b) &
+                 + d1_coeffs_s(9, 4)*u(i, 8, b)*v(i, 8, b)
+      dud(i, 4, b) = d1_fw(4)*(temp_dud - d1_af(3)*dud(i, 3, b))
+      temp_d2u = d2_coeffs_s(1, 4)*u_s(i, 4, b) &
+                 + d2_coeffs_s(2, 4)*u(i, 1, b) &
+                 + d2_coeffs_s(3, 4)*u(i, 2, b) &
+                 + d2_coeffs_s(4, 4)*u(i, 3, b) &
+                 + d2_coeffs_s(5, 4)*u(i, 4, b) &
+                 + d2_coeffs_s(6, 4)*u(i, 5, b) &
+                 + d2_coeffs_s(7, 4)*u(i, 6, b) &
+                 + d2_coeffs_s(8, 4)*u(i, 7, b) &
+                 + d2_coeffs_s(9, 4)*u(i, 8, b)
+      d2u(i, 4, b) = d2_fw(4)*(temp_d2u - d2_af(3)*d2u(i, 3, b))
+
+      d1_alpha = d1_af(5)
+      d2_alpha = d2_af(5)
+
+      do j = 5, n - 4
+         ! du
+         temp_du = d1_c_m4*u(i, j - 4, b) &
+                   + d1_c_m3*u(i, j - 3, b) &
+                   + d1_c_m2*u(i, j - 2, b) &
+                   + d1_c_m1*u(i, j - 1, b) &
+                   + d1_c_j*u(i, j, b) &
+                   + d1_c_p1*u(i, j + 1, b) &
+                   + d1_c_p2*u(i, j + 2, b) &
+                   + d1_c_p3*u(i, j + 3, b) &
+                   + d1_c_p4*u(i, j + 4, b)
+         du(i, j, b) = d1_fw(j)*(temp_du - d1_alpha*du(i, j - 1, b))
+         ! dud
+         temp_dud = d1_c_m4*u(i, j - 4, b)*v(i, j - 4, b) &
+                    + d1_c_m3*u(i, j - 3, b)*v(i, j - 3, b) &
+                    + d1_c_m2*u(i, j - 2, b)*v(i, j - 2, b) &
+                    + d1_c_m1*u(i, j - 1, b)*v(i, j - 1, b) &
+                    + d1_c_j*u(i, j, b)*v(i, j, b) &
+                    + d1_c_p1*u(i, j + 1, b)*v(i, j + 1, b) &
+                    + d1_c_p2*u(i, j + 2, b)*v(i, j + 2, b) &
+                    + d1_c_p3*u(i, j + 3, b)*v(i, j + 3, b) &
+                    + d1_c_p4*u(i, j + 4, b)*v(i, j + 4, b)
+         dud(i, j, b) = d1_fw(j)*(temp_dud - d1_alpha*dud(i, j - 1, b))
+         ! d2u
+         temp_d2u = d2_c_m4*u(i, j - 4, b) &
+                    + d2_c_m3*u(i, j - 3, b) &
+                    + d2_c_m2*u(i, j - 2, b) &
+                    + d2_c_m1*u(i, j - 1, b) &
+                    + d2_c_j*u(i, j, b) &
+                    + d2_c_p1*u(i, j + 1, b) &
+                    + d2_c_p2*u(i, j + 2, b) &
+                    + d2_c_p3*u(i, j + 3, b) &
+                    + d2_c_p4*u(i, j + 4, b)
+         d2u(i, j, b) = d2_fw(j)*(temp_d2u - d2_alpha*d2u(i, j - 1, b))
+      end do
+
+      j = n - 3
+      temp_du = d1_coeffs_e(1, 1)*u(i, j - 4, b) &
+                + d1_coeffs_e(2, 1)*u(i, j - 3, b) &
+                + d1_coeffs_e(3, 1)*u(i, j - 2, b) &
+                + d1_coeffs_e(4, 1)*u(i, j - 1, b) &
+                + d1_coeffs_e(5, 1)*u(i, j, b) &
+                + d1_coeffs_e(6, 1)*u(i, j + 1, b) &
+                + d1_coeffs_e(7, 1)*u(i, j + 2, b) &
+                + d1_coeffs_e(8, 1)*u(i, j + 3, b) &
+                + d1_coeffs_e(9, 1)*u_e(i, 1, b)
+      du(i, j, b) = d1_fw(j)*(temp_du - d1_af(j)*du(i, j - 1, b))
+      temp_dud = d1_coeffs_e(1, 1)*u(i, j - 4, b)*v(i, j - 4, b) &
+                 + d1_coeffs_e(2, 1)*u(i, j - 3, b)*v(i, j - 3, b) &
+                 + d1_coeffs_e(3, 1)*u(i, j - 2, b)*v(i, j - 2, b) &
+                 + d1_coeffs_e(4, 1)*u(i, j - 1, b)*v(i, j - 1, b) &
+                 + d1_coeffs_e(5, 1)*u(i, j, b)*v(i, j, b) &
+                 + d1_coeffs_e(6, 1)*u(i, j + 1, b)*v(i, j + 1, b) &
+                 + d1_coeffs_e(7, 1)*u(i, j + 2, b)*v(i, j + 2, b) &
+                 + d1_coeffs_e(8, 1)*u(i, j + 3, b)*v(i, j + 3, b) &
+                 + d1_coeffs_e(9, 1)*u_e(i, 1, b)*v_e(i, 1, b)
+      dud(i, j, b) = d1_fw(j)*(temp_dud - d1_af(j)*dud(i, j - 1, b))
+      temp_d2u = d1_coeffs_e(1, 1)*u(i, j - 4, b) &
+                 + d2_coeffs_e(2, 1)*u(i, j - 3, b) &
+                 + d2_coeffs_e(3, 1)*u(i, j - 2, b) &
+                 + d2_coeffs_e(4, 1)*u(i, j - 1, b) &
+                 + d2_coeffs_e(5, 1)*u(i, j, b) &
+                 + d2_coeffs_e(6, 1)*u(i, j + 1, b) &
+                 + d2_coeffs_e(7, 1)*u(i, j + 2, b) &
+                 + d2_coeffs_e(8, 1)*u(i, j + 3, b) &
+                 + d2_coeffs_e(9, 1)*u_e(i, 1, b)
+      d2u(i, j, b) = d2_fw(j)*(temp_d2u - d2_af(j)*d2u(i, j - 1, b))
+      j = n - 2
+      temp_du = d1_coeffs_e(1, 2)*u(i, j - 4, b) &
+                + d1_coeffs_e(2, 2)*u(i, j - 3, b) &
+                + d1_coeffs_e(3, 2)*u(i, j - 2, b) &
+                + d1_coeffs_e(4, 2)*u(i, j - 1, b) &
+                + d1_coeffs_e(5, 2)*u(i, j, b) &
+                + d1_coeffs_e(6, 2)*u(i, j + 1, b) &
+                + d1_coeffs_e(7, 2)*u(i, j + 2, b) &
+                + d1_coeffs_e(8, 2)*u_e(i, 1, b) &
+                + d1_coeffs_e(9, 2)*u_e(i, 2, b)
+      du(i, j, b) = d1_fw(j)*(temp_du - d1_af(j)*du(i, j - 1, b))
+      temp_dud = d1_coeffs_e(1, 2)*u(i, j - 4, b)*v(i, j - 4, b) &
+                 + d1_coeffs_e(2, 2)*u(i, j - 3, b)*v(i, j - 3, b) &
+                 + d1_coeffs_e(3, 2)*u(i, j - 2, b)*v(i, j - 2, b) &
+                 + d1_coeffs_e(4, 2)*u(i, j - 1, b)*v(i, j - 1, b) &
+                 + d1_coeffs_e(5, 2)*u(i, j, b)*v(i, j, b) &
+                 + d1_coeffs_e(6, 2)*u(i, j + 1, b)*v(i, j + 1, b) &
+                 + d1_coeffs_e(7, 2)*u(i, j + 2, b)*v(i, j + 2, b) &
+                 + d1_coeffs_e(8, 2)*u_e(i, 1, b)*v_e(i, 1, b) &
+                 + d1_coeffs_e(9, 2)*u_e(i, 2, b)*v_e(i, 2, b)
+      dud(i, j, b) = d1_fw(j)*(temp_dud - d1_af(j)*dud(i, j - 1, b))
+      temp_d2u = d2_coeffs_e(1, 2)*u(i, j - 4, b) &
+                 + d2_coeffs_e(2, 2)*u(i, j - 3, b) &
+                 + d2_coeffs_e(3, 2)*u(i, j - 2, b) &
+                 + d2_coeffs_e(4, 2)*u(i, j - 1, b) &
+                 + d2_coeffs_e(5, 2)*u(i, j, b) &
+                 + d2_coeffs_e(6, 2)*u(i, j + 1, b) &
+                 + d2_coeffs_e(7, 2)*u(i, j + 2, b) &
+                 + d2_coeffs_e(8, 2)*u_e(i, 1, b) &
+                 + d2_coeffs_e(9, 2)*u_e(i, 2, b)
+      d2u(i, j, b) = d2_fw(j)*(temp_d2u - d2_af(j)*d2u(i, j - 1, b))
+      j = n - 1
+      temp_du = d1_coeffs_e(1, 3)*u(i, j - 4, b) &
+                + d1_coeffs_e(2, 3)*u(i, j - 3, b) &
+                + d1_coeffs_e(3, 3)*u(i, j - 2, b) &
+                + d1_coeffs_e(4, 3)*u(i, j - 1, b) &
+                + d1_coeffs_e(5, 3)*u(i, j, b) &
+                + d1_coeffs_e(6, 3)*u(i, j + 1, b) &
+                + d1_coeffs_e(7, 3)*u_e(i, 1, b) &
+                + d1_coeffs_e(8, 3)*u_e(i, 2, b) &
+                + d1_coeffs_e(9, 3)*u_e(i, 3, b)
+      du(i, j, b) = d1_fw(j)*(temp_du - d1_af(j)*du(i, j - 1, b))
+      temp_dud = d1_coeffs_e(1, 3)*u(i, j - 4, b)*v(i, j - 4, b) &
+                + d1_coeffs_e(2, 3)*u(i, j - 3, b)*v(i, j - 3, b) &
+                + d1_coeffs_e(3, 3)*u(i, j - 2, b)*v(i, j - 2, b) &
+                + d1_coeffs_e(4, 3)*u(i, j - 1, b)*v(i, j - 1, b) &
+                + d1_coeffs_e(5, 3)*u(i, j, b)*v(i, j, b) &
+                + d1_coeffs_e(6, 3)*u(i, j + 1, b)*v(i, j + 1, b) &
+                + d1_coeffs_e(7, 3)*u_e(i, 1, b)*v_e(i, 1, b) &
+                + d1_coeffs_e(8, 3)*u_e(i, 2, b)*v_e(i, 2, b) &
+                + d1_coeffs_e(9, 3)*u_e(i, 3, b)*v_e(i, 3, b)
+      dud(i, j, b) = d1_fw(j)*(temp_dud - d1_af(j)*dud(i, j - 1, b))
+      temp_d2u = d2_coeffs_e(1, 3)*u(i, j - 4, b) &
+                 + d2_coeffs_e(2, 3)*u(i, j - 3, b) &
+                 + d2_coeffs_e(3, 3)*u(i, j - 2, b) &
+                 + d2_coeffs_e(4, 3)*u(i, j - 1, b) &
+                 + d2_coeffs_e(5, 3)*u(i, j, b) &
+                 + d2_coeffs_e(6, 3)*u(i, j + 1, b) &
+                 + d2_coeffs_e(7, 3)*u_e(i, 1, b) &
+                 + d2_coeffs_e(8, 3)*u_e(i, 2, b) &
+                 + d2_coeffs_e(9, 3)*u_e(i, 3, b)
+      d2u(i, j, b) = d2_fw(j)*(temp_d2u - d2_af(j)*d2u(i, j - 1, b))
+      j = n
+      temp_du = d1_coeffs_e(1, 4)*u(i, j - 4, b) &
+                + d1_coeffs_e(2, 4)*u(i, j - 3, b) &
+                + d1_coeffs_e(3, 4)*u(i, j - 2, b) &
+                + d1_coeffs_e(4, 4)*u(i, j - 1, b) &
+                + d1_coeffs_e(5, 4)*u(i, j, b) &
+                + d1_coeffs_e(6, 4)*u_e(i, 1, b) &
+                + d1_coeffs_e(7, 4)*u_e(i, 2, b) &
+                + d1_coeffs_e(8, 4)*u_e(i, 3, b) &
+                + d1_coeffs_e(9, 4)*u_e(i, 4, b)
+      du(i, j, b) = d1_fw(j)*(temp_du - d1_af(j)*du(i, j - 1, b))
+      temp_dud = d1_coeffs_e(1, 4)*u(i, j - 4, b)*v(i, j - 4, b) &
+                + d1_coeffs_e(2, 4)*u(i, j - 3, b)*v(i, j - 3, b) &
+                + d1_coeffs_e(3, 4)*u(i, j - 2, b)*v(i, j - 2, b) &
+                + d1_coeffs_e(4, 4)*u(i, j - 1, b)*v(i, j - 1, b) &
+                + d1_coeffs_e(5, 4)*u(i, j, b)*v(i, j, b) &
+                + d1_coeffs_e(6, 4)*u_e(i, 1, b)*v_e(i, 1, b) &
+                + d1_coeffs_e(7, 4)*u_e(i, 2, b)*v_e(i, 2, b) &
+                + d1_coeffs_e(8, 4)*u_e(i, 3, b)*v_e(i, 3, b) &
+                + d1_coeffs_e(9, 4)*u_e(i, 4, b)*v_e(i, 4, b)
+      dud(i, j, b) = d1_fw(j)*(temp_dud - d1_af(j)*dud(i, j - 1, b))
+      temp_d2u = d2_coeffs_e(1, 4)*u(i, j - 4, b) &
+                 + d2_coeffs_e(2, 4)*u(i, j - 3, b) &
+                 + d2_coeffs_e(3, 4)*u(i, j - 2, b) &
+                 + d2_coeffs_e(4, 4)*u(i, j - 1, b) &
+                 + d2_coeffs_e(5, 4)*u(i, j, b) &
+                 + d2_coeffs_e(6, 4)*u_e(i, 1, b) &
+                 + d2_coeffs_e(7, 4)*u_e(i, 2, b) &
+                 + d2_coeffs_e(8, 4)*u_e(i, 3, b) &
+                 + d2_coeffs_e(9, 4)*u_e(i, 4, b)
+      d2u(i, j, b) = d2_fw(j)*(temp_d2u - d2_af(j)*d2u(i, j - 1, b))
+
+      send_du_e(i, 1, b) = du(i, n, b)
+      send_dud_e(i, 1, b) = dud(i, n, b)
+      send_d2u_e(i, 1, b) = d2u(i, n, b)
+
+      ! Backward pass of the hybrid algorithm
+      do j = n - 2, 2, -1
+         du(i, j, b) = du(i, j, b) - d1_bw(j)*du(i, j + 1, b)
+         dud(i, j, b) = dud(i, j, b) - d1_bw(j)*dud(i, j + 1, b)
+         d2u(i, j, b) = d2u(i, j, b) - d2_bw(j)*d2u(i, j + 1, b)
+      end do
+      du(i, 1, b) = d1_last_r*(du(i, 1, b) - d1_bw(1)*du(i, 2, b))
+      dud(i, 1, b) = d1_last_r*(dud(i, 1, b) - d1_bw(1)*dud(i, 2, b))
+      d2u(i, 1, b) = d2_last_r*(d2u(i, 1, b) - d2_bw(1)*d2u(i, 2, b))
+
+      send_du_s(i, 1, b) = du(i, 1, b)
+      send_dud_s(i, 1, b) = dud(i, 1, b)
+      send_d2u_s(i, 1, b) = d2u(i, 1, b)
+
+   end subroutine transeq_3fused_dist
+
+   attributes(global) subroutine transeq_3fused_subs( &
+      r_u, conv, du, dud, d2u, &
+      recv_du_s, recv_du_e, recv_dud_s, recv_dud_e, recv_d2u_s, recv_d2u_e, &
+      d1_sa, d1_sc, d2_sa, d2_sc, n, nu &
+      )
+      implicit none
+
+      ! Arguments
+      real(dp), device, intent(out), dimension(:, :, :) :: r_u
+      real(dp), device, intent(in), dimension(:, :, :) :: conv, du, dud, d2u
+      real(dp), device, intent(in), dimension(:, :, :) :: &
+         recv_du_s, recv_du_e, recv_dud_s, recv_dud_e, recv_d2u_s, recv_d2u_e
+      real(dp), device, intent(in), dimension(:) :: d1_sa, d1_sc, d2_sa, d2_sc
+      integer, value, intent(in) :: n
+      real(dp), value, intent(in) :: nu
+
+      ! Local variables
+      integer :: i, j, b
+      real(dp) :: ur, bl, recp
+      real(dp) :: du_temp, dud_temp, d2u_temp
+      real(dp) :: du_s, du_e, dud_s, dud_e, d2u_s, d2u_e
+
+      i = threadIdx%x
+      b = blockIdx%x
+
+      ! A small trick we do here is valid for symmetric Toeplitz matrices.
+      ! In our case our matrices satisfy this criteria in the (5:n-4) region
+      ! and as long as a rank has around at least 20 entries the assumptions
+      ! we make here are perfectly valid.
+
+      ! bl is the bottom left entry in the 2x2 matrix
+      ! ur is the upper right entry in the 2x2 matrix
+
+      ! Start
+      ! At the start we have the 'bl', and assume 'ur'
+      ! first derivative
+      bl = d1_sa(1)
+      ur = d1_sa(1)
+      recp = 1._dp/(1._dp - ur*bl)
+
+      du_s = recp*(du(i, 1, b) - bl*recv_du_s(i, 1, b))
+      dud_s = recp*(dud(i, 1, b) - bl*recv_dud_s(i, 1, b))
+
+      ! second derivative
+      bl = d2_sa(1)
+      ur = d2_sa(1)
+      recp = 1._dp/(1._dp - ur*bl)
+
+      d2u_s = recp*(d2u(i, 1, b) - bl*recv_d2u_s(i, 1, b))
+
+      ! End
+      ! At the end we have the 'ur', and assume 'bl'
+      ! first derivative
+      bl = d1_sc(n)
+      ur = d1_sc(n)
+      recp = 1._dp/(1._dp - ur*bl)
+
+      du_e = recp*(du(i, n, b) - ur*recv_du_e(i, 1, b))
+      dud_e = recp*(dud(i, n, b) - ur*recv_dud_e(i, 1, b))
+
+      ! second derivative
+      bl = d2_sc(n)
+      ur = d2_sc(n)
+      recp = 1._dp/(1._dp - ur*bl)
+
+      d2u_e = recp*(d2u(i, n, b) - ur*recv_d2u_e(i, 1, b))
+
+      ! final substitution
+      r_u(i, 1, b) = -0.5_dp*(conv(i, 1, b)*du_s + dud_s) + nu*d2u_s
+      do j = 2, n - 1
+         du_temp = (du(i, j, b) - d1_sa(j)*du_s - d1_sc(j)*du_e)
+         dud_temp = (dud(i, j, b) - d1_sa(j)*dud_s - d1_sc(j)*dud_e)
+         d2u_temp = (d2u(i, j, b) - d2_sa(j)*d2u_s - d2_sc(j)*d2u_e)
+         r_u(i, j, b) = -0.5_dp*(conv(i, j, b)*du_temp + dud_temp) &
+                        + nu*d2u_temp
+      end do
+      r_u(i, n, b) = -0.5_dp*(conv(i, n, b)*du_e + dud_e) + nu*d2u_e
+
+   end subroutine transeq_3fused_subs
+
 end module m_cuda_kernels_dist

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TESTSRC
 set(CUDATESTSRC
   cuda/test_cuda_allocator.f90
   cuda/test_cuda_tridiag.f90
+  cuda/test_cuda_transeq.f90
 )
 
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI")

--- a/tests/cuda/test_cuda_transeq.f90
+++ b/tests/cuda/test_cuda_transeq.f90
@@ -1,0 +1,291 @@
+program test_cuda_tridiag
+   use iso_fortran_env, only: stderr => error_unit
+   use cudafor
+   use mpi
+
+   use m_common, only: dp, pi
+   use m_cuda_common, only: SZ
+   use m_cuda_kernels_dist, only: transeq_3fused_dist, transeq_3fused_subs
+   use m_cuda_tdsops, only: cuda_tdsops_t
+
+   implicit none
+
+   logical :: allpass = .true.
+   real(dp), allocatable, dimension(:, :, :) :: u, v, r_u
+   real(dp), device, allocatable, dimension(:, :, :) :: &
+      u_dev, v_dev, r_u_dev, & ! main fields u, v and result r_u
+      du_dev, dud_dev, d2u_dev ! intermediate solution arrays
+   real(dp), device, allocatable, dimension(:, :, :) :: &
+      du_recv_s_dev, du_recv_e_dev, du_send_s_dev, du_send_e_dev, &
+      dud_recv_s_dev, dud_recv_e_dev, dud_send_s_dev, dud_send_e_dev, &
+      d2u_recv_s_dev, d2u_recv_e_dev, d2u_send_s_dev, d2u_send_e_dev
+
+   real(dp), device, allocatable, dimension(:, :, :) :: &
+      u_send_s_dev, u_send_e_dev, u_recv_s_dev, u_recv_e_dev, &
+      v_send_s_dev, v_send_e_dev, v_recv_s_dev, v_recv_e_dev
+
+   type(cuda_tdsops_t) :: der1st, der2nd
+
+   integer :: n, n_block, i, j, k, n_halo, n_iters
+   integer :: n_glob
+   integer :: nrank, nproc, pprev, pnext, tag1=1234, tag2=1234
+   integer :: srerr(12), mpireq(12)
+   integer :: ierr, ndevs, devnum, memClockRt, memBusWidth
+
+   type(dim3) :: blocks, threads
+   real(dp) :: dx, dx_per, nu, norm_du, tol = 1d-8, tstart, tend
+   real(dp) :: achievedBW, deviceBW, achievedBWmax, achievedBWmin
+
+   call MPI_Init(ierr)
+   call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
+   call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+
+   if (nrank == 0) print*, 'Parallel run with', nproc, 'ranks'
+
+   ierr = cudaGetDeviceCount(ndevs)
+   ierr = cudaSetDevice(mod(nrank, ndevs)) ! round-robin
+   ierr = cudaGetDevice(devnum)
+
+   !print*, 'I am rank', nrank, 'I am running on device', devnum
+   pnext = modulo(nrank - nproc + 1, nproc)
+   pprev = modulo(nrank - 1, nproc)
+
+   n_glob = 512*4
+   n = n_glob/nproc
+   n_block = 512*512/SZ
+   n_iters = 100
+
+   nu = 1._dp
+
+   allocate(u(SZ, n, n_block), v(SZ, n, n_block), r_u(SZ, n, n_block))
+
+   ! main input fields
+   allocate(u_dev(SZ, n, n_block), v_dev(SZ, n, n_block))
+   ! field for storing the result
+   allocate(r_u_dev(SZ, n, n_block))
+   ! intermediate solution fields
+   allocate(du_dev(SZ, n, n_block))
+   allocate(dud_dev(SZ, n, n_block))
+   allocate(d2u_dev(SZ, n, n_block))
+
+   dx_per = 2*pi/n_glob
+   dx = 2*pi/(n_glob - 1)
+
+   do k = 1, n_block
+      do j = 1, n
+         do i = 1, SZ
+            u(i, j, k) = sin((j - 1 + nrank*n)*dx_per)
+            v(i, j, k) = cos((j - 1 + nrank*n)*dx_per)
+         end do
+      end do
+   end do
+
+   ! move data to device
+   u_dev = u
+   v_dev = v
+
+   n_halo = 4
+
+   ! arrays for exchanging data between ranks
+   allocate(u_send_s_dev(SZ, n_halo, n_block))
+   allocate(u_send_e_dev(SZ, n_halo, n_block))
+   allocate(u_recv_s_dev(SZ, n_halo, n_block))
+   allocate(u_recv_e_dev(SZ, n_halo, n_block))
+   allocate(v_send_s_dev(SZ, n_halo, n_block))
+   allocate(v_send_e_dev(SZ, n_halo, n_block))
+   allocate(v_recv_s_dev(SZ, n_halo, n_block))
+   allocate(v_recv_e_dev(SZ, n_halo, n_block))
+
+   allocate(du_send_s_dev(SZ, 1, n_block), du_send_e_dev(SZ, 1, n_block))
+   allocate(du_recv_s_dev(SZ, 1, n_block), du_recv_e_dev(SZ, 1, n_block))
+   allocate(dud_send_s_dev(SZ, 1, n_block), dud_send_e_dev(SZ, 1, n_block))
+   allocate(dud_recv_s_dev(SZ, 1, n_block), dud_recv_e_dev(SZ, 1, n_block))
+   allocate(d2u_send_s_dev(SZ, 1, n_block), d2u_send_e_dev(SZ, 1, n_block))
+   allocate(d2u_recv_s_dev(SZ, 1, n_block), d2u_recv_e_dev(SZ, 1, n_block))
+
+   ! preprocess the operator and coefficient arrays
+   der1st = cuda_tdsops_t(n, dx_per, operation='first-deriv', &
+                          scheme='compact6')
+   der2nd = cuda_tdsops_t(n, dx_per, operation='second-deriv', &
+                          scheme='compact6')
+
+   blocks = dim3(n_block, 1, 1)
+   threads = dim3(SZ, 1, 1)
+
+   call cpu_time(tstart)
+   do i = 1, n_iters
+      u_send_s_dev(:, :, :) = u_dev(:, 1:4, :)
+      u_send_e_dev(:, :, :) = u_dev(:, n - n_halo + 1:n, :)
+      v_send_s_dev(:, :, :) = v_dev(:, 1:4, :)
+      v_send_e_dev(:, :, :) = v_dev(:, n - n_halo + 1:n, :)
+
+      ! halo exchange
+      if (nproc == 1) then
+         u_recv_s_dev = u_send_e_dev
+         u_recv_e_dev = u_send_s_dev
+         v_recv_s_dev = v_send_e_dev
+         v_recv_e_dev = v_send_s_dev
+      else
+         ! MPI send/recv for multi-rank simulations
+         call MPI_Isend(u_send_s_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(1), srerr(1))
+         call MPI_Irecv(u_recv_e_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag1, MPI_COMM_WORLD, &
+                        mpireq(2), srerr(2))
+         call MPI_Isend(u_send_e_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(3), srerr(3))
+         call MPI_Irecv(u_recv_s_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag2, MPI_COMM_WORLD, &
+                        mpireq(4), srerr(4))
+
+         call MPI_Isend(v_send_s_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(5), srerr(5))
+         call MPI_Irecv(v_recv_e_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag1, MPI_COMM_WORLD, &
+                        mpireq(6), srerr(6))
+         call MPI_Isend(v_send_e_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(7), srerr(7))
+         call MPI_Irecv(v_recv_s_dev, SZ*n_halo*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag2, MPI_COMM_WORLD, &
+                        mpireq(8), srerr(8))
+
+         call MPI_Waitall(8, mpireq, MPI_STATUSES_IGNORE, ierr)
+      end if
+
+      call transeq_3fused_dist<<<blocks, threads>>>( &
+         du_dev, dud_dev, d2u_dev, &
+         du_send_s_dev, du_send_e_dev, &
+         dud_send_s_dev, dud_send_e_dev, &
+         d2u_send_s_dev, d2u_send_e_dev, &
+         u_dev, u_recv_s_dev, u_recv_e_dev, &
+         v_dev, v_recv_s_dev, v_recv_e_dev, n, &
+         der1st%coeffs_s_dev, der1st%coeffs_e_dev, der1st%coeffs_dev, &
+         der1st%dist_fw_dev, der1st%dist_bw_dev, der1st%dist_af_dev, &
+         der2nd%coeffs_s_dev, der2nd%coeffs_e_dev, der2nd%coeffs_dev, &
+         der2nd%dist_fw_dev, der2nd%dist_bw_dev, der2nd%dist_af_dev &
+      )
+
+      ! halo exchange for 2x2 systems
+      if (nproc == 1) then
+         du_recv_s_dev = du_send_e_dev
+         du_recv_e_dev = du_send_s_dev
+         dud_recv_s_dev = dud_send_e_dev
+         dud_recv_e_dev = dud_send_s_dev
+         d2u_recv_s_dev = d2u_send_e_dev
+         d2u_recv_e_dev = d2u_send_s_dev
+      else
+         ! MPI send/recv for multi-rank simulations
+         call MPI_Isend(du_send_s_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(1), srerr(1))
+         call MPI_Irecv(du_recv_e_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(2), srerr(2))
+         call MPI_Isend(du_send_e_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(3), srerr(3))
+         call MPI_Irecv(du_recv_s_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(4), srerr(4))
+
+         call MPI_Isend(dud_send_s_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(5), srerr(5))
+         call MPI_Irecv(dud_recv_e_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(6), srerr(6))
+         call MPI_Isend(dud_send_e_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(7), srerr(7))
+         call MPI_Irecv(dud_recv_s_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(8), srerr(8))
+
+         call MPI_Isend(d2u_send_s_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(9), srerr(9))
+         call MPI_Irecv(d2u_recv_e_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(10), srerr(10))
+         call MPI_Isend(d2u_send_e_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pnext, tag2, MPI_COMM_WORLD, &
+                        mpireq(11), srerr(11))
+         call MPI_Irecv(d2u_recv_s_dev, SZ*n_block, &
+                        MPI_DOUBLE_PRECISION, pprev, tag1, MPI_COMM_WORLD, &
+                        mpireq(12), srerr(12))
+
+         call MPI_Waitall(12, mpireq, MPI_STATUSES_IGNORE, ierr)
+      end if
+
+      call transeq_3fused_subs<<<blocks, threads>>>( &
+         r_u_dev, v_dev, du_dev, dud_dev, d2u_dev, &
+         du_recv_s_dev, du_recv_e_dev, &
+         dud_recv_s_dev, dud_recv_e_dev, &
+         d2u_recv_s_dev, d2u_recv_e_dev, &
+         der1st%dist_sa_dev, der1st%dist_sc_dev, &
+         der2nd%dist_sa_dev, der2nd%dist_sc_dev, &
+         n, nu &
+      )
+   end do
+
+   call cpu_time(tend)
+   if (nrank == 0) print*, 'Total time', tend - tstart
+
+   ! BW utilisation and performance checks
+   ! 11 in the first phase, 5 in the second phase, 16 in total
+   achievedBW = 16._dp*n_iters*n*n_block*SZ*dp/(tend - tstart)
+   call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_DOUBLE_PRECISION, &
+                      MPI_MAX, MPI_COMM_WORLD, ierr)
+   call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_DOUBLE_PRECISION, &
+                      MPI_MIN, MPI_COMM_WORLD, ierr)
+
+   if (nrank == 0) then
+      print'(a, f8.3, a)', 'Achieved BW min: ', achievedBWmin/2**30, ' GiB/s'
+      print'(a, f8.3, a)', 'Achieved BW max: ', achievedBWmax/2**30, ' GiB/s'
+   end if
+
+   ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, 0)
+   ierr = cudaDeviceGetAttribute(memBusWidth, &
+                                 cudaDevAttrGlobalMemoryBusWidth, 0)
+   deviceBW = 2*memBusWidth/8._dp*memClockRt*1000
+
+   if (nrank == 0) then
+      print'(a, f8.3, a)', 'Device BW:   ', deviceBW/2**30, ' GiB/s'
+      print'(a, f5.2)', 'Effective BW util min: %', achievedBWmin/deviceBW*100
+      print'(a, f5.2)', 'Effective BW util max: %', achievedBWmax/deviceBW*100
+   end if
+
+   ! check error
+   r_u = r_u_dev
+   r_u = r_u - (-v*v + 0.5_dp*u*u - nu*u)
+   norm_du = norm2(r_u)
+   norm_du = norm_du*norm_du/n_glob/n_block/SZ
+   call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_DOUBLE_PRECISION, &
+                      MPI_SUM, MPI_COMM_WORLD, ierr)
+   norm_du = sqrt(norm_du)
+
+   if (nrank == 0) print*, 'error norm', norm_du
+
+   if (nrank == 0) then
+      if ( norm_du > tol ) then
+         allpass = .false.
+         write(stderr, '(a)') 'Check second derivatives... failed'
+      else
+         write(stderr, '(a)') 'Check second derivatives... passed'
+      end if
+   end if
+
+   if (allpass) then
+      if (nrank == 0) write(stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
+   else
+      error stop 'SOME TESTS FAILED.'
+   end if
+
+   call MPI_Finalize(ierr)
+
+end program test_cuda_tridiag
+


### PR DESCRIPTION
In order to save some bandwidth on GPUs we fuse some of the operations in the transport equation.

This fused kernel is capable of evaluating
$${RHS}_x^u \leftarrow -\frac{1}{2} \bigg(u\frac{\partial u}{\partial x} + \frac{\partial u u}{\partial x}\bigg) + \nu \frac{\partial u^2}{\partial x}$$
or
$${RHS}_z^v \leftarrow -\frac{1}{2} \bigg(w\frac{\partial v}{\partial z} + \frac{\partial v w}{\partial z}\bigg) + \nu \frac{\partial v^2}{\partial z}$$
and similar groups of terms in the transport equation depending on the inputs.
In total this fused kernel is executed 3 times per direction, and 9 times in total per timestep to evaluate all the terms in the transport equation.

$${RHS}^u = {RHS}_x^u + {RHS}_y^u + {RHS}_z^u$$

$${RHS}^v = {RHS}_x^v + {RHS}_y^v + {RHS}_z^v$$

$${RHS}^w = {RHS}_x^w + {RHS}_y^w + {RHS}_z^w$$