### PR TITLE
Add divergence and gradient

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -34,6 +34,7 @@ module m_base_backend
       procedure(trans_d2d), deferred :: trans_z2y
       procedure(trans_d2d), deferred :: trans_y2x
       procedure(sum9into3), deferred :: sum_yzintox
+      procedure(vecadd), deferred :: vecadd
       procedure(get_fields), deferred :: get_fields
       procedure(set_fields), deferred :: set_fields
       procedure(alloc_tdsops), deferred :: alloc_tdsops
@@ -121,6 +122,22 @@ module m_base_backend
          class(field_t), intent(inout) :: du, dv, dw
          class(field_t), intent(in) :: du_y, dv_y, dw_y, du_z, dv_z, dw_z
       end subroutine sum9into3
+   end interface
+
+   abstract interface
+      subroutine vecadd(self, a, x, b, y)
+         !! adds two vectors together: y = a*x + b*y
+         import :: base_backend_t
+         import :: dp
+         import :: field_t
+         implicit none
+
+         class(base_backend_t) :: self
+         real(dp), intent(in) :: a
+         class(field_t), intent(in) :: x
+         real(dp), intent(in) :: b
+         class(field_t), intent(inout) :: y
+      end subroutine vecadd
    end interface
 
    abstract interface

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -30,6 +30,9 @@ module m_base_backend
       procedure(tds_solve), deferred :: tds_solve
       procedure(transposer), deferred :: trans_x2y
       procedure(transposer), deferred :: trans_x2z
+      procedure(trans_d2d), deferred :: trans_y2z
+      procedure(trans_d2d), deferred :: trans_z2y
+      procedure(trans_d2d), deferred :: trans_y2x
       procedure(sum9into3), deferred :: sum_yzintox
       procedure(get_fields), deferred :: get_fields
       procedure(set_fields), deferred :: set_fields
@@ -90,6 +93,20 @@ module m_base_backend
          class(field_t), intent(inout) :: u_, v_, w_
          class(field_t), intent(in) :: u, v, w
       end subroutine transposer
+
+      subroutine trans_d2d(self, u_, u)
+         !! transposer subroutines are straightforward, they rearrange
+         !! data into our specialist data structure so that regardless
+         !! of the direction tridiagonal systems are solved efficiently
+         !! and fast.
+         import :: base_backend_t
+         import :: field_t
+         implicit none
+
+         class(base_backend_t) :: self
+         class(field_t), intent(inout) :: u_
+         class(field_t), intent(in) :: u
+      end subroutine trans_d2d
    end interface
 
    abstract interface

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -136,7 +136,8 @@ module m_base_backend
    end interface
 
    abstract interface
-      subroutine alloc_tdsops(self, tdsops, n, dx, operation, scheme)
+      subroutine alloc_tdsops(self, tdsops, n, dx, operation, scheme, n_halo, &
+                              from_to, bc_start, bc_end, sym, c_nu, nu0_nu)
          import :: base_backend_t
          import :: dp
          import :: tdsops_t
@@ -147,6 +148,10 @@ module m_base_backend
          integer, intent(in) :: n
          real(dp), intent(in) :: dx
          character(*), intent(in) :: operation, scheme
+         integer, optional, intent(in) :: n_halo
+         character(*), optional, intent(in) :: from_to, bc_start, bc_end
+         logical, optional, intent(in) :: sym
+         real(dp), optional, intent(in) :: c_nu, nu0_nu
       end subroutine alloc_tdsops
    end interface
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -101,7 +101,10 @@ module m_cuda_backend
 
    end function init
 
-   subroutine alloc_cuda_tdsops(self, tdsops, n, dx, operation, scheme)
+   subroutine alloc_cuda_tdsops( &
+      self, tdsops, n, dx, operation, scheme, &
+      n_halo, from_to, bc_start, bc_end, sym, c_nu, nu0_nu &
+      )
       implicit none
 
       class(cuda_backend_t) :: self
@@ -109,6 +112,10 @@ module m_cuda_backend
       integer, intent(in) :: n
       real(dp), intent(in) :: dx
       character(*), intent(in) :: operation, scheme
