### PR TITLE
Remove unused variables from OMP build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,10 +43,13 @@ jobs:
         echo "$GITHUB_WORKSPACE/openmpi-${OMPI_VERSION}/installed/bin" \
           >> $GITHUB_PATH
 
-    - name: Check Debug build
+    - name: Configure Debug build
       run: FC=mpif90 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+    - name: Build with Debug (strict) flags
+      run: make -C build
       
-    - name: Configure build
+    - name: Configure Release build
       run: FC=mpif90 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,8 +43,11 @@ jobs:
         echo "$GITHUB_WORKSPACE/openmpi-${OMPI_VERSION}/installed/bin" \
           >> $GITHUB_PATH
 
+    - name: Check Debug build
+      run: FC=mpif90 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+      
     - name: Configure build
-      run: FC=mpif90 cmake -S . -B build
+      run: FC=mpif90 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
     - name: Build tests
       run: make -C build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,14 +36,10 @@ target_link_libraries(xcompact PRIVATE x3d2)
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")
  
-  target_compile_options(x3d2 PRIVATE "-O3")
-  target_compile_options(xcompact PRIVATE "-O3")
-  target_compile_options(xcompact PRIVATE "-cpp")
-  target_compile_options(x3d2 PRIVATE "-cuda")
-  target_compile_options(x3d2 PRIVATE "-fast")
+  set(CMAKE_Fortran_FLAGS "-cpp -cuda")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -Mbounds")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fast")
   target_link_options(x3d2 INTERFACE "-cuda")
-  target_compile_options(xcompact PRIVATE "-cuda")
-  target_compile_options(xcompact PRIVATE "-fast")
 
   target_compile_options(xcompact PRIVATE "-DCUDA")
   #  target_link_options(xcompact INTERFACE "-cuda")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")
  
   set(CMAKE_Fortran_FLAGS "-cpp -cuda")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -Mbounds")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -traceback -Mbounds -Mchkptr -Ktrap=fp")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fast")
   target_link_options(x3d2 INTERFACE "-cuda")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,12 +33,12 @@ target_include_directories(x3d2 INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 add_executable(xcompact xcompact.f90)
 target_link_libraries(xcompact PRIVATE x3d2)
 
-target_compile_options(x3d2 PRIVATE "-O3")
-target_compile_options(xcompact PRIVATE "-O3")
-target_compile_options(xcompact PRIVATE "-cpp")
-
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")
+ 
+  target_compile_options(x3d2 PRIVATE "-O3")
+  target_compile_options(xcompact PRIVATE "-O3")
+  target_compile_options(xcompact PRIVATE "-cpp")
   target_compile_options(x3d2 PRIVATE "-cuda")
   target_compile_options(x3d2 PRIVATE "-fast")
   target_link_options(x3d2 INTERFACE "-cuda")
@@ -47,11 +47,10 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
 
   target_compile_options(xcompact PRIVATE "-DCUDA")
   #  target_link_options(xcompact INTERFACE "-cuda")
-endif()
-
-if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
-  target_compile_options(x3d2 PRIVATE "-ffast-math")
-  target_compile_options(xcompact PRIVATE "-ffast-math")
+elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
+  set(CMAKE_Fortran_FLAGS "-cpp -std=f2008")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-g -Og -Wall -Wpedantic -Werror -Wimplicit-interface -Wimplicit-procedure -Wno-unused-dummy-argument")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ffast-math")
 endif()
 
 find_package(OpenMP REQUIRED)

