### PR TITLE
Reduce the memory usage

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -30,7 +30,6 @@ module m_base_backend
       procedure(transeq_ders), deferred :: transeq_z
       procedure(tds_solve), deferred :: tds_solve
       procedure(reorder), deferred :: reorder
-      procedure(sum_yzintox), deferred :: sum_yzintox
       procedure(sum_intox), deferred :: sum_yintox
       procedure(sum_intox), deferred :: sum_zintox
       procedure(vecadd), deferred :: vecadd
@@ -97,18 +96,6 @@ module m_base_backend
    end interface
 
    abstract interface
-      subroutine sum_yzintox(self, u, u_y, u_z)
-         !! sum9into3 subroutine combines all the directional velocity
-         !! derivatives into the corresponding x directional fields.
-         import :: base_backend_t
-         import :: field_t
-         implicit none
-
-         class(base_backend_t) :: self
-         class(field_t), intent(inout) :: u
-         class(field_t), intent(in) :: u_y, u_z
-      end subroutine sum_yzintox
-
       subroutine sum_intox(self, u, u_)
          !! sum9into3 subroutine combines all the directional velocity
          !! derivatives into the corresponding x directional fields.

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -31,6 +31,8 @@ module m_base_backend
       procedure(tds_solve), deferred :: tds_solve
       procedure(reorder), deferred :: reorder
       procedure(sum_yzintox), deferred :: sum_yzintox
+      procedure(sum_intox), deferred :: sum_yintox
+      procedure(sum_intox), deferred :: sum_zintox
       procedure(vecadd), deferred :: vecadd
       procedure(get_fields), deferred :: get_fields
       procedure(set_fields), deferred :: set_fields
@@ -106,6 +108,18 @@ module m_base_backend
          class(field_t), intent(inout) :: u
          class(field_t), intent(in) :: u_y, u_z
       end subroutine sum_yzintox
+
+      subroutine sum_intox(self, u, u_)
+         !! sum9into3 subroutine combines all the directional velocity
+         !! derivatives into the corresponding x directional fields.
+         import :: base_backend_t
+         import :: field_t
+         implicit none
+
+         class(base_backend_t) :: self
+         class(field_t), intent(inout) :: u
+         class(field_t), intent(in) :: u_
+      end subroutine sum_intox
    end interface
 
    abstract interface

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -37,7 +37,6 @@ module m_cuda_backend
       procedure :: transeq_z => transeq_z_cuda
       procedure :: tds_solve => tds_solve_cuda
       procedure :: reorder => reorder_cuda
-      procedure :: sum_yzintox => sum_yzintox_cuda
       procedure :: sum_yintox => sum_yintox_cuda
       procedure :: sum_zintox => sum_zintox_cuda
       procedure :: vecadd => vecadd_cuda
@@ -501,30 +500,6 @@ module m_cuda_backend
       call sum_zintox<<<blocks, threads>>>(u_d, u_z_d, self%nz_loc)
 
    end subroutine sum_zintox_cuda
-
-   subroutine sum_yzintox_cuda(self, u, u_y, u_z)
-      implicit none
-
-      class(cuda_backend_t) :: self
-      class(field_t), intent(inout) :: u
-      class(field_t), intent(in) :: u_y, u_z
-
-      real(dp), device, pointer, dimension(:, :, :) :: u_d, u_y_d, u_z_d
-      type(dim3) :: blocks, threads
-
-      select type(u); type is (cuda_field_t); u_d => u%data_d; end select
-      select type(u_y); type is (cuda_field_t); u_y_d => u_y%data_d; end select
-      select type(u_z); type is (cuda_field_t); u_z_d => u_z%data_d; end select
-
-      blocks = dim3(self%nx_loc/SZ, self%ny_loc/SZ, self%nz_loc)
-      threads = dim3(SZ, SZ, 1)
-      call sum_yintox<<<blocks, threads>>>(u_d, u_y_d, self%nz_loc)
-
-      blocks = dim3(self%nx_loc, self%ny_loc/SZ, 1)
-      threads = dim3(SZ, 1, 1)
-      call sum_zintox<<<blocks, threads>>>(u_d, u_z_d, self%nz_loc)
-
-   end subroutine sum_yzintox_cuda
 
    subroutine vecadd_cuda(self, a, x, b, y)
       implicit none

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -38,6 +38,8 @@ module m_cuda_backend
       procedure :: tds_solve => tds_solve_cuda
       procedure :: reorder => reorder_cuda
       procedure :: sum_yzintox => sum_yzintox_cuda
+      procedure :: sum_yintox => sum_yintox_cuda
+      procedure :: sum_zintox => sum_zintox_cuda
       procedure :: vecadd => vecadd_cuda
       procedure :: set_fields => set_fields_cuda
       procedure :: get_fields => get_fields_cuda