+      integer, optional, intent(in) :: n_halo
+      character(*), optional, intent(in) :: from_to, bc_start, bc_end
+      logical, optional, intent(in) :: sym
+      real(dp), optional, intent(in) :: c_nu, nu0_nu
 
       allocate(cuda_tdsops_t :: tdsops)
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -38,6 +38,7 @@ module m_cuda_backend
       procedure :: trans_z2y => trans_z2y_cuda
       procedure :: trans_y2x => trans_y2x_cuda
       procedure :: sum_yzintox => sum_yzintox_cuda
+      procedure :: vecadd => vecadd_cuda
       procedure :: set_fields => set_fields_cuda
       procedure :: get_fields => get_fields_cuda
       procedure :: transeq_cuda_dist
@@ -467,6 +468,17 @@ module m_cuda_backend
       class(field_t), intent(in) :: du_y, dv_y, dw_y, du_z, dv_z, dw_z
 
    end subroutine sum_yzintox_cuda
+
+   subroutine vecadd_cuda(self, a, x, b, y)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      real(dp), intent(in) :: a
+      class(field_t), intent(in) :: x
+      real(dp), intent(in) :: b
+      class(field_t), intent(inout) :: y
+
+   end subroutine vecadd_cuda
 
    subroutine copy_into_buffers(u_send_s_dev, u_send_e_dev, u_dev, n)
       implicit none

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -125,7 +125,8 @@ module m_cuda_backend
 
       select type (tdsops)
       type is (cuda_tdsops_t)
-         tdsops = cuda_tdsops_t(n, dx, operation, scheme)
+         tdsops = cuda_tdsops_t(n, dx, operation, scheme, n_halo, from_to, &
+                                bc_start, bc_end, sym, c_nu, nu0_nu)
       end select
 
    end subroutine alloc_cuda_tdsops

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -34,6 +34,9 @@ module m_cuda_backend
       procedure :: tds_solve => tds_solve_cuda
       procedure :: trans_x2y => trans_x2y_cuda
       procedure :: trans_x2z => trans_x2z_cuda
+      procedure :: trans_y2z => trans_y2z_cuda
+      procedure :: trans_z2y => trans_z2y_cuda
+      procedure :: trans_y2x => trans_y2x_cuda
       procedure :: sum_yzintox => sum_yzintox_cuda
       procedure :: set_fields => set_fields_cuda
       procedure :: get_fields => get_fields_cuda
@@ -427,6 +430,33 @@ module m_cuda_backend
       class(field_t), intent(in) :: u, v, w
 
    end subroutine trans_x2z_cuda
+
+   subroutine trans_y2z_cuda(self, u_z, u_y)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      class(field_t), intent(inout) :: u_z
+      class(field_t), intent(in) :: u_y
+
+   end subroutine trans_y2z_cuda
+
+   subroutine trans_z2y_cuda(self, u_y, u_z)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      class(field_t), intent(inout) :: u_y
+      class(field_t), intent(in) :: u_z
+
+   end subroutine trans_z2y_cuda
+
+   subroutine trans_y2x_cuda(self, u_x, u_y)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      class(field_t), intent(inout) :: u_x
+      class(field_t), intent(in) :: u_y
+
+   end subroutine trans_y2x_cuda
 
    subroutine sum_yzintox_cuda(self, du, dv, dw, &
                                du_y, dv_y, dw_y, du_z, dv_z, dw_z)

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -182,30 +182,30 @@ module m_omp_backend
 
    end subroutine trans_x2z_omp
 
-   subroutine trans_y2z_omp(self, u_z, u_y)
+   subroutine trans_y2z_omp(self, u_, u)
       implicit none
 
       class(omp_backend_t) :: self
-      class(field_t), intent(inout) :: u_z
-      class(field_t), intent(in) :: u_y
+      class(field_t), intent(inout) :: u_
+      class(field_t), intent(in) :: u
 
    end subroutine trans_y2z_omp
 
