### PR TITLE
Make allocator more flexible with domain sizes

### DIFF
--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -38,9 +38,9 @@ module m_allocator
       !> incremented each time a new block is allocated.
       integer :: next_id = 0
       !> Padded dimensions for x, y, and z oriented fields
-      integer :: xdims(3), ydims(3), zdims(3)
+      integer :: xdims_padded(3), ydims_padded(3), zdims_padded(3)
       !> Padded dimensions for natural Cartesian ordering
-      integer :: cdims(3)
+      integer :: cdims_padded(3)
       !> The pointer to the first block on the list.  Non associated if
       !> the list is empty
       ! TODO: Rename first to head
@@ -119,10 +119,10 @@ contains
       allocator%ngrid = nx_padded*ny_padded*nz_padded
       allocator%sz = sz
 
-      allocator%xdims = [sz, nx_padded, ny_padded*nz_padded/sz]
-      allocator%ydims = [sz, ny_padded, nx_padded*nz_padded/sz]
-      allocator%zdims = [sz, nz_padded, nx_padded*ny_padded/sz]
-      allocator%cdims = [nx_padded, ny_padded, nz_padded]
+      allocator%xdims_padded = [sz, nx_padded, ny_padded*nz_padded/sz]
+      allocator%ydims_padded = [sz, ny_padded, nx_padded*nz_padded/sz]
+      allocator%zdims_padded = [sz, nz_padded, nx_padded*ny_padded/sz]
+      allocator%cdims_padded = [nx_padded, ny_padded, nz_padded]
    end function allocator_init
 
    function create_block(self, next) result(ptr)
@@ -169,13 +169,13 @@ contains
       ! Set dims based on direction
       select case(dir)
       case (DIR_X)
-         dims = self%xdims
+         dims = self%xdims_padded
       case (DIR_Y)
-         dims = self%ydims
+         dims = self%ydims_padded
       case (DIR_Z)
-         dims = self%zdims
+         dims = self%zdims_padded
       case (DIR_C)
-         dims = self%cdims
+         dims = self%cdims_padded
       case default
          error stop 'Undefined direction, allocator cannot provide a shape.'
       end select

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -64,6 +64,7 @@ module m_allocator
       class(field_t), pointer :: next
       real(dp), pointer, private :: p_data(:)
       real(dp), pointer, contiguous :: data(:, :, :)
+      integer :: dir
       integer :: refcount = 0
       integer :: id !! An integer identifying the memory block.
    contains
@@ -165,6 +166,9 @@ contains
       else
          direction = DIR_X
       end if
+
+      ! Store direction info in the field type.
+      handle%dir = direction
 
       ! Set dims based on direction
       select case(direction)

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -48,13 +48,13 @@ module m_allocator
    end type allocator_t
 
    type :: field_t
-     !! Memory block type holding both a 3D data field and a pointer
+     !! Memory block type holding both a data field and a pointer
      !! to the next block.  The `field_t` type also holds a integer
      !! `refcount` that counts the number of references to this
      !! field.  User code is currently responsible for incrementing
      !! the reference count.
       class(field_t), pointer :: next
-      real(dp), allocatable :: data(:, :, :)
+      real(dp), allocatable :: data(:)
       integer :: refcount = 0
       integer :: id !! An integer identifying the memory block.
    end type field_t
@@ -74,7 +74,7 @@ contains
       type(field_t), pointer, intent(in) :: next
       type(field_t) :: m
 