@@ -461,6 +463,44 @@ module m_cuda_backend
       end select
 
    end subroutine reorder_cuda
+
+   subroutine sum_yintox_cuda(self, u, u_y)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      class(field_t), intent(inout) :: u
+      class(field_t), intent(in) :: u_y
+
+      real(dp), device, pointer, dimension(:, :, :) :: u_d, u_y_d
+      type(dim3) :: blocks, threads
+
+      select type(u); type is (cuda_field_t); u_d => u%data_d; end select
+      select type(u_y); type is (cuda_field_t); u_y_d => u_y%data_d; end select
+
+      blocks = dim3(self%nx_loc/SZ, self%ny_loc/SZ, self%nz_loc)
+      threads = dim3(SZ, SZ, 1)
+      call sum_yintox<<<blocks, threads>>>(u_d, u_y_d, self%nz_loc)
+
+   end subroutine sum_yintox_cuda
+
+   subroutine sum_zintox_cuda(self, u, u_z)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      class(field_t), intent(inout) :: u
+      class(field_t), intent(in) :: u_z
+
+      real(dp), device, pointer, dimension(:, :, :) :: u_d, u_z_d
+      type(dim3) :: blocks, threads
+
+      select type(u); type is (cuda_field_t); u_d => u%data_d; end select
+      select type(u_z); type is (cuda_field_t); u_z_d => u_z%data_d; end select
+
+      blocks = dim3(self%nx_loc, self%ny_loc/SZ, 1)
+      threads = dim3(SZ, 1, 1)
+      call sum_zintox<<<blocks, threads>>>(u_d, u_z_d, self%nz_loc)
+
+   end subroutine sum_zintox_cuda
 
    subroutine sum_yzintox_cuda(self, u, u_y, u_z)
       implicit none

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -25,7 +25,6 @@ module m_omp_backend
       procedure :: transeq_z => transeq_z_omp
       procedure :: tds_solve => tds_solve_omp
       procedure :: reorder => reorder_omp
-      procedure :: sum_yzintox => sum_yzintox_omp
       procedure :: sum_yintox => sum_yintox_omp
       procedure :: sum_zintox => sum_zintox_omp
       procedure :: vecadd => vecadd_omp
@@ -189,15 +188,6 @@ module m_omp_backend
       class(field_t), intent(in) :: u_
 
    end subroutine sum_zintox_omp
-
-   subroutine sum_yzintox_omp(self, u, u_y, u_z)
-      implicit none
-
-      class(omp_backend_t) :: self
-      class(field_t), intent(inout) :: u
-      class(field_t), intent(in) :: u_y, u_z
-
-   end subroutine sum_yzintox_omp
 
    subroutine vecadd_omp(self, a, x, b, y)
       implicit none

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -26,6 +26,8 @@ module m_omp_backend
       procedure :: tds_solve => tds_solve_omp
       procedure :: reorder => reorder_omp
       procedure :: sum_yzintox => sum_yzintox_omp
+      procedure :: sum_yintox => sum_yintox_omp
+      procedure :: sum_zintox => sum_zintox_omp
       procedure :: vecadd => vecadd_omp
       procedure :: set_fields => set_fields_omp
       procedure :: get_fields => get_fields_omp
@@ -169,6 +171,24 @@ module m_omp_backend
       integer, intent(in) :: direction
 
    end subroutine reorder_omp
+
+   subroutine sum_yintox_omp(self, u, u_)
+      implicit none
+
+      class(omp_backend_t) :: self
+      class(field_t), intent(inout) :: u
+      class(field_t), intent(in) :: u_
+
+   end subroutine sum_yintox_omp
+
+   subroutine sum_zintox_omp(self, u, u_)
+      implicit none
+
+      class(omp_backend_t) :: self
+      class(field_t), intent(inout) :: u
+      class(field_t), intent(in) :: u_
+
+   end subroutine sum_zintox_omp
 
    subroutine sum_yzintox_omp(self, u, u_y, u_z)
       implicit none

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -200,6 +200,14 @@ contains
       call self%backend%allocator%release_block(v_y)
       call self%backend%allocator%release_block(w_y)
 
+      call self%backend%sum_yintox(du, du_y)
+      call self%backend%sum_yintox(dv, dv_y)
+      call self%backend%sum_yintox(dw, dw_y)
+
+      call self%backend%allocator%release_block(du_y)
+      call self%backend%allocator%release_block(dv_y)
+      call self%backend%allocator%release_block(dw_y)
+
       ! just like in y direction, get some fields for the z derivatives.
       u_z => self%backend%allocator%get_block()
       v_z => self%backend%allocator%get_block()