-   subroutine trans_z2y_omp(self, u_y, u_z)
+   subroutine trans_z2y_omp(self, u_, u)
       implicit none
 
       class(omp_backend_t) :: self
-      class(field_t), intent(inout) :: u_y
-      class(field_t), intent(in) :: u_z
+      class(field_t), intent(inout) :: u_
+      class(field_t), intent(in) :: u
 
    end subroutine trans_z2y_omp
 
-   subroutine trans_y2x_omp(self, u_x, u_y)
+   subroutine trans_y2x_omp(self, u_, u)
       implicit none
 
       class(omp_backend_t) :: self
-      class(field_t), intent(inout) :: u_x
-      class(field_t), intent(in) :: u_y
+      class(field_t), intent(inout) :: u_
+      class(field_t), intent(in) :: u
 
    end subroutine trans_y2x_omp
 

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -26,6 +26,9 @@ module m_omp_backend
       procedure :: tds_solve => tds_solve_omp
       procedure :: trans_x2y => trans_x2y_omp
       procedure :: trans_x2z => trans_x2z_omp
+      procedure :: trans_y2z => trans_y2z_omp
+      procedure :: trans_z2y => trans_z2y_omp
+      procedure :: trans_y2x => trans_y2x_omp
       procedure :: sum_yzintox => sum_yzintox_omp
       procedure :: set_fields => set_fields_omp
       procedure :: get_fields => get_fields_omp
@@ -176,6 +179,33 @@ module m_omp_backend
       class(field_t), intent(in) :: u, v, w
 
    end subroutine trans_x2z_omp
+
+   subroutine trans_y2z_omp(self, u_z, u_y)
+      implicit none
+
+      class(omp_backend_t) :: self
+      class(field_t), intent(inout) :: u_z
+      class(field_t), intent(in) :: u_y
+
+   end subroutine trans_y2z_omp
+
+   subroutine trans_z2y_omp(self, u_y, u_z)
+      implicit none
+
+      class(omp_backend_t) :: self
+      class(field_t), intent(inout) :: u_y
+      class(field_t), intent(in) :: u_z
+
+   end subroutine trans_z2y_omp
+
+   subroutine trans_y2x_omp(self, u_x, u_y)
+      implicit none
+
+      class(omp_backend_t) :: self
+      class(field_t), intent(inout) :: u_x
+      class(field_t), intent(in) :: u_y
+
+   end subroutine trans_y2x_omp
 
    subroutine sum_yzintox_omp(self, du, dv, dw, &
                                du_y, dv_y, dw_y, du_z, dv_z, dw_z)

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -107,7 +107,8 @@ module m_omp_backend
 
       select type (tdsops)
       type is (tdsops_t)
-         tdsops = tdsops_t(n, dx, operation, scheme)
+         tdsops = tdsops_t(n, dx, operation, scheme, n_halo, from_to, &
+                           bc_start, bc_end, sym, c_nu, nu0_nu)
       end select
 
    end subroutine alloc_omp_tdsops

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -30,6 +30,7 @@ module m_omp_backend
       procedure :: trans_z2y => trans_z2y_omp
       procedure :: trans_y2x => trans_y2x_omp
       procedure :: sum_yzintox => sum_yzintox_omp
+      procedure :: vecadd => vecadd_omp
       procedure :: set_fields => set_fields_omp
       procedure :: get_fields => get_fields_omp
    end type omp_backend_t
@@ -216,6 +217,17 @@ module m_omp_backend
       class(field_t), intent(in) :: du_y, dv_y, dw_y, du_z, dv_z, dw_z
 
    end subroutine sum_yzintox_omp
+
+   subroutine vecadd_omp(self, a, x, b, y)
+      implicit none
+
+      class(omp_backend_t) :: self
+      real(dp), intent(in) :: a
+      class(field_t), intent(in) :: x
+      real(dp), intent(in) :: b
+      class(field_t), intent(inout) :: y
+
+   end subroutine vecadd_omp
 
    subroutine copy_into_buffers(u_send_s, u_send_e, u, n)
       implicit none

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -83,7 +83,10 @@ module m_omp_backend
 
    end function init
 
