### PR TITLE
Add curl operator in solver

### DIFF
--- a/src/solver.f90
+++ b/src/solver.f90
@@ -45,7 +45,7 @@ module m_solver
    contains
       procedure :: transeq
       procedure :: divergence_v2p
-      procedure :: gradient
+      procedure :: gradient_p2v
       procedure :: run
    end type solver_t
 
@@ -310,7 +310,7 @@ contains
 
    end subroutine divergence_v2p
 
-   subroutine gradient(self, dpdx, dpdy, dpdz, pressure)
+   subroutine gradient_p2v(self, dpdx, dpdy, dpdz, pressure)
       implicit none
 
       class(solver_t) :: self
@@ -387,7 +387,7 @@ contains
       call self%backend%allocator%release_block(dpdy_sx_x)
       call self%backend%allocator%release_block(dpdz_sx_x)
 
-   end subroutine gradient
+   end subroutine gradient_p2v
 
    subroutine run(self, n_iter, u_out, v_out, w_out)
       implicit none
@@ -432,7 +432,7 @@ contains
          dpdy => self%backend%allocator%get_block()
          dpdz => self%backend%allocator%get_block()
 
-         call self%gradient(dpdx, dpdy, dpdz, pressure)
+         call self%gradient_p2v(dpdx, dpdy, dpdz, pressure)
 
          call self%backend%allocator%release_block(pressure)
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -44,7 +44,7 @@ module m_solver
       class(time_intg_t), pointer :: time_integrator
    contains
       procedure :: transeq
-      procedure :: divergence
+      procedure :: divergence_v2p
       procedure :: gradient
       procedure :: run
    end type solver_t
@@ -215,7 +215,7 @@ contains
 
    end subroutine transeq
 
-   subroutine divergence(self, div_u, u, v, w)
+   subroutine divergence_v2p(self, div_u, u, v, w)
       implicit none
 
       class(solver_t) :: self
@@ -308,7 +308,7 @@ contains
       call self%backend%allocator%release_block(w_z)
       call self%backend%allocator%release_block(dw_z)
 
-   end subroutine divergence
+   end subroutine divergence_v2p
 
    subroutine gradient(self, dpdx, dpdy, dpdz, pressure)
       implicit none
@@ -420,7 +420,7 @@ contains
          ! pressure
          div_u => self%backend%allocator%get_block()
 
-         call self%divergence(div_u, self%u, self%v, self%w)
+         call self%divergence_v2p(div_u, self%u, self%v, self%w)
 
          pressure => self%backend%allocator%get_block()
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -47,6 +47,7 @@ module m_solver
       procedure :: divergence_v2p
       procedure :: divergence_v2v
       procedure :: gradient_p2v
+      procedure :: curl_v2v
       procedure :: run
    end type solver_t
 
@@ -441,6 +442,66 @@ contains
       call self%backend%allocator%release_block(dpdz_sx_x)
 
    end subroutine gradient_p2v
+
+   subroutine curl_v2v(self, o_x, o_y, o_z, u, v, w)
+      implicit none
+
+      class(solver_t) :: self
+      class(field_t), intent(inout) :: o_x, o_y, o_z !! omega_x/_y/_z
+      class(field_t), intent(in) :: u, v, w
+
+      class(field_t), pointer :: u_y, w_y, du_y, u_z, v_z, du_z, dv_z
+
+      ! o_x = dw/dy - dv/dz
+      ! o_y = du/dz - dw/dx
+      ! o_z = dv/dx - du/dy
+
+      ! obtain dw/dx, dv/dx and store them directly in omega_y, omega_z
+      call self%backend%tds_solve(o_y, w, self%xdirps, self%xdirps%der1st)
+      call self%backend%tds_solve(o_z, v, self%xdirps, self%xdirps%der1st)
+
+      u_y => self%backend%allocator%get_block()
+      w_y => self%backend%allocator%get_block()
+
+      call self%backend%reorder(u_y, u, RDR_X2Y)
+      call self%backend%reorder(w_y, w, RDR_X2Y)
+
+      du_y => self%backend%allocator%get_block()
+
+      ! obtain du/dy, dw/dy
+      ! store du/dy in a temporary field to add into omega_z later
+      ! dw/dy can be stored directly in omega_x as it is empty
+      call self%backend%tds_solve(du_y, u_y, self%ydirps, self%ydirps%der1st)
+      call self%backend%tds_solve(o_x, w_y, self%ydirps, self%ydirps%der1st)
+
+      call self%backend%allocator%release_block(u_y)
+      call self%backend%allocator%release_block(w_y)
+
+      ! omega_z = dv/dz - du/dy
+      call self%backend%vecadd(-1._dp, du_y, 1._dp, o_z)
+
+      call self%backend%allocator%release_block(du_y)
+
+      u_z => self%backend%allocator%get_block()
+      v_z => self%backend%allocator%get_block()
+      du_z => self%backend%allocator%get_block()
+      dv_z => self%backend%allocator%get_block()
+
+      ! obtain du/dz, dv/dz and store them in temporary fields
+      call self%backend%tds_solve(du_z, u_z, self%zdirps, self%zdirps%der1st)
+      call self%backend%tds_solve(dv_z, v_z, self%zdirps, self%zdirps%der1st)
+
+      ! omega_x = dw/dy - dv/dz
+      call self%backend%vecadd(-1._dp, dv_z, 1._dp, o_x)
+      ! omega_y = du/dz - dw/dx
+      call self%backend%vecadd(1._dp, du_z, -1._dp, o_y)
+
+      call self%backend%allocator%release_block(u_z)
+      call self%backend%allocator%release_block(v_z)
+      call self%backend%allocator%release_block(du_z)
+      call self%backend%allocator%release_block(dv_z)
+
+   end subroutine curl_v2v
 
    subroutine run(self, n_iter, u_out, v_out, w_out)
       implicit none

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -46,7 +46,7 @@ module m_solver
       procedure :: transeq
       procedure :: divergence_v2p
       procedure :: gradient_p2v
