### PR TITLE
Add support for scalar product operator

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -33,6 +33,7 @@ module m_base_backend
       procedure(sum_intox), deferred :: sum_yintox
       procedure(sum_intox), deferred :: sum_zintox
       procedure(vecadd), deferred :: vecadd
+      procedure(scalar_product), deferred :: scalar_product
       procedure(get_fields), deferred :: get_fields
       procedure(set_fields), deferred :: set_fields
       procedure(alloc_tdsops), deferred :: alloc_tdsops
@@ -123,6 +124,20 @@ module m_base_backend
          real(dp), intent(in) :: b
          class(field_t), intent(inout) :: y
       end subroutine vecadd
+   end interface
+
+   abstract interface
+      subroutine scalar_product(self, s, x, y)
+         !! Calculates the scalar product of two input fields
+         import :: base_backend_t
+         import :: dp
+         import :: field_t
+         implicit none
+
+         class(base_backend_t) :: self
+         real(dp), intent(out) :: s
+         class(field_t), intent(in) :: x, y
+      end subroutine scalar_product
    end interface
 
    abstract interface

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -34,8 +34,8 @@ module m_base_backend
       procedure(sum_intox), deferred :: sum_zintox
       procedure(vecadd), deferred :: vecadd
       procedure(scalar_product), deferred :: scalar_product
-      procedure(get_fields), deferred :: get_fields
-      procedure(set_fields), deferred :: set_fields
+      procedure(get_field), deferred :: get_field
+      procedure(set_field), deferred :: set_field
       procedure(alloc_tdsops), deferred :: alloc_tdsops
    end type base_backend_t
 
@@ -141,7 +141,7 @@ module m_base_backend
    end interface
 
    abstract interface
-      subroutine get_fields(self, u_out, v_out, w_out, u, v, w)
+      subroutine get_field(self, arr, f)
          !! copy the specialist data structure from device or host back
          !! to a regular 3D data structure.
          import :: base_backend_t
@@ -150,13 +150,13 @@ module m_base_backend
          implicit none
 
          class(base_backend_t) :: self
-         real(dp), dimension(:, :, :), intent(out) :: u_out, v_out, w_out
-         class(field_t), intent(in) :: u, v, w
-      end subroutine get_fields
+         real(dp), dimension(:, :, :), intent(out) :: arr
+         class(field_t), intent(in) :: f
+      end subroutine get_field
 
-      subroutine set_fields(self, u, v, w, u_in, v_in, w_in)
+      subroutine set_field(self, f, arr)
          !! copy the initial condition stored in a regular 3D data
-         !! structure into the specialist data structure arrays on the
+         !! structure into the specialist data structure array on the
          !! device or host.
          import :: base_backend_t
          import :: dp
@@ -164,9 +164,9 @@ module m_base_backend
          implicit none
 
          class(base_backend_t) :: self
-         class(field_t), intent(inout) :: u, v, w
-         real(dp), dimension(:, :, :), intent(in) :: u_in, v_in, w_in
-      end subroutine set_fields
+         class(field_t), intent(inout) :: f
+         real(dp), dimension(:, :, :), intent(in) :: arr
+      end subroutine set_field
    end interface
 
    abstract interface

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -127,7 +127,7 @@ module m_base_backend
    end interface
 
    abstract interface
-      subroutine scalar_product(self, s, x, y)
+      real(dp) function scalar_product(self, x, y) result(s)
          !! Calculates the scalar product of two input fields
          import :: base_backend_t
          import :: dp
@@ -135,9 +135,8 @@ module m_base_backend
          implicit none
 
          class(base_backend_t) :: self
-         real(dp), intent(out) :: s
          class(field_t), intent(in) :: x, y
-      end subroutine scalar_product
+      end function scalar_product
    end interface
 
    abstract interface

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -41,6 +41,7 @@ module m_cuda_backend
       procedure :: sum_yintox => sum_yintox_cuda
       procedure :: sum_zintox => sum_zintox_cuda
       procedure :: vecadd => vecadd_cuda
+      procedure :: scalar_product => scalar_product_cuda
       procedure :: set_fields => set_fields_cuda
       procedure :: get_fields => get_fields_cuda
       procedure :: transeq_cuda_dist
@@ -528,6 +529,15 @@ module m_cuda_backend
       call axpby<<<blocks, threads>>>(nx, a, x_d, b, y_d)
 
    end subroutine vecadd_cuda