-   subroutine alloc_omp_tdsops(self, tdsops, n, dx, operation, scheme)
+   subroutine alloc_omp_tdsops( &
+      self, tdsops, n, dx, operation, scheme, &
+      n_halo, from_to, bc_start, bc_end, sym, c_nu, nu0_nu &
+      )
       implicit none
 
       class(omp_backend_t) :: self
@@ -91,6 +94,10 @@ module m_omp_backend
       integer, intent(in) :: n
       real(dp), intent(in) :: dx
       character(*), intent(in) :: operation, scheme
+      integer, optional, intent(in) :: n_halo
+      character(*), optional, intent(in) :: from_to, bc_start, bc_end
+      logical, optional, intent(in) :: sym
+      real(dp), optional, intent(in) :: c_nu, nu0_nu
 
       allocate(tdsops_t :: tdsops)
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -295,7 +295,8 @@ contains
       ! call vecadd(1, dv_y, 1, dw_y)
 
       ! reorder from y to z
-      !call self%backend%trans_y2z(u_z, w_z, du_y, dw_y)
+      call self%backend%trans_y2z(u_z, du_y)
+      call self%backend%trans_y2z(w_z, dw_y)
 
       ! release all the unnecessary blocks.
       call self%backend%allocator%release_block(du_y)
@@ -349,7 +350,8 @@ contains
       dpdz_sxy_y => self%backend%allocator%get_block()
 
       ! reorder data from z orientation to y orientation
-      !call self%backend%trans_z2y(p_sxy_y, dpdz_sxy_y, p_sxy_z, dpdz_sxy_z)
+      call self%backend%trans_z2y(p_sxy_y, p_sxy_z)
+      call self%backend%trans_z2y(dpdz_sxy_y, dpdz_sxy_z)
 
       call self%backend%allocator%release_block(p_sxy_z)
       call self%backend%allocator%release_block(dpdz_sxy_z)
@@ -376,8 +378,9 @@ contains
       dpdz_sx_x => self%backend%allocator%get_block()
 
       ! reorder from y to x
-      !call self%backend%trans_y2x(p_sx_x, dpdy_sx_x, dpdz_sx_x, &
-      !                            p_sx_y, dpdy_sx_y, dpdz_sx_y)
+      call self%backend%trans_y2x(p_sx_x, p_sx_y)
+      call self%backend%trans_y2x(dpdy_sx_x, dpdy_sx_y)
+      call self%backend%trans_y2x(dpdz_sx_x, dpdz_sx_y)
 
       ! release all the y directional fields.
       call self%backend%allocator%release_block(p_sx_y)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -292,7 +292,7 @@ contains
       w_z => self%backend%allocator%get_block()
 
       ! dv_y = dv_y + dw_y
-      ! call vecadd(1, dv_y, 1, dw_y)
+      call self%backend%vecadd(1._dp, dw_y, 1._dp, dv_y)
 
       ! reorder from y to z
       call self%backend%trans_y2z(u_z, du_y)
@@ -312,7 +312,7 @@ contains
                                   self%zdirps%stagder_v2p)
 
       ! div_u = div_u + dw_z
-      !call vecadd(1, div_u, 1, dw_z)
+      call self%backend%vecadd(1._dp, dw_z, 1._dp, div_u)
 
       ! div_u array is in z orientation
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -338,8 +338,8 @@ contains
       p_sxy_z => self%backend%allocator%get_block()
       dpdz_sxy_z => self%backend%allocator%get_block()
 