-      procedure :: curl_v2v
+      procedure :: curl
       procedure :: run
    end type solver_t
 
@@ -390,7 +390,7 @@ contains
 
    end subroutine gradient_p2v
 
-   subroutine curl_v2v(self, o_x, o_y, o_z, u, v, w)
+   subroutine curl(self, o_x, o_y, o_z, u, v, w)
       implicit none
 
       class(solver_t) :: self
@@ -448,7 +448,7 @@ contains
       call self%backend%allocator%release_block(du_z)
       call self%backend%allocator%release_block(dv_z)
 
-   end subroutine curl_v2v
+   end subroutine curl
 
    subroutine run(self, n_iter, u_out, v_out, w_out)
       implicit none

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -45,7 +45,6 @@ module m_solver
    contains
       procedure :: transeq
       procedure :: divergence_v2p
-      procedure :: divergence_v2v
       procedure :: gradient_p2v
       procedure :: curl_v2v
       procedure :: run
@@ -311,58 +310,6 @@ contains
       call self%backend%allocator%release_block(dw_z)
 
    end subroutine divergence_v2p
-
-   subroutine divergence_v2v(self, div_u, u, v, w)
-      implicit none
-
-      class(solver_t) :: self
-      class(field_t), intent(inout) :: div_u
-      class(field_t), intent(in) :: u, v, w
-
-      class(field_t), pointer :: v_y, dv_y, w_z, dw_z
-
-      ! obtain du/dx: div_u = du/dx
-      call self%backend%tds_solve(div_u, u, self%xdirps, self%xdirps%der1st)
-
-      ! request a field from the allocator for v in y orientation
-      v_y => self%backend%allocator%get_block()
-
-      ! reorder v from x orientation to y orientation
-      call self%backend%reorder(v_y, v, RDR_X2Y)
-
-      ! request a field for storing the dv/dy
-      dv_y => self%backend%allocator%get_block()
-
-      ! obtain dv/dy
-      call self%backend%tds_solve(dv_y, v_y, self%ydirps, self%ydirps%der1st)
-
-      ! div_u = div_u + dv/dy
-      call self%backend%sum_yintox(div_u, dv_y)
-
-      ! v velocity and dv/dy in y orientation are not required any more
-      call self%backend%allocator%release_block(v_y)
-      call self%backend%allocator%release_block(dv_y)
-
-      ! request a field from the allocator for w in z orientation
-      w_z => self%backend%allocator%get_block()
-
-      ! reorder w from x orientation to z orientation
-      call self%backend%reorder(w_z, w, RDR_X2Z)
-
-      ! request a field for storing the dw/dz
-      dw_z => self%backend%allocator%get_block()
-
-      ! obtain dw/dz
-      call self%backend%tds_solve(dw_z, w_z, self%zdirps, self%zdirps%der1st)
-
-      ! div_u = div_u + dw/dz
-      call self%backend%sum_zintox(div_u, dw_z)
-
-      ! w velocity and dw/dz in z orientation are not required any more
-      call self%backend%allocator%release_block(w_z)
-      call self%backend%allocator%release_block(dw_z)
-
-   end subroutine divergence_v2v
 
    subroutine gradient_p2v(self, dpdx, dpdy, dpdz, pressure)
       implicit none


### PR DESCRIPTION
I added two new vector operators

- ~~divergence_v2v: required for checking the divergence of velocity field~~
- curl_v2v: required for enstrophy

Also renamed original divergence -> divergence_v2p and gradient -> gradient_p2v to clarify that these are switching from vertex grid to pressure grid.

Had a quick chat with @slaizet and he pointed out that we actually check the divergence of velocity field at the pressure grid and divergence of velocity at velocity grid wouldn't be zero. So removing divergence_v2v as we don't see any use case for it.