+
+   subroutine scalar_product_cuda(self, s, x, y)
+      implicit none
+
+      class(cuda_backend_t) :: self
+      real(dp), intent(out) :: s
+      class(field_t), intent(in) :: x, y
+
+   end subroutine scalar_product_cuda
 
    subroutine copy_into_buffers(u_send_s_dev, u_send_e_dev, u_dev, n)
       implicit none

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -42,8 +42,8 @@ module m_cuda_backend
       procedure :: sum_zintox => sum_zintox_cuda
       procedure :: vecadd => vecadd_cuda
       procedure :: scalar_product => scalar_product_cuda
-      procedure :: set_fields => set_fields_cuda
-      procedure :: get_fields => get_fields_cuda
+      procedure :: set_field => set_field_cuda
+      procedure :: get_field => get_field_cuda
       procedure :: transeq_cuda_dist
       procedure :: transeq_cuda_thom
       procedure :: tds_solve_dist
@@ -575,31 +575,27 @@ module m_cuda_backend
 
    end subroutine copy_into_buffers
 
-   subroutine set_fields_cuda(self, u, v, w, u_in, v_in, w_in)
+   subroutine set_field_cuda(self, f, arr)
       implicit none
 
       class(cuda_backend_t) :: self
-      class(field_t), intent(inout) :: u, v, w
-      real(dp), dimension(:, :, :), intent(in) :: u_in, v_in, w_in
+      class(field_t), intent(inout) :: f
+      real(dp), dimension(:, :, :), intent(in) :: arr
 
-      select type(u); type is (cuda_field_t); u%data_d = u_in; end select
-      select type(v); type is (cuda_field_t); v%data_d = v_in; end select
-      select type(w); type is (cuda_field_t); w%data_d = w_in; end select
+      select type(f); type is (cuda_field_t); f%data_d = arr; end select
 
-   end subroutine set_fields_cuda
+   end subroutine set_field_cuda
 
-   subroutine get_fields_cuda(self, u_out, v_out, w_out, u, v, w)
+   subroutine get_field_cuda(self, arr, f)
       implicit none
 
       class(cuda_backend_t) :: self
-      real(dp), dimension(:, :, :), intent(out) :: u_out, v_out, w_out
-      class(field_t), intent(in) :: u, v, w
+      real(dp), dimension(:, :, :), intent(out) :: arr
+      class(field_t), intent(in) :: f
 
-      select type(u); type is (cuda_field_t); u_out = u%data_d; end select
-      select type(v); type is (cuda_field_t); v_out = v%data_d; end select
-      select type(w); type is (cuda_field_t); w_out = w%data_d; end select
+      select type(f); type is (cuda_field_t); arr = f%data_d; end select
 
-   end subroutine get_fields_cuda
+   end subroutine get_field_cuda
 
 end module m_cuda_backend
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -530,11 +530,10 @@ module m_cuda_backend
 
    end subroutine vecadd_cuda
 
-   subroutine scalar_product_cuda(self, s, x, y)
+   real(dp) function scalar_product_cuda(self, x, y) result(s)
       implicit none
 
       class(cuda_backend_t) :: self
-      real(dp), intent(out) :: s
       class(field_t), intent(in) :: x, y
 
       real(dp), device, pointer, dimension(:, :, :) :: x_d, y_d
@@ -555,7 +554,7 @@ module m_cuda_backend
 
       s = sum_d
 
-   end subroutine scalar_product_cuda
+   end function scalar_product_cuda
 
    subroutine copy_into_buffers(u_send_s_dev, u_send_e_dev, u_dev, n)
       implicit none

--- a/src/cuda/kernels/reorder.f90
+++ b/src/cuda/kernels/reorder.f90
@@ -199,6 +199,27 @@ contains
 
    end subroutine axpby
 
+   attributes(global) subroutine scalar_product(s, x, y, n)
+      implicit none
+
+      real(dp), device, intent(inout) :: s
+      real(dp), device, intent(in), dimension(:, :, :) :: x, y
+      integer, value, intent(in) :: n
+
+      real(dp) :: s_pncl !! pencil sum
+      integer :: i, j, b, ierr
+
+      i = threadIdx%x
+      b = blockIdx%x
+
+      s_pncl = 0._dp
+      do j = 1, n
+         s_pncl = s_pncl + x(i, j, b)*y(i, j, b)
+      end do
+      ierr = atomicadd(s, s_pncl)
+
+   end subroutine scalar_product
+
    attributes(global) subroutine buffer_copy(u_send_s, u_send_e, u, n, n_halo)
       implicit none
 

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -31,8 +31,8 @@ module m_omp_backend
       procedure :: sum_zintox => sum_zintox_omp
       procedure :: vecadd => vecadd_omp
       procedure :: scalar_product => scalar_product_omp