--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -105,7 +105,6 @@ contains
     !! ```
       class(allocator_t), intent(inout) :: self
       class(field_t), pointer :: handle
-      class(field_t), allocatable, target :: ptr
       ! If the list is empty, allocate a new block before returning a
       ! pointer to it.
       if (.not. associated(self%first)) then

--- a/src/common.f90
+++ b/src/common.f90
@@ -26,7 +26,7 @@ contains
       integer, intent(out) :: xprev, xnext, yprev, ynext, zprev, znext
       integer, intent(in) :: xnproc, ynproc, znproc, nrank
 
-      integer :: i, ix, iy, iz
+      integer :: ix, iy, iz
 
       ix = modulo(nrank, xnproc)
       iy = modulo((nrank - ix)/xnproc, ynproc)

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -158,7 +158,6 @@ module m_omp_backend
       class(field_t), intent(inout) :: du, dv, dw
       class(field_t), intent(in) :: u, v, w
       type(dirps_t), intent(in) :: dirps
-      integer :: n_halo
 
       call transeq_halo_exchange(self, u, v, w, dirps)
 

--- a/src/omp/kernels_dist.f90
+++ b/src/omp/kernels_dist.f90
@@ -178,7 +178,8 @@ contains
 
       ! Local variables
       integer :: i, j!, b
-      real(dp) :: ur, bl, recp, du_s, du_e
+      real(dp) :: ur, bl, recp
+      real(dp), dimension(SZ) :: du_s, du_e
 
       !$omp simd
       do i = 1, SZ
@@ -195,32 +196,32 @@ contains
          bl = dist_sa(1)
          ur = dist_sa(1)
          recp = 1._dp/(1._dp - ur*bl)
-         du_s = recp*(du(i, 1) - bl*recv_u_s(i, 1))
+         du_s(i) = recp*(du(i, 1) - bl*recv_u_s(i, 1))
 
          ! End
          ! At the end we have the 'ur', and assume 'bl'
          bl = dist_sc(n)
          ur = dist_sc(n)
          recp = 1._dp/(1._dp - ur*bl)
-         du_e = recp*(du(i, n) - ur*recv_u_e(i, 1))
+         du_e(i) = recp*(du(i, n) - ur*recv_u_e(i, 1))
       end do
       !$omp end simd
 
       !$omp simd
       do i = 1, SZ
-         du(i, 1) = du_s
+         du(i, 1) = du_s(i)
       end do
       !$omp end simd
       do j = 2, n - 1
          !$omp simd
          do i = 1, SZ
-            du(i, j) = (du(i, j) - dist_sa(j)*du_s - dist_sc(j)*du_e)
+            du(i, j) = (du(i, j) - dist_sa(j)*du_s(i) - dist_sc(j)*du_e(i))
          end do
          !$omp end simd
       end do
       !$omp simd
       do i = 1, SZ
-         du(i, n) = du_e
+         du(i, n) = du_e(i)
       end do
       !$omp end simd
 

--- a/src/omp/kernels_dist.f90
+++ b/src/omp/kernels_dist.f90
@@ -24,7 +24,6 @@ contains
 
       ! Local variables
       integer :: i, j!, b
-      integer :: jm2, jm1, jp1, jp2
 
       real(dp) :: c_m4, c_m3, c_m2, c_m1, c_j, c_p1, c_p2, c_p3, c_p4, &
                   temp_du, alpha, last_r

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -224,7 +224,7 @@ contains
 
       class(field_t), pointer :: du_x, dv_x, dw_x, &
                                  u_y, v_y, w_y, du_y, dv_y, dw_y, &
-                                 u_z, w_z, du_z, dw_z
+                                 u_z, w_z, dw_z
 
       du_x => self%backend%allocator%get_block()
       dv_x => self%backend%allocator%get_block()

--- a/src/tdsops.f90
+++ b/src/tdsops.f90
@@ -89,9 +89,9 @@ contains
          tdsops%n_halo = n_halo
          if (n_halo /= 4) then
             write (stderr, '("Warning: n_halo is set to ", i2, "be careful! &
-                              The default is 4 and there are quite a few &
-                              places where things are hardcoded assuming &
-                              n_halo is 4.")') n_halo
+                              &The default is 4 and there are quite a few &
+                              &places where things are hardcoded assuming &
+                              &n_halo is 4.")') n_halo
          end if
       else
          tdsops%n_halo = 4
@@ -617,7 +617,7 @@ contains
       logical, optional, intent(in) :: sym
 
       real(dp), allocatable :: dist_b(:)
-      real(dp) :: alpha, aci, bci, cci, dci
+      real(dp) :: alpha, aci, bci
       integer :: i, n, n_halo
 
       if (self%n_halo < 2) error stop 'Staggared deriv require n_halo >= 2'

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -30,6 +30,7 @@ program xcompact
 #ifdef CUDA
    type(cuda_backend_t), target :: cuda_backend
    type(cuda_allocator_t), target :: cuda_allocator
+   integer :: ndevs, devnum
 #else
    type(omp_backend_t), target :: omp_backend
    type(allocator_t), target :: omp_allocator
@@ -38,7 +39,7 @@ program xcompact
    real(dp), allocatable, dimension(:, :, :) :: u, v, w
 
    real(dp) :: t_start, t_end
-   integer :: nrank, nproc, ierr, ndevs, devnum
+   integer :: nrank, nproc, ierr
 
    call MPI_Init(ierr)
    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)


### PR DESCRIPTION
There are unused dummy arguments, but they may be required by generic interface, or are not yet implemented.

These variables were found by setting CMAKE_Compiler_FLAGS to
```
-g -std=f2008 -Wall -Wpedantic -Werror -Wimplicit-interface -Wimplicit-procedure -Wno-unused-dummy-argument
```
in the CMake configuration.

We should aim to do development with (similar) flags to ensure code quality.