### PR TITLE
Refactor `transeq_cuda_dist`

### DIFF
--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -87,7 +87,8 @@ module m_cuda_backend
       backend%nz_loc = globs%nz_loc
 
       n_halo = 4
-      n_block = globs%n_groups_x
+      ! Buffer size should be big enough for the largest MPI exchange.
+      n_block = max(globs%n_groups_x, globs%n_groups_y, globs%n_groups_z)
 
       allocate(backend%u_send_s_dev(SZ, n_halo, n_block))
       allocate(backend%u_send_e_dev(SZ, n_halo, n_block))

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -276,6 +276,9 @@ module m_cuda_backend
                                      conv_recv_s_dev, conv_recv_e_dev, &
                                      tdsops_du, tdsops_dud, tdsops_d2u, &
                                      dirps, blocks, threads)
+      !! Computes RHS_x^u following:
+      !!
+      !! rhs_x^u = -0.5*(conv*du/dx + d(u*conv)/dx) + nu*d2u/dx2
       class(cuda_backend_t) :: self
       real(dp), device, dimension(:, :, :), intent(inout) :: rhs_dev
       real(dp), device, dimension(:, :, :), intent(in) :: u_dev, conv_dev

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -286,19 +286,19 @@ module m_cuda_backend
       type(dirps_t), intent(in) :: dirps
       type(dim3), intent(in) :: blocks, threads
 
-      class(field_t), pointer :: temp_du, temp_dud, temp_d2u
+      class(field_t), pointer :: du, dud, d2u
 
       real(dp), device, pointer, dimension(:, :, :) :: &
          du_dev, dud_dev, d2u_dev
 
       ! Get some fields for storing the intermediate results
-      temp_du => self%allocator%get_block()
-      temp_dud => self%allocator%get_block()
-      temp_d2u => self%allocator%get_block()
+      du => self%allocator%get_block()
+      dud => self%allocator%get_block()
+      d2u => self%allocator%get_block()
 
-      call resolve_field_t(du_dev, temp_du)
-      call resolve_field_t(dud_dev, temp_dud)
-      call resolve_field_t(d2u_dev, temp_d2u)
+      call resolve_field_t(du_dev, du)
+      call resolve_field_t(dud_dev, dud)
+      call resolve_field_t(d2u_dev, d2u)
 
       call exec_dist_transeq_3fused( &
          rhs_dev, &
@@ -317,9 +317,9 @@ module m_cuda_backend
          )
 
       ! Release temporary blocks
-      call self%allocator%release_block(temp_du)
-      call self%allocator%release_block(temp_dud)
-      call self%allocator%release_block(temp_d2u)
+      call self%allocator%release_block(du)
+      call self%allocator%release_block(dud)
+      call self%allocator%release_block(d2u)
 
    end subroutine transeq_dist_component
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -23,6 +23,8 @@ module m_cuda_backend
 
    implicit none
 
+   private :: transeq_halo_exchange, transeq_dist_component
+
    type, extends(base_backend_t) :: cuda_backend_t
       !character(len=*), parameter :: name = 'cuda'
       integer :: MPI_FP_PREC = dp

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -246,7 +246,7 @@ module m_cuda_backend
          self%u_send_s_dev, self%u_send_e_dev, &
          self%v_send_s_dev, self%v_send_e_dev, &
          self%w_send_s_dev, self%w_send_e_dev, &
-         SZ*4*blocks%x, dirps%nproc, dirps%pprev, dirps%pnext &
+         SZ*4*dirps%n_blocks, dirps%nproc, dirps%pprev, dirps%pnext &
       )
 
       ! get some fields for storing the result
@@ -413,7 +413,7 @@ module m_cuda_backend
 
       call sendrecv_fields(self%u_recv_s_dev, self%u_recv_e_dev, &
                            self%u_send_s_dev, self%u_send_e_dev, &
-                           SZ*4*blocks%x, dirps%nproc, &
+                           SZ*4*dirps%n_blocks, dirps%nproc, &
                            dirps%pprev, dirps%pnext)
 
       ! call exec_dist

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -11,6 +11,8 @@ module m_omp_backend
 
    implicit none
 