-      allocate (m%data(dims(1), dims(2), dims(3)))
+      allocate (m%data(dims(1)*dims(2)*dims(3)))
       m%refcount = 0
       m%next => next
       m%id = id

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -150,8 +150,8 @@ contains
     !! ```
       class(allocator_t), intent(inout) :: self
       class(field_t), pointer :: handle
-      integer, optional, intent(in) :: dir
-      integer :: direction, dims(3)
+      integer, intent(in) :: dir
+      integer :: dims(3)
       ! If the list is empty, allocate a new block before returning a
       ! pointer to it.
       if (.not. associated(self%first)) then
@@ -163,18 +163,11 @@ contains
       self%first => self%first%next ! 2nd block becomes head block
       handle%next => null() ! Detach ex-head block from the block list
 
-      ! If no direction is specified assume DIR_X
-      if (present(dir)) then
-         direction = dir
-      else
-         direction = DIR_X
-      end if
-
       ! Store direction info in the field type.
-      handle%dir = direction
+      handle%dir = dir
 
       ! Set dims based on direction
-      select case(direction)
+      select case(dir)
       case (DIR_X)
          dims = self%xdims
       case (DIR_Y)

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -1,4 +1,6 @@
 module m_allocator
+   use iso_fortran_env, only: stderr => error_unit
+
    use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C
 
    implicit none
@@ -180,6 +182,8 @@ contains
          dims = self%zdims
       case (DIR_C)
          dims = self%cdims
+      case default
+         error stop 'Undefined direction, allocator cannot provide a shape.'
       end select
 
       ! Apply bounds remapping based on requested direction

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -1,5 +1,5 @@
 module m_allocator
-   use m_common, only: dp
+   use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C
 
    implicit none
 
@@ -150,7 +150,7 @@ contains
       class(allocator_t), intent(inout) :: self
       class(field_t), pointer :: handle
       integer, optional, intent(in) :: dir
-      integer :: dims(3)
+      integer :: direction, dims(3)
       ! If the list is empty, allocate a new block before returning a
       ! pointer to it.
       if (.not. associated(self%first)) then
@@ -162,8 +162,27 @@ contains
       self%first => self%first%next ! 2nd block becomes head block
       handle%next => null() ! Detach ex-head block from the block list
 
-      ! set dims based on dir
-      call handle%set_shape(self%xdims)
+      ! If no direction is specified assume DIR_X
+      if (present(dir)) then
+         direction = dir
+      else
+         direction = DIR_X
+      end if
+
+      ! Set dims based on direction
+      select case(direction)
+      case (DIR_X)
+         dims = self%xdims
+      case (DIR_Y)
+         dims = self%ydims
+      case (DIR_Z)
+         dims = self%zdims
+      case (DIR_C)
+         dims = self%cdims
+      end select
+
+      ! Apply bounds remapping based on requested direction
+      call handle%set_shape(dims)
    end function get_block
 
    subroutine release_block(self, handle)

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -113,7 +113,8 @@ contains
       ! Apply padding based on sz
       nx_padded = nx - 1 + mod(-(nx - 1), sz) + sz
       ny_padded = ny - 1 + mod(-(ny - 1), sz) + sz
-      nz_padded = nz - 1 + mod(-(nz - 1), sz) + sz
+      ! Current reorder functions do not require a padding in z-direction.
+      nz_padded = nz
 
       allocator%ngrid = nx_padded*ny_padded*nz_padded
       allocator%sz = sz

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -31,7 +31,7 @@ module m_allocator
      !! [[m_allocator(module):release_block(subroutine)]].  The
      !! released block is then pushed in front of the block list.
 
-      integer :: nx_padded, ny_padded, nz_padded, sz
+      integer :: ngrid, sz
       !> The id for the next allocated block.  This counter is
       !> incremented each time a new block is allocated.
       integer :: next_id = 0
@@ -80,12 +80,12 @@ module m_allocator
 
 contains
 
-   function field_init(nx, ny, nz, sz, next, id) result(f)
-      integer, intent(in) :: nx, ny, nz, sz, id
+   function field_init(ngrid, next, id) result(f)
+      integer, intent(in) :: ngrid, id
       type(field_t), pointer, intent(in) :: next
       type(field_t) :: f
 
-      allocate (f%p_data(nx*ny*nz))
+      allocate (f%p_data(ngrid))
       f%refcount = 0
       f%next => next
       f%id = id
@@ -112,9 +112,7 @@ contains
       ny_padded = ny - 1 + mod(-(ny - 1), sz) + sz
       nz_padded = nz - 1 + mod(-(nz - 1), sz) + sz
 
-      allocator%nx_padded = nx_padded
-      allocator%ny_padded = ny_padded
-      allocator%nz_padded = nz_padded
+      allocator%ngrid = nx_padded*ny_padded*nz_padded
       allocator%sz = sz
 
       allocator%xdims = [sz, nx_padded, ny_padded*nz_padded/sz]
@@ -132,8 +130,7 @@ contains
       class(field_t), pointer :: ptr
       self%next_id = self%next_id + 1
       allocate (newblock)
-      newblock = field_t(self%nx_padded, self%ny_padded, self%nz_padded, &
-                         self%sz, next, id=self%next_id)
+      newblock = field_t(self%ngrid, next, id=self%next_id)
       ptr => newblock
    end function create_block
 

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -108,9 +108,9 @@ contains
       integer :: nx_padded, ny_padded, nz_padded
 
       ! Apply padding based on sz
-      nx_padded = nx
-      ny_padded = ny
-      nz_padded = nz
+      nx_padded = nx - 1 + mod(-(nx - 1), sz) + sz
+      ny_padded = ny - 1 + mod(-(ny - 1), sz) + sz
+      nz_padded = nz - 1 + mod(-(nz - 1), sz) + sz
 
       allocator%nx_padded = nx_padded
       allocator%ny_padded = ny_padded

--- a/src/common.f90
+++ b/src/common.f90
@@ -6,7 +6,7 @@ module m_common
 
    integer, parameter :: RDR_X2Y = 12, RDR_X2Z = 13, RDR_Y2X = 21, &
                          RDR_Y2Z = 23, RDR_Z2X = 31, RDR_Z2Y = 32
-
+   integer, parameter :: DIR_X = 1, DIR_Y = 2, DIR_Z = 3, DIR_C = 4
    integer, parameter :: POISSON_SOLVER_FFT = 0, POISSON_SOLVER_CG = 1
 
    type :: globs_t

--- a/src/cuda/allocator.f90
+++ b/src/cuda/allocator.f90
@@ -10,7 +10,7 @@ module m_cuda_allocator
    end type cuda_allocator_t
 
    type, extends(field_t) :: cuda_field_t
-      real(dp), allocatable, device :: data_d(:, :, :)
+      real(dp), allocatable, device :: data_d(:)
    end type cuda_field_t
 
    interface cuda_field_t
@@ -24,7 +24,7 @@ contains
       type(cuda_field_t), pointer, intent(in) :: next
       type(cuda_field_t) :: m
 
-      allocate (m%data_d(dims(1), dims(2), dims(3)))
+      allocate (m%data_d(dims(1)*dims(2)*dims(3)))
       m%refcount = 0
       m%next => next
       m%id = id

--- a/src/cuda/allocator.f90
+++ b/src/cuda/allocator.f90
@@ -26,12 +26,12 @@ module m_cuda_allocator
 
 contains
 
-   function cuda_field_init(nx, ny, nz, sz, next, id) result(f)
-      integer, intent(in) :: nx, ny, nz, sz, id
+   function cuda_field_init(ngrid, next, id) result(f)
+      integer, intent(in) :: ngrid, id
       type(cuda_field_t), pointer, intent(in) :: next
       type(cuda_field_t) :: f
 
-      allocate (f%p_data_d(nx*ny*nz))
+      allocate (f%p_data_d(ngrid))
       f%refcount = 0
       f%next => next
       f%id = id
@@ -61,8 +61,7 @@ contains
       class(field_t), pointer :: ptr
       allocate (newblock)
       self%next_id = self%next_id + 1
-      newblock = cuda_field_t(self%nx_padded, self%ny_padded, self%nz_padded, &
-                              self%sz, next, id=self%next_id)
+      newblock = cuda_field_t(self%ngrid, next, id=self%next_id)
       ptr => newblock
    end function create_cuda_block
 

--- a/src/cuda/allocator.f90
+++ b/src/cuda/allocator.f90
@@ -9,26 +9,40 @@ module m_cuda_allocator
       procedure :: create_block => create_cuda_block
    end type cuda_allocator_t
 
+   interface cuda_allocator_t
+      module procedure cuda_allocator_init
+   end interface cuda_allocator_t
+
    type, extends(field_t) :: cuda_field_t
-      real(dp), allocatable, device :: data_d(:)
+      real(dp), device, pointer, private :: p_data_d(:)
+      real(dp), device, pointer, contiguous :: data_d(:, :, :)
    end type cuda_field_t
 
    interface cuda_field_t
-      module procedure cuda_field_constructor
+      module procedure cuda_field_init
    end interface cuda_field_t
 
 contains
 
-   function cuda_field_constructor(dims, next, id) result(m)
-      integer, intent(in) :: dims(3), id
+   function cuda_field_init(nx, ny, nz, sz, next, id) result(f)
+      integer, intent(in) :: nx, ny, nz, sz, id
       type(cuda_field_t), pointer, intent(in) :: next
-      type(cuda_field_t) :: m
+      type(cuda_field_t) :: f
 
-      allocate (m%data_d(dims(1)*dims(2)*dims(3)))
-      m%refcount = 0
-      m%next => next
-      m%id = id
-   end function cuda_field_constructor
+      allocate (f%p_data_d(nx*ny*nz))
+      ! will be removed, bounds remapping will be carried out by get_block.
+      f%data_d(1:sz, 1:nx, 1:ny*nz/sz) => f%p_data_d
+      f%refcount = 0
+      f%next => next
+      f%id = id
+   end function cuda_field_init
+
+   function cuda_allocator_init(nx, ny, nz, sz) result(allocator)
+      integer, intent(in) :: nx, ny, nz, sz
+      type(cuda_allocator_t) :: allocator
+
+      allocator%allocator_t = allocator_t(nx, ny, nz, sz)
+   end function cuda_allocator_init
 
    function create_cuda_block(self, next) result(ptr)
       class(cuda_allocator_t), intent(inout) :: self
@@ -37,7 +51,8 @@ contains
       class(field_t), pointer :: ptr
       allocate (newblock)
       self%next_id = self%next_id + 1
-      newblock = cuda_field_t(self%dims, next, id=self%next_id)
+      newblock = cuda_field_t(self%nx_padded, self%ny_padded, self%nz_padded, &
+                              self%sz, next, id=self%next_id)
       ptr => newblock
    end function create_cuda_block
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -297,9 +297,9 @@ module m_cuda_backend
          du_dev, dud_dev, d2u_dev
 
       ! Get some fields for storing the intermediate results
-      du => self%allocator%get_block()
-      dud => self%allocator%get_block()
-      d2u => self%allocator%get_block()
+      du => self%allocator%get_block(dirps%dir)
+      dud => self%allocator%get_block(dirps%dir)
+      d2u => self%allocator%get_block(dirps%dir)
 
       call resolve_field_t(du_dev, du)
       call resolve_field_t(dud_dev, dud)

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -352,6 +352,11 @@ module m_cuda_backend
 
       type(dim3) :: blocks, threads
 
+      ! Check if direction matches for both in/out fields and dirps
+      if (dirps%dir /= du%dir .or. u%dir /= du%dir) then
+         error stop 'DIR mismatch between fields and dirps in tds_solve.'
+      end if
+
       blocks = dim3(dirps%n_blocks, 1, 1); threads = dim3(SZ, 1, 1)
 
       call tds_solve_dist(self, du, u, dirps, tdsops, blocks, threads)

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -225,9 +225,9 @@ module m_omp_backend
       type(dirps_t), intent(in) :: dirps
       class(field_t), pointer :: du, d2u, dud
 
-      du => self%allocator%get_block()
-      dud => self%allocator%get_block()
-      d2u => self%allocator%get_block()
+      du => self%allocator%get_block(dirps%dir)
+      dud => self%allocator%get_block(dirps%dir)
+      d2u => self%allocator%get_block(dirps%dir)
 
       call exec_dist_transeq_compact(&
          rhs%data, du%data, dud%data, d2u%data, &

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -254,6 +254,11 @@ module m_omp_backend
       type(dirps_t), intent(in) :: dirps
       class(tdsops_t), intent(in) :: tdsops
 
+      ! Check if direction matches for both in/out fields and dirps
+      if (dirps%dir /= du%dir .or. u%dir /= du%dir) then
+         error stop 'DIR mismatch between fields and dirps in tds_solve.'
+      end if
+
       call tds_solve_dist(self, du, u, dirps, tdsops)
 
    end subroutine tds_solve_omp

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -102,7 +102,7 @@ contains
       solver%w => solver%backend%allocator%get_block(DIR_X)
 
       ! Set initial conditions
-      dims(:) = solver%backend%allocator%xdims(:)
+      dims(:) = solver%backend%allocator%xdims_padded(:)
       allocate(u_init(dims(1), dims(2), dims(3)))
       allocate(v_init(dims(1), dims(2), dims(3)))
       allocate(w_init(dims(1), dims(2), dims(3)))

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -571,7 +571,7 @@ contains
       real(dp), intent(in) :: t
       real(dp), dimension(:, :, :), intent(inout) :: u_out
 
-      class(field_t), pointer :: du, dv, dw
+      class(field_t), pointer :: du, dv, dw, div_u
       integer :: ngrid
 
       ngrid = self%xdirps%n*self%ydirps%n*self%zdirps%n
@@ -592,8 +592,13 @@ contains
       call self%backend%allocator%release_block(dv)
       call self%backend%allocator%release_block(dw)
 
-      call self%divergence_v2p(du, self%u, self%v, self%w)
-      call self%backend%get_field(u_out, du)
+      div_u => self%backend%allocator%get_block(DIR_Z)
+
+      call self%divergence_v2p(div_u, self%u, self%v, self%w)
+      call self%backend%get_field(u_out, div_u)
+
+      call self%backend%allocator%release_block(div_u)
+
       print*, 'div u max mean:', maxval(abs(u_out)), sum(abs(u_out))/ngrid
 
    end subroutine output

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -3,7 +3,8 @@ module m_solver
    use m_base_backend, only: base_backend_t
    use m_common, only: dp, globs_t, &
                        RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
-                       POISSON_SOLVER_FFT, POISSON_SOLVER_CG
+                       POISSON_SOLVER_FFT, POISSON_SOLVER_CG, &
+                       DIR_X, DIR_Y, DIR_Z
    use m_tdsops, only: tdsops_t, dirps_t
    use m_time_integrator, only: time_intg_t
 
@@ -96,9 +97,9 @@ contains
       solver%ydirps => ydirps
       solver%zdirps => zdirps
 
-      solver%u => solver%backend%allocator%get_block()
-      solver%v => solver%backend%allocator%get_block()
-      solver%w => solver%backend%allocator%get_block()
+      solver%u => solver%backend%allocator%get_block(DIR_X)
+      solver%v => solver%backend%allocator%get_block(DIR_X)
+      solver%w => solver%backend%allocator%get_block(DIR_X)
 
       ! Set initial conditions
       dims(:) = solver%backend%allocator%xdims(:)
@@ -203,12 +204,12 @@ contains
       call self%backend%transeq_x(du, dv, dw, u, v, w, self%xdirps)
 
       ! request fields from the allocator
-      u_y => self%backend%allocator%get_block()
-      v_y => self%backend%allocator%get_block()
-      w_y => self%backend%allocator%get_block()
-      du_y => self%backend%allocator%get_block()
-      dv_y => self%backend%allocator%get_block()
-      dw_y => self%backend%allocator%get_block()
+      u_y => self%backend%allocator%get_block(DIR_Y)
+      v_y => self%backend%allocator%get_block(DIR_Y)
+      w_y => self%backend%allocator%get_block(DIR_Y)
+      du_y => self%backend%allocator%get_block(DIR_Y)
+      dv_y => self%backend%allocator%get_block(DIR_Y)
+      dw_y => self%backend%allocator%get_block(DIR_Y)
 
       ! reorder data from x orientation to y orientation
       call self%backend%reorder(u_y, u, RDR_X2Y)
@@ -235,12 +236,12 @@ contains
       call self%backend%allocator%release_block(dw_y)
 
       ! just like in y direction, get some fields for the z derivatives.
-      u_z => self%backend%allocator%get_block()
-      v_z => self%backend%allocator%get_block()
-      w_z => self%backend%allocator%get_block()
-      du_z => self%backend%allocator%get_block()
-      dv_z => self%backend%allocator%get_block()
-      dw_z => self%backend%allocator%get_block()
+      u_z => self%backend%allocator%get_block(DIR_Z)
+      v_z => self%backend%allocator%get_block(DIR_Z)
+      w_z => self%backend%allocator%get_block(DIR_Z)
+      du_z => self%backend%allocator%get_block(DIR_Z)
+      dv_z => self%backend%allocator%get_block(DIR_Z)
+      dw_z => self%backend%allocator%get_block(DIR_Z)
 
       ! reorder from x to z
       call self%backend%reorder(u_z, u, RDR_X2Z)
@@ -280,9 +281,9 @@ contains
                                  u_y, v_y, w_y, du_y, dv_y, dw_y, &
                                  u_z, w_z, dw_z
 
-      du_x => self%backend%allocator%get_block()
-      dv_x => self%backend%allocator%get_block()
-      dw_x => self%backend%allocator%get_block()
+      du_x => self%backend%allocator%get_block(DIR_X)
+      dv_x => self%backend%allocator%get_block(DIR_X)
+      dw_x => self%backend%allocator%get_block(DIR_X)
 
       ! Staggared der for u field in x
       ! Interpolation for v field in x
@@ -295,9 +296,9 @@ contains
                                   self%xdirps%interpl_v2p)
 
       ! request fields from the allocator
-      u_y => self%backend%allocator%get_block()
-      v_y => self%backend%allocator%get_block()
-      w_y => self%backend%allocator%get_block()
+      u_y => self%backend%allocator%get_block(DIR_Y)
+      v_y => self%backend%allocator%get_block(DIR_Y)
+      w_y => self%backend%allocator%get_block(DIR_Y)
 
       ! reorder data from x orientation to y orientation
       call self%backend%reorder(u_y, du_x, RDR_X2Y)
@@ -308,9 +309,9 @@ contains
       call self%backend%allocator%release_block(dv_x)
       call self%backend%allocator%release_block(dw_x)
 
-      du_y => self%backend%allocator%get_block()
-      dv_y => self%backend%allocator%get_block()
-      dw_y => self%backend%allocator%get_block()
+      du_y => self%backend%allocator%get_block(DIR_Y)
+      dv_y => self%backend%allocator%get_block(DIR_Y)
+      dw_y => self%backend%allocator%get_block(DIR_Y)
 
       ! similar to the x direction, obtain derivatives in y.
       call self%backend%tds_solve(du_y, u_y, self%ydirps, &
@@ -329,8 +330,8 @@ contains
       call self%backend%allocator%release_block(w_y)
 
       ! just like in y direction, get some fields for the z derivatives.
-      u_z => self%backend%allocator%get_block()
-      w_z => self%backend%allocator%get_block()
+      u_z => self%backend%allocator%get_block(DIR_Z)
+      w_z => self%backend%allocator%get_block(DIR_Z)
 
       ! du_y = dv_y + du_y
       call self%backend%vecadd(1._dp, dv_y, 1._dp, du_y)
@@ -344,7 +345,7 @@ contains
       call self%backend%allocator%release_block(dv_y)
       call self%backend%allocator%release_block(dw_y)
 
-      dw_z => self%backend%allocator%get_block()
+      dw_z => self%backend%allocator%get_block(DIR_Z)
 
       ! get the derivatives in z
       call self%backend%tds_solve(div_u, u_z, self%zdirps, &
@@ -378,8 +379,8 @@ contains
                                  p_sx_y, dpdy_sx_y, dpdz_sx_y, &
                                  p_sx_x, dpdy_sx_x, dpdz_sx_x
 
-      p_sxy_z => self%backend%allocator%get_block()
-      dpdz_sxy_z => self%backend%allocator%get_block()
+      p_sxy_z => self%backend%allocator%get_block(DIR_Z)
+      dpdz_sxy_z => self%backend%allocator%get_block(DIR_Z)
 
       ! Staggared der for pressure field in z
       ! Interpolation for pressure field in z
@@ -389,8 +390,8 @@ contains
                                   self%zdirps%stagder_p2v)
 
       ! request fields from the allocator
-      p_sxy_y => self%backend%allocator%get_block()
-      dpdz_sxy_y => self%backend%allocator%get_block()
+      p_sxy_y => self%backend%allocator%get_block(DIR_Y)
+      dpdz_sxy_y => self%backend%allocator%get_block(DIR_Y)
 
       ! reorder data from z orientation to y orientation
       call self%backend%reorder(p_sxy_y, p_sxy_z, RDR_Z2Y)
@@ -399,9 +400,9 @@ contains
       call self%backend%allocator%release_block(p_sxy_z)
       call self%backend%allocator%release_block(dpdz_sxy_z)
 
-      p_sx_y => self%backend%allocator%get_block()
-      dpdy_sx_y => self%backend%allocator%get_block()
-      dpdz_sx_y => self%backend%allocator%get_block()
+      p_sx_y => self%backend%allocator%get_block(DIR_Y)
+      dpdy_sx_y => self%backend%allocator%get_block(DIR_Y)
+      dpdz_sx_y => self%backend%allocator%get_block(DIR_Y)
 
       ! similar to the z direction, obtain derivatives in y.
       call self%backend%tds_solve(p_sx_y, p_sxy_y, self%ydirps, &
@@ -416,9 +417,9 @@ contains
       call self%backend%allocator%release_block(dpdz_sxy_y)
 
       ! just like in y direction, get some fields for the x derivatives.
-      p_sx_x => self%backend%allocator%get_block()
-      dpdy_sx_x => self%backend%allocator%get_block()
-      dpdz_sx_x => self%backend%allocator%get_block()
+      p_sx_x => self%backend%allocator%get_block(DIR_X)
+      dpdy_sx_x => self%backend%allocator%get_block(DIR_X)
+      dpdz_sx_x => self%backend%allocator%get_block(DIR_X)
 
       ! reorder from y to x
       call self%backend%reorder(p_sx_x, p_sx_y, RDR_Y2X)
@@ -464,8 +465,8 @@ contains
 
       ! omega_i_hat
       ! dw/dy
-      w_y => self%backend%allocator%get_block()
-      dwdy_y => self%backend%allocator%get_block()
+      w_y => self%backend%allocator%get_block(DIR_Y)
+      dwdy_y => self%backend%allocator%get_block(DIR_Y)
       call self%backend%reorder(w_y, w, RDR_X2Y)
       call self%backend%tds_solve(dwdy_y, w_y, self%ydirps, self%ydirps%der1st)
 
@@ -475,12 +476,12 @@ contains
       call self%backend%allocator%release_block(dwdy_y)
 
       ! dv/dz
-      v_z => self%backend%allocator%get_block()
-      dvdz_z => self%backend%allocator%get_block()
+      v_z => self%backend%allocator%get_block(DIR_Z)
+      dvdz_z => self%backend%allocator%get_block(DIR_Z)
       call self%backend%reorder(v_z, v, RDR_X2Z)
       call self%backend%tds_solve(dvdz_z, v_z, self%zdirps, self%zdirps%der1st)
 
-      dvdz_x => self%backend%allocator%get_block()
+      dvdz_x => self%backend%allocator%get_block(DIR_X)
       call self%backend%reorder(dvdz_x, dvdz_z, RDR_Z2X)
 
       call self%backend%allocator%release_block(v_z)
@@ -493,12 +494,12 @@ contains
 
       ! omega_j_hat
       ! du/dz
-      u_z => self%backend%allocator%get_block()
-      dudz_z => self%backend%allocator%get_block()
+      u_z => self%backend%allocator%get_block(DIR_Z)
+      dudz_z => self%backend%allocator%get_block(DIR_Z)
       call self%backend%reorder(u_z, u, RDR_X2Z)
       call self%backend%tds_solve(dudz_z, u_z, self%zdirps, self%zdirps%der1st)
 
-      dudz_x => self%backend%allocator%get_block()
+      dudz_x => self%backend%allocator%get_block(DIR_X)
       call self%backend%reorder(dudz_x, dudz_z, RDR_Z2X)
 
       call self%backend%allocator%release_block(u_z)
@@ -517,12 +518,12 @@ contains
       call self%backend%tds_solve(o_k_hat, v, self%xdirps, self%xdirps%der1st)
 
       ! du/dy
-      u_y => self%backend%allocator%get_block()
-      dudy_y => self%backend%allocator%get_block()
+      u_y => self%backend%allocator%get_block(DIR_Y)
+      dudy_y => self%backend%allocator%get_block(DIR_Y)
       call self%backend%reorder(u_y, u, RDR_X2Y)
       call self%backend%tds_solve(dudy_y, u_y, self%ydirps, self%ydirps%der1st)
 
-      dudy_x => self%backend%allocator%get_block()
+      dudy_x => self%backend%allocator%get_block(DIR_X)
       call self%backend%reorder(dudy_x, dudy_y, RDR_Y2X)
 
       call self%backend%allocator%release_block(u_y)
@@ -576,9 +577,9 @@ contains
       ngrid = self%xdirps%n*self%ydirps%n*self%zdirps%n
       print*, 'time = ', t
 
-      du => self%backend%allocator%get_block()
-      dv => self%backend%allocator%get_block()
-      dw => self%backend%allocator%get_block()
+      du => self%backend%allocator%get_block(DIR_X)
+      dv => self%backend%allocator%get_block(DIR_X)
+      dw => self%backend%allocator%get_block(DIR_X)
 
       call self%curl(du, dv, dw, self%u, self%v, self%w)
       print*, 'enstrophy:', 0.5_dp*( &
@@ -615,9 +616,9 @@ contains
       print*, 'start run'
 
       do i = 1, self%n_iters
-         du => self%backend%allocator%get_block()
-         dv => self%backend%allocator%get_block()
-         dw => self%backend%allocator%get_block()
+         du => self%backend%allocator%get_block(DIR_X)
+         dv => self%backend%allocator%get_block(DIR_X)
+         dw => self%backend%allocator%get_block(DIR_X)
 
          call self%transeq(du, dv, dw, self%u, self%v, self%w)
 
@@ -630,19 +631,19 @@ contains
          call self%backend%allocator%release_block(dw)
 
          ! pressure
-         div_u => self%backend%allocator%get_block()
+         div_u => self%backend%allocator%get_block(DIR_Z)
 
          call self%divergence_v2p(div_u, self%u, self%v, self%w)
 
-         pressure => self%backend%allocator%get_block()
+         pressure => self%backend%allocator%get_block(DIR_Z)
 
          call self%poisson(pressure, div_u)
 
          call self%backend%allocator%release_block(div_u)
 
-         dpdx => self%backend%allocator%get_block()
-         dpdy => self%backend%allocator%get_block()
-         dpdz => self%backend%allocator%get_block()
+         dpdx => self%backend%allocator%get_block(DIR_X)
+         dpdy => self%backend%allocator%get_block(DIR_X)
+         dpdz => self%backend%allocator%get_block(DIR_X)
 
          call self%gradient_p2v(dpdx, dpdy, dpdz, pressure)
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -101,7 +101,7 @@ contains
       solver%w => solver%backend%allocator%get_block()
 
       ! Set initial conditions
-      dims(:) = solver%backend%allocator%dims(:)
+      dims(:) = solver%backend%allocator%xdims(:)
       allocate(u_init(dims(1), dims(2), dims(3)))
       allocate(v_init(dims(1), dims(2), dims(3)))
       allocate(w_init(dims(1), dims(2), dims(3)))

--- a/src/tdsops.f90
+++ b/src/tdsops.f90
@@ -46,7 +46,7 @@ module m_tdsops
                                       der2nd, der2nd_sym, &
                                       stagder_v2p, stagder_p2v, &
                                       interpl_v2p, interpl_p2v
-      integer :: nrank, nproc, pnext, pprev, n, n_blocks
+      integer :: nrank, nproc, pnext, pprev, n, n_blocks, dir
       real(dp) :: L, d
    end type dirps_t
 

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -1,7 +1,7 @@
 module m_time_integrator
    use m_allocator, only: allocator_t, field_t, flist_t
    use m_base_backend, only: base_backend_t
-   use m_common, only: dp
+   use m_common, only: dp, DIR_X
 
    implicit none
 
@@ -46,7 +46,7 @@ contains
       ! Request all the storage for old timesteps
       do i = 1, constructor%nvars
          do j = 1, constructor%nolds
-            constructor%olds(i, j)%ptr => allocator%get_block()
+            constructor%olds(i, j)%ptr => allocator%get_block(DIR_X)
          end do
       end do
 

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -4,7 +4,8 @@ program xcompact
    use m_allocator
    use m_base_backend
    use m_common, only: pi, globs_t, set_pprev_pnext, &
-                       POISSON_SOLVER_FFT, POISSON_SOLVER_CG
+                       POISSON_SOLVER_FFT, POISSON_SOLVER_CG, &
+                       DIR_X, DIR_Y, DIR_Z
    use m_solver, only: solver_t
    use m_time_integrator, only: time_intg_t
    use m_tdsops, only: tdsops_t
@@ -109,6 +110,8 @@ program xcompact
    xdirps%n_blocks = globs%n_groups_x
    ydirps%n_blocks = globs%n_groups_y
    zdirps%n_blocks = globs%n_groups_z
+
+   xdirps%dir = DIR_X; ydirps%dir = DIR_Y; zdirps%dir = DIR_Z
 
 #ifdef CUDA
    cuda_allocator = cuda_allocator_t(globs%nx_loc, globs%ny_loc, &

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -111,7 +111,8 @@ program xcompact
    zdirps%n_blocks = globs%n_groups_z
 
 #ifdef CUDA
-   cuda_allocator = cuda_allocator_t([SZ, globs%nx_loc, globs%n_groups_x])
+   cuda_allocator = cuda_allocator_t(globs%nx_loc, globs%ny_loc, &
+                                     globs%nz_loc, SZ)
    allocator => cuda_allocator
    print*, 'CUDA allocator instantiated'
 
@@ -119,7 +120,7 @@ program xcompact
    backend => cuda_backend
    print*, 'CUDA backend instantiated'
 #else
-   omp_allocator = allocator_t([SZ, globs%nx_loc, globs%n_groups_x])
+   omp_allocator = allocator_t(globs%nx_loc, globs%ny_loc, globs%nz_loc, SZ)
    allocator => omp_allocator
    print*, 'OpenMP allocator instantiated'
 

--- a/tests/cuda/test_cuda_allocator.f90
+++ b/tests/cuda/test_cuda_allocator.f90
@@ -2,6 +2,7 @@ program test_allocator_cuda
   use iso_fortran_env, only: stderr => error_unit
 
   use m_allocator, only: allocator_t, field_t
+  use m_common, only: DIR_X
   use m_cuda_allocator, only: cuda_allocator_t
 
   implicit none
@@ -28,8 +29,8 @@ program test_allocator_cuda
 
   ! Request two blocks and release them in reverse order.  List should
   ! contain two free blocks. (1 -> 2)
-  ptr1 => allocator%get_block()
-  ptr2 => allocator%get_block()
+  ptr1 => allocator%get_block(DIR_X)
+  ptr2 => allocator%get_block(DIR_X)
   call allocator%release_block(ptr2)
   call allocator%release_block(ptr1)
 
@@ -52,13 +53,13 @@ program test_allocator_cuda
 
   ! Request a block from a list of three.  This should grab the first
   ! block on top of the pile and reduce the free list to two blocks.
-  ptr1 => allocator%get_block()
-  ptr2 => allocator%get_block()
-  ptr3 => allocator%get_block()
+  ptr1 => allocator%get_block(DIR_X)
+  ptr2 => allocator%get_block(DIR_X)
+  ptr3 => allocator%get_block(DIR_X)
   call allocator%release_block(ptr3)
   call allocator%release_block(ptr2)
   call allocator%release_block(ptr1)
-  ptr1 => allocator%get_block()
+  ptr1 => allocator%get_block(DIR_X)
 
   if (.not. all(allocator%get_block_ids() .eq. [2, 3])) then
      allpass = .false.

--- a/tests/cuda/test_cuda_allocator.f90
+++ b/tests/cuda/test_cuda_allocator.f90
@@ -12,7 +12,7 @@ program test_allocator_cuda
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
 
-  allocator = cuda_allocator_t(dims)
+  allocator = cuda_allocator_t(dims(1), dims(2), dims(3), 8)
 
   allpass = .true.
 

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -3,7 +3,7 @@ program test_omp_transeq
    use mpi
 
    use m_allocator, only: allocator_t, field_t
-   use m_common, only: dp, pi, globs_t, set_pprev_pnext
+   use m_common, only: dp, pi, globs_t, set_pprev_pnext, DIR_X, DIR_Y, DIR_Z
    use m_omp_common, only: SZ
    use m_omp_sendrecv, only: sendrecv_fields
    use m_omp_backend, only: omp_backend_t, transeq_x_omp, base_backend_t
@@ -67,6 +67,10 @@ program test_omp_transeq
    xdirps%n_blocks = globs%n_groups_x
    ydirps%n_blocks = globs%n_groups_y
    zdirps%n_blocks = globs%n_groups_z
+
+   xdirps%dir = DIR_X
+   ydirps%dir = DIR_Y
+   zdirps%dir = DIR_Z
 
    omp_allocator = allocator_t(xdirps%n, ydirps%n, zdirps%n, SZ)
    allocator => omp_allocator

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -91,13 +91,13 @@ program test_omp_transeq
    omp_backend%nu = nu
 
    
-   u => allocator%get_block()
-   v => allocator%get_block()
-   w => allocator%get_block()
+   u => allocator%get_block(DIR_X)
+   v => allocator%get_block(DIR_X)
+   w => allocator%get_block(DIR_X)
 
-   du => allocator%get_block()
-   dv => allocator%get_block()
-   dw => allocator%get_block()
+   du => allocator%get_block(DIR_X)
+   dv => allocator%get_block(DIR_X)
+   dw => allocator%get_block(DIR_X)
 
    dx_per = 2*pi/n_glob
    dx = 2*pi/(n_glob - 1)

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -68,7 +68,7 @@ program test_omp_transeq
    ydirps%n_blocks = globs%n_groups_y
    zdirps%n_blocks = globs%n_groups_z
 
-   omp_allocator = allocator_t([SZ, globs%nx_loc, globs%n_groups_x])
+   omp_allocator = allocator_t(xdirps%n, ydirps%n, zdirps%n, SZ)
    allocator => omp_allocator
    print*, 'OpenMP allocator instantiated'
 

--- a/tests/test_allocator.f90
+++ b/tests/test_allocator.f90
@@ -2,6 +2,7 @@ program test_allocator
   use iso_fortran_env, only: stderr => error_unit
 
   use m_allocator, only: allocator_t, field_t
+  use m_common, only: DIR_X
 
   implicit none
 
@@ -27,8 +28,8 @@ program test_allocator
 
   ! Request two blocks and release them in reverse order.  List should
   ! contain two free blocks. (1 -> 2)
-  ptr1 => allocator%get_block()
-  ptr2 => allocator%get_block()
+  ptr1 => allocator%get_block(DIR_X)
+  ptr2 => allocator%get_block(DIR_X)
   call allocator%release_block(ptr2)
   call allocator%release_block(ptr1)
 
@@ -51,13 +52,13 @@ program test_allocator
 
   ! Request a block from a list of three.  This should grab the first
   ! block on top of the pile and reduce the free list to two blocks.
-  ptr1 => allocator%get_block()
-  ptr2 => allocator%get_block()
-  ptr3 => allocator%get_block()
+  ptr1 => allocator%get_block(DIR_X)
+  ptr2 => allocator%get_block(DIR_X)
+  ptr3 => allocator%get_block(DIR_X)
   call allocator%release_block(ptr3)
   call allocator%release_block(ptr2)
   call allocator%release_block(ptr1)
-  ptr1 => allocator%get_block()
+  ptr1 => allocator%get_block(DIR_X)
 
   if (.not. all(allocator%get_block_ids() .eq. [2, 3])) then
      allpass = .false.

--- a/tests/test_allocator.f90
+++ b/tests/test_allocator.f90
@@ -11,7 +11,7 @@ program test_allocator
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
 
-  allocator = allocator_t(dims)
+  allocator = allocator_t(dims(1), dims(2), dims(3), 8)
 
   allpass = .true.
 


### PR DESCRIPTION
The problem is described in #24. I wanted to have a draft PR here so that we can plan ahead how to make this transition in both backends.

In the CUDA backend we always type check and assing a pointer to the `%data_d` component of `field_t`. Fortran allows a bounds remapping with pointer assignments and we can use this to have a 3D pointer pointing a 1D `data_d` array. My plan is to move all the type selection bits into a subroutine in CUDA backend like @pbartholomew08 suggested in a previous PR, and sort the bounds remapping there.

With the OpenMP backend the current way allocator works is very handy, but obviously we need to support different nx, ny, and nz and currently it is not possible. I think currently the `%data` component in `field_t` is passed directly into the kernels and it doesn't allow fixing the dimensions of `data` array when switching form x, y, and z orientations. My suggestion is again using bounds remapping and pointing to the 1D `data` array with the right dimensions based on the x, y, z orientations we're at. What do you think, @Nanoseb?

Alternative to this bounds remaping strategy is using assumed shape arrays in kernels but I think it might be more complicated especially with different velocity grid dimensions and pressure grid dimensions. I think padding is a good strategy to deal with this and assumed shape arrays would't mix well with with padding I believe.