-      ! Staggared der for pressure field in x
-      ! Interpolation for pressure field in x
+      ! Staggared der for pressure field in z
+      ! Interpolation for pressure field in z
       call self%backend%tds_solve(p_sxy_z, pressure, self%zdirps, &
                                   self%zdirps%interpl_p2v)
       call self%backend%tds_solve(dpdz_sxy_z, pressure, self%zdirps, &
@@ -360,7 +360,7 @@ contains
       dpdy_sx_y => self%backend%allocator%get_block()
       dpdz_sx_y => self%backend%allocator%get_block()
 
-      ! similar to the z direction, obtain derivatives in x.
+      ! similar to the z direction, obtain derivatives in y.
       call self%backend%tds_solve(p_sx_y, p_sxy_y, self%ydirps, &
                                   self%ydirps%interpl_p2v)
       call self%backend%tds_solve(dpdy_sx_y, p_sxy_y, self%ydirps, &
@@ -372,7 +372,7 @@ contains
       call self%backend%allocator%release_block(p_sxy_y)
       call self%backend%allocator%release_block(dpdz_sxy_y)
 
-      ! just like in y direction, get some fields for the z derivatives.
+      ! just like in y direction, get some fields for the x derivatives.
       p_sx_x => self%backend%allocator%get_block()
       dpdy_sx_x => self%backend%allocator%get_block()
       dpdz_sx_x => self%backend%allocator%get_block()

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -130,6 +130,32 @@ contains
       call solver%backend%alloc_tdsops(solver%zdirps%der2nd_sym, nz, dz, &
                                        'second-deriv', 'compact6')
 
+      call solver%backend%alloc_tdsops(solver%xdirps%interpl_v2p, nx, dx, &
+                                       'interpolate', 'classic', from_to='v2p')
+      call solver%backend%alloc_tdsops(solver%ydirps%interpl_v2p, ny, dy, &
+                                       'interpolate', 'classic', from_to='v2p')
+      call solver%backend%alloc_tdsops(solver%zdirps%interpl_v2p, nz, dz, &
+                                       'interpolate', 'classic', from_to='v2p')
+      call solver%backend%alloc_tdsops(solver%xdirps%interpl_p2v, nx, dx, &
+                                       'interpolate', 'classic', from_to='p2v')
+      call solver%backend%alloc_tdsops(solver%ydirps%interpl_p2v, ny, dy, &
+                                       'interpolate', 'classic', from_to='p2v')
+      call solver%backend%alloc_tdsops(solver%zdirps%interpl_p2v, nz, dz, &
+                                       'interpolate', 'classic', from_to='p2v')
+
+      call solver%backend%alloc_tdsops(solver%xdirps%stagder_v2p, nx, dx, &
+                                       'stag-deriv', 'compact6', from_to='v2p')
+      call solver%backend%alloc_tdsops(solver%ydirps%stagder_v2p, ny, dy, &
+                                       'stag-deriv', 'compact6', from_to='v2p')
+      call solver%backend%alloc_tdsops(solver%zdirps%stagder_v2p, nz, dz, &
+                                       'stag-deriv', 'compact6', from_to='v2p')
+      call solver%backend%alloc_tdsops(solver%xdirps%stagder_p2v, nx, dx, &
+                                       'stag-deriv', 'compact6', from_to='p2v')
+      call solver%backend%alloc_tdsops(solver%ydirps%stagder_p2v, ny, dy, &
+                                       'stag-deriv', 'compact6', from_to='p2v')
+      call solver%backend%alloc_tdsops(solver%zdirps%stagder_p2v, nz, dz, &
+                                       'stag-deriv', 'compact6', from_to='p2v')
+
    end function init
 
    subroutine transeq(self, du, dv, dw, u, v, w)

--- a/src/tdsops.f90
+++ b/src/tdsops.f90
@@ -108,7 +108,7 @@ contains
                                c_nu, nu0_nu)
       else if (operation == 'interpolate') then
          call tdsops%interpl_mid(scheme, from_to, bc_start, bc_end, sym)
-      else if (operation == 'staggared-deriv') then
+      else if (operation == 'stag-deriv') then
          call tdsops%stagder_1st(delta, scheme, from_to, bc_start, bc_end, sym)
       else
          error stop 'operation is not defined'


### PR DESCRIPTION
This PR demonstrates the current capability of the framework pretty well. Both the divergence and gradient operations in Xcompact3D algorithm is now supported in the new framework and this feature is added only by adding two corresponding functions in the solver class. There was no need to add anything special in any of the backends to add this support as they already provide a method that solves a single tridiagonal system.