+   private :: transeq_halo_exchange, transeq_dist_component
+
    type, extends(base_backend_t) :: omp_backend_t
       !character(len=*), parameter :: name = 'omp'
       integer :: MPI_FP_PREC = dp

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -165,11 +165,20 @@ module m_omp_backend
       call transeq_halo_exchange(self, u, v, w, dirps)
 
       call transeq_dist_component(self, du, u, u, &
-            dirps%der1st, dirps%der1st_sym, dirps%der2nd, dirps)
+                                  self%u_recv_s, self%u_recv_e, &
+                                  self%u_recv_s, self%u_recv_e, &
+                                  dirps%der1st, dirps%der1st_sym, &
+                                  dirps%der2nd, dirps)
       call transeq_dist_component(self, dv, v, u, &
-            dirps%der1st_sym, dirps%der1st, dirps%der2nd_sym, dirps)
+                                  self%v_recv_s, self%v_recv_e, &
+                                  self%u_recv_s, self%u_recv_e, &
+                                  dirps%der1st_sym, dirps%der1st, &
+                                  dirps%der2nd_sym, dirps)
       call transeq_dist_component(self, dw, w, u, &
-            dirps%der1st_sym, dirps%der1st, dirps%der2nd_sym, dirps)
+                                  self%w_recv_s, self%w_recv_e, &
+                                  self%u_recv_s, self%u_recv_e, &
+                                  dirps%der1st_sym, dirps%der1st, &
+                                  dirps%der2nd_sym, dirps)
 
    end subroutine transeq_omp_dist
 
@@ -196,13 +205,18 @@ module m_omp_backend
 
    end subroutine transeq_halo_exchange
 
-   !> Computes RHS_x^v following:
-   ! rhs_x^v = -0.5*(u*dv/dx + duv/dx) + nu*d2v/dx2
-   subroutine transeq_dist_component(self, rhs, v, u, tdsops_du, tdsops_dud, tdsops_d2u, dirps)
-
+   subroutine transeq_dist_component(self, rhs, u, conv, &
+                                     u_recv_s, u_recv_e, &
+                                     conv_recv_s, conv_recv_e, &
+                                     tdsops_du, tdsops_dud, tdsops_d2u, dirps)
+      !! Computes RHS_x^u following:
+      !!
+      !! rhs_x^u = -0.5*(conv*du/dx + d(u*conv)/dx) + nu*d2u/dx2
       class(omp_backend_t) :: self
       class(field_t), intent(inout) :: rhs
-      class(field_t), intent(in) :: u, v
+      class(field_t), intent(in) :: u, conv
+      real(dp), dimension(:, :, :), intent(in) :: u_recv_s, u_recv_e, &
+                                                  conv_recv_s, conv_recv_e
       class(tdsops_t), intent(in) :: tdsops_du
       class(tdsops_t), intent(in) :: tdsops_dud
       class(tdsops_t), intent(in) :: tdsops_d2u
@@ -218,8 +232,8 @@ module m_omp_backend
          self%du_send_s,  self%du_send_e,  self%du_recv_s,  self%du_recv_e, &
          self%dud_send_s, self%dud_send_e, self%dud_recv_s, self%dud_recv_e, &
          self%d2u_send_s, self%d2u_send_e, self%d2u_recv_s, self%d2u_recv_e, &
-         u%data, self%u_recv_s, self%u_recv_e, &
-         v%data, self%v_recv_s, self%v_recv_e, &
+         u%data, u_recv_s, u_recv_e, &
+         conv%data, conv_recv_s, conv_recv_e, &
          tdsops_du, tdsops_dud, tdsops_d2u, self%nu, &
          dirps%nproc, dirps%pprev, dirps%pnext, dirps%n_blocks)
 

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -121,7 +121,11 @@ program test_omp_transeq
    allocate(r_u(SZ, n, n_block))
 
    ! check error
-   r_u = dv%data - (-v%data*v%data + 0.5_dp*u%data*u%data - nu*u%data)
+   ! dv = -1/2*(u*dv/dx + d(u*v)/dx) + nu*d2v/dx2
+   ! u is sin, v is cos;
+   ! dv = -1/2*(u*(-u) + v*v + u*(-u)) + nu*(-v)
+   !    = u*u - 1/2*v*v - nu*v
+   r_u = dv%data - (u%data*u%data - 0.5_dp*v%data*v%data - nu*v%data)
    norm_du = norm2(r_u)
    norm_du = norm_du*norm_du/n_glob/n_block/SZ
    call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_DOUBLE_PRECISION, &


### PR DESCRIPTION
The PR Just simplifies the way we carry out the transeq. @Nanoseb implemented exactly in this way on the OpenMP backend which is better and I'm just following it.

The important part for the OpenMP backend is that there is actually a minor bug. I realised this only after running the TGV case on the CUDA backend, its a very subtle bug, and did the fix on the CUDA backend so that TGV works fine now.

Here is the problem. The `transeq_dist_component` simplifies the way we pass `u`, `v`, and `w` fields in different orders to correctly evaluate all the derivatives. But just in the line below, the halo components of the `u`, `v`, and `w` fields are not passed down to the `transeq_dist_component`, instead assumed that they're always `u` and `v`.
https://github.com/xcompact3d/x3d2/blob/e916fe8ff835aae420193a2b3b3a1474dafc5038/src/omp/backend.f90#L221-L222

So, I'm happy to fix this quickly on the OpenMP backend as well, if you're happy with this @Nanoseb. Or if you anticipate a merge conflict due to the PR you're working on or want to fix this later its completely fine, I'll leave it as is.