@@ -222,14 +230,11 @@ contains
       call self%backend%allocator%release_block(w_z)
 
       ! gather all the contributions into the x result array
-      call self%backend%sum_yzintox(du, du_y, du_z)
-      call self%backend%sum_yzintox(dv, dv_y, dv_z)
-      call self%backend%sum_yzintox(dw, dw_y, dw_z)
+      call self%backend%sum_zintox(du, du_z)
+      call self%backend%sum_zintox(dv, dv_z)
+      call self%backend%sum_zintox(dw, dw_z)
 
       ! release all the unnecessary blocks.
-      call self%backend%allocator%release_block(du_y)
-      call self%backend%allocator%release_block(dv_y)
-      call self%backend%allocator%release_block(dw_y)
       call self%backend%allocator%release_block(du_z)
       call self%backend%allocator%release_block(dv_z)
       call self%backend%allocator%release_block(dw_z)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -37,7 +37,7 @@ module m_solver
 
       real(dp) :: dt, nu
 
-      class(field_t), pointer :: u, v, w, du, dv, dw
+      class(field_t), pointer :: u, v, w
 
       class(base_backend_t), pointer :: backend
       class(dirps_t), pointer :: xdirps, ydirps, zdirps
@@ -97,11 +97,6 @@ contains
 
       deallocate(u_init, v_init, w_init)
       print*, 'initial conditions are set'
-
-      ! Allocate fields for storing the RHS
-      solver%du => solver%backend%allocator%get_block()
-      solver%dv => solver%backend%allocator%get_block()
-      solver%dw => solver%backend%allocator%get_block()
 
       nx = globs%nx_loc; ny = globs%ny_loc; nz = globs%nz_loc
       dx = globs%dx; dy = globs%dy; dz = globs%dz
@@ -422,18 +417,26 @@ contains
       integer, intent(in) :: n_iter
       real(dp), dimension(:, :, :), intent(inout) :: u_out, v_out, w_out
 
-      class(field_t), pointer :: div_u, pressure, dpdx, dpdy, dpdz
+      class(field_t), pointer :: du, dv, dw, div_u, pressure, dpdx, dpdy, dpdz
 
       integer :: i
 
       print*, 'start run'
 
       do i = 1, n_iter
-         call self%transeq(self%du, self%dv, self%dw, self%u, self%v, self%w)
+         du => self%backend%allocator%get_block()
+         dv => self%backend%allocator%get_block()
+         dw => self%backend%allocator%get_block()
+
+         call self%transeq(du, dv, dw, self%u, self%v, self%w)
 
          ! time integration
          call self%time_integrator%step(self%u, self%v, self%w, &
-                                        self%du, self%dv, self%dw, self%dt)
+                                        du, dv, dw, self%dt)
+
+         call self%backend%allocator%release_block(du)
+         call self%backend%allocator%release_block(dv)
+         call self%backend%allocator%release_block(dw)
 
          ! pressure
          div_u => self%backend%allocator%get_block()
@@ -467,7 +470,7 @@ contains
       print*, 'run end'
 
       call self%backend%get_fields( &
-         u_out, v_out, w_out, self%du, self%dv, self%dw &
+         u_out, v_out, w_out, self%u, self%v, self%w &
       )
 
    end subroutine run


### PR DESCRIPTION
I can't believe I missed this! 

In transeq at the very end we do
`du_x = du_x + du_y + du_z`

However due to the restictions on running GPU kernels with specific thread and block dimensions we carry out this operation in 2 separate calls as
`du_x = du_x + du_y`
`du_x = du_x + du_z`

And this gives an oppurtunity to move the y2x sum up just below `transeq_y` call. Then we release `du_y, dv_y, dw_y` right after adding these into _x counterparts.

This basic fix allowed **reducing the memory usage from 18 scalar fields down to 15**, without affecting the performance at all for the CUDA backend. (15GiB for a $512^3$ simulation). The total figure excludes Poisson solvers memory requirement which is not yet in the codebase. 

Any further reductions in memory usage after this point would result in an increase in the runtime of the simulation. For example we might be able to reduce it down to 12, which shouldn't be that hard, but it would require some extra reordering operations and its better not to work on that at this stage I think.

Assuming that FFT based Poisson solver will requre ~4 scalar field equivalent memory, we should be able to fit a $1024^3$ simulation on a typical 4xA100 node!

Now we have separate `sum_yintox`, `sum_zintox`, and `vecadd` subroutines in backends, all similar at some level. All these can be combined into a single subroutine like we did with reorder subroutines, and that's what I'll do next. I'll create an issue to discuss this further, and not include this next step in the current PR. I'm happy to merge this one as soon as someone approves.