-      procedure :: set_fields => set_fields_omp
-      procedure :: get_fields => get_fields_omp
+      procedure :: set_field => set_field_omp
+      procedure :: get_field => get_field_omp
       procedure :: transeq_omp_dist
    end type omp_backend_t
 
@@ -339,31 +339,27 @@ module m_omp_backend
 
    end subroutine copy_into_buffers
 
-   subroutine set_fields_omp(self, u, v, w, u_in, v_in, w_in)
+   subroutine set_field_omp(self, f, arr)
       implicit none
 
       class(omp_backend_t) :: self
-      class(field_t), intent(inout) :: u, v, w
-      real(dp), dimension(:, :, :), intent(in) :: u_in, v_in, w_in
+      class(field_t), intent(inout) :: f
+      real(dp), dimension(:, :, :), intent(in) :: arr
 
-      u%data = u_in
-      v%data = v_in
-      w%data = w_in
+      f%data = arr
 
-   end subroutine set_fields_omp
+   end subroutine set_field_omp
 
-   subroutine get_fields_omp(self, u_out, v_out, w_out, u, v, w)
+   subroutine get_field_omp(self, arr, f)
       implicit none
 
       class(omp_backend_t) :: self
-      real(dp), dimension(:, :, :), intent(out) :: u_out, v_out, w_out
-      class(field_t), intent(in) :: u, v, w
+      real(dp), dimension(:, :, :), intent(out) :: arr
+      class(field_t), intent(in) :: f
 
-      u_out = u%data
-      v_out = v%data
-      w_out = w%data
+      arr = f%data
 
-   end subroutine get_fields_omp
+   end subroutine get_field_omp
 
 end module m_omp_backend
 

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -305,14 +305,15 @@ module m_omp_backend
 
    end subroutine vecadd_omp
 
-   subroutine scalar_product_omp(self, s, x, y)
+   real(dp) function scalar_product_omp(self, x, y) result(s)
       implicit none
 
       class(omp_backend_t) :: self
-      real(dp), intent(out) :: s
       class(field_t), intent(in) :: x, y
 
-   end subroutine scalar_product_omp
+      s = 0._dp
+
+   end function scalar_product_omp
 
    subroutine copy_into_buffers(u_send_s, u_send_e, u, n, n_blocks)
       implicit none

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -30,6 +30,7 @@ module m_omp_backend
       procedure :: sum_yintox => sum_yintox_omp
       procedure :: sum_zintox => sum_zintox_omp
       procedure :: vecadd => vecadd_omp
+      procedure :: scalar_product => scalar_product_omp
       procedure :: set_fields => set_fields_omp
       procedure :: get_fields => get_fields_omp
       procedure :: transeq_omp_dist
@@ -303,6 +304,15 @@ module m_omp_backend
       class(field_t), intent(inout) :: y
 
    end subroutine vecadd_omp
+
+   subroutine scalar_product_omp(self, s, x, y)
+      implicit none
+
+      class(omp_backend_t) :: self
+      real(dp), intent(out) :: s
+      class(field_t), intent(in) :: x, y
+
+   end subroutine scalar_product_omp
 
    subroutine copy_into_buffers(u_send_s, u_send_e, u, n, n_blocks)
       implicit none

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -93,9 +93,9 @@ contains
       v_init = 0
       w_init = 0
 
-      call solver%backend%set_fields( &
-         solver%u, solver%v, solver%w, u_init, v_init, w_init &
-      )
+      call solver%backend%set_field(solver%u, u_init)
+      call solver%backend%set_field(solver%v, v_init)
+      call solver%backend%set_field(solver%w, w_init)
 
       deallocate(u_init, v_init, w_init)
       print*, 'initial conditions are set'
@@ -548,9 +548,9 @@ contains
 
       print*, 'run end'
 
-      call self%backend%get_fields( &
-         u_out, v_out, w_out, self%u, self%v, self%w &
-      )
+      call self%backend%get_field(u_out, self%u)
+      call self%backend%get_field(v_out, self%v)
+      call self%backend%get_field(w_out, self%w)
 
    end subroutine run
 


### PR DESCRIPTION
We need a scalar product operator for calculating the enstrophy in the domain. The CUDA kernel can be implemented in a more performant way, there are lots of examples out there, but the current implementation is not bad. We only need to run this once in maybe 100/1000 iterations for post-processing so not worried too much.