### PR TITLE
Add reorder kernels for switching from/to Cartesian ordering

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -206,12 +206,14 @@ module m_base_backend
 contains
 
    subroutine get_field_data(self, data, f, dir)
+   !! Extract data from field `f` optionally reordering into `dir` orientation.
+   !! To output in same orientation as `f`, use `call ...%get_field_data(data, f, f%dir)`
       implicit none
 
       class(base_backend_t) :: self
-      real(dp), dimension(:, :, :), intent(out) :: data
-      class(field_t), intent(in) :: f
-      integer, optional, intent(in) :: dir
+      real(dp), dimension(:, :, :), intent(out) :: data !! Output array
+      class(field_t), intent(in) :: f !! Field
+      integer, optional, intent(in) :: dir !! Desired orientation of output array (defaults to Cartesian)
 
       class(field_t), pointer :: f_temp
       integer :: direction, rdr_dir
@@ -241,9 +243,9 @@ contains
       implicit none
 
       class(base_backend_t) :: self
-      class(field_t), intent(inout) :: f
-      real(dp), dimension(:, :, :), intent(in) :: data
-      integer, optional, intent(in) :: dir
+      class(field_t), intent(inout) :: f !! Field
+      real(dp), dimension(:, :, :), intent(in) :: data !! Input array
+      integer, optional, intent(in) :: dir !! Orientation of input array (defaults to Cartesian)
 
       class(field_t), pointer :: f_temp
       integer :: direction, rdr_dir

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -1,6 +1,6 @@
 module m_base_backend
    use m_allocator, only: allocator_t, field_t
-   use m_common, only: dp
+   use m_common, only: dp, DIR_C, get_rdr_from_dirs
    use m_poisson_fft, only: poisson_fft_t
    use m_tdsops, only: tdsops_t, dirps_t
 
@@ -36,10 +36,12 @@ module m_base_backend
       procedure(sum_intox), deferred :: sum_zintox
       procedure(vecadd), deferred :: vecadd
       procedure(scalar_product), deferred :: scalar_product
-      procedure(get_field), deferred :: get_field
-      procedure(set_field), deferred :: set_field
+      procedure(copy_data_to_f), deferred :: copy_data_to_f
+      procedure(copy_f_to_data), deferred :: copy_f_to_data
       procedure(alloc_tdsops), deferred :: alloc_tdsops
       procedure(init_poisson_fft), deferred :: init_poisson_fft
+      procedure :: get_field_data
+      procedure :: set_field_data
    end type base_backend_t
 
    abstract interface
@@ -143,32 +145,31 @@ module m_base_backend
    end interface
 
    abstract interface
-      subroutine get_field(self, arr, f)
-         !! copy the specialist data structure from device or host back
-         !! to a regular 3D data structure.
+      subroutine copy_data_to_f(self, f, data)
+         !! Copy the specialist data structure from device or host back
+         !! to a regular 3D data array in host memory.
          import :: base_backend_t
          import :: dp
          import :: field_t
          implicit none
 
-         class(base_backend_t) :: self
-         real(dp), dimension(:, :, :), intent(out) :: arr
-         class(field_t), intent(in) :: f
-      end subroutine get_field
-
-      subroutine set_field(self, f, arr)
-         !! copy the initial condition stored in a regular 3D data
-         !! structure into the specialist data structure array on the
-         !! device or host.
-         import :: base_backend_t
-         import :: dp
-         import :: field_t
-         implicit none
-
-         class(base_backend_t) :: self
+         class(base_backend_t), intent(inout) :: self
          class(field_t), intent(inout) :: f
-         real(dp), dimension(:, :, :), intent(in) :: arr
-      end subroutine set_field
+         real(dp), dimension(:, :, :), intent(in) :: data
+      end subroutine copy_data_to_f
+
+      subroutine copy_f_to_data(self, data, f)
+         !! Copy a regular 3D array in host memory into the specialist
+         !! data structure field that lives on device or host
+         import :: base_backend_t
+         import :: dp
+         import :: field_t
+         implicit none
+
+         class(base_backend_t), intent(inout) :: self
+         real(dp), dimension(:, :, :), intent(out) :: data
+         class(field_t), intent(in) :: f
+      end subroutine copy_f_to_data
    end interface
 
    abstract interface
@@ -201,5 +202,71 @@ module m_base_backend
          type(dirps_t), intent(in) :: xdirps, ydirps, zdirps
       end subroutine init_poisson_fft
    end interface
+
+contains
+
+   subroutine get_field_data(self, data, f, dir)
+      implicit none
+
+      class(base_backend_t) :: self
+      real(dp), dimension(:, :, :), intent(out) :: data
+      class(field_t), intent(in) :: f
+      integer, optional, intent(in) :: dir
+
+      class(field_t), pointer :: f_temp
+      integer :: direction, rdr_dir
+
+      if (present(dir)) then
+         direction = dir
+      else
+         direction = DIR_C
+      end if
+
+      ! Returns 0 if no reorder required
+      rdr_dir = get_rdr_from_dirs(direction, f%dir)
+
+      ! Carry out a reorder if we need, and copy from field to data array
+      if (rdr_dir /= 0) then
+         f_temp => self%allocator%get_block(direction)
+         call self%reorder(f_temp, f, rdr_dir)
+         call self%copy_f_to_data(data, f_temp)
+         call self%allocator%release_block(f_temp)
+      else
+         call self%copy_f_to_data(data, f)
+      end if
+
+   end subroutine get_field_data
+
+   subroutine set_field_data(self, f, data, dir)
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(inout) :: f
+      real(dp), dimension(:, :, :), intent(in) :: data
+      integer, optional, intent(in) :: dir
+
+      class(field_t), pointer :: f_temp
+      integer :: direction, rdr_dir
+
+      if (present(dir)) then
+         direction = dir
+      else
+         direction = DIR_C
+      end if
+
+      ! Returns 0 if no reorder required
+      rdr_dir = get_rdr_from_dirs(f%dir, direction)
+
+      ! Carry out a reorder if we need, and copy from data array to field
+      if (rdr_dir /= 0) then
+         f_temp => self%allocator%get_block(direction)
+         call self%copy_data_to_f(f_temp, data)
+         call self%reorder(f, f_temp, rdr_dir)
+         call self%allocator%release_block(f_temp)
+      else
+         call self%copy_data_to_f(f, data)
+      end if
+
+   end subroutine set_field_data
 
 end module m_base_backend

--- a/src/common.f90
+++ b/src/common.f90
@@ -11,6 +11,12 @@ module m_common
    integer, parameter :: DIR_X = 1, DIR_Y = 2, DIR_Z = 3, DIR_C = 4
    integer, parameter :: POISSON_SOLVER_FFT = 0, POISSON_SOLVER_CG = 1
 
+   integer, protected :: &
+      rdr_map(4, 4) = reshape([0, RDR_X2Y, RDR_X2Z, RDR_X2C, &
+                               RDR_Y2X, 0, RDR_Y2Z, RDR_Y2C, &
+                               RDR_Z2X, RDR_Z2Y, 0, RDR_Z2C, &
+                               RDR_C2X, RDR_C2Y, RDR_C2Z, 0], shape=[4, 4])
+
    type :: globs_t
       integer :: nx, ny, nz
       integer :: nx_loc, ny_loc, nz_loc
@@ -80,5 +86,12 @@ contains
       end if
 
    end subroutine set_pprev_pnext
+
+   integer function get_rdr_from_dirs(dir_from, dir_to) result(rdr_dir)
+      !! Returns RDR_?2? value based on two direction inputs
+      integer, intent(in) :: dir_from, dir_to
+
+      rdr_dir = rdr_map(dir_from, dir_to)
+   end function get_rdr_from_dirs
 
 end module m_common

--- a/src/common.f90
+++ b/src/common.f90
@@ -6,7 +6,8 @@ module m_common
 
    integer, parameter :: RDR_X2Y = 12, RDR_X2Z = 13, RDR_Y2X = 21, &
                          RDR_Y2Z = 23, RDR_Z2X = 31, RDR_Z2Y = 32, &
-                         RDR_C2X = 41, RDR_X2C = 14
+                         RDR_C2X = 41, RDR_C2Y = 42, RDR_C2Z = 43, &
+                         RDR_X2C = 14, RDR_Y2C = 24, RDR_Z2C = 34
    integer, parameter :: DIR_X = 1, DIR_Y = 2, DIR_Z = 3, DIR_C = 4
    integer, parameter :: POISSON_SOLVER_FFT = 0, POISSON_SOLVER_CG = 1
 

--- a/src/common.f90
+++ b/src/common.f90
@@ -5,7 +5,8 @@ module m_common
    real(dp), parameter :: pi = 4*atan(1.0_dp)
 
    integer, parameter :: RDR_X2Y = 12, RDR_X2Z = 13, RDR_Y2X = 21, &
-                         RDR_Y2Z = 23, RDR_Z2X = 31, RDR_Z2Y = 32
+                         RDR_Y2Z = 23, RDR_Z2X = 31, RDR_Z2Y = 32, &
+                         RDR_C2X = 41, RDR_X2C = 14
    integer, parameter :: DIR_X = 1, DIR_Y = 2, DIR_Z = 3, DIR_C = 4
    integer, parameter :: POISSON_SOLVER_FFT = 0, POISSON_SOLVER_CG = 1
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -50,8 +50,8 @@ module m_cuda_backend
       procedure :: sum_zintox => sum_zintox_cuda
       procedure :: vecadd => vecadd_cuda
       procedure :: scalar_product => scalar_product_cuda
-      procedure :: set_field => set_field_cuda
-      procedure :: get_field => get_field_cuda
+      procedure :: copy_data_to_f => copy_data_to_f_cuda
+      procedure :: copy_f_to_data => copy_f_to_data_cuda
       procedure :: init_poisson_fft => init_cuda_poisson_fft
       procedure :: transeq_cuda_dist
       procedure :: transeq_cuda_thom
@@ -630,27 +630,21 @@ module m_cuda_backend
 
    end subroutine copy_into_buffers
 
-   subroutine set_field_cuda(self, f, arr)
-      implicit none
-
-      class(cuda_backend_t) :: self
+   subroutine copy_data_to_f_cuda(self, f, data)
+      class(cuda_backend_t), intent(inout) :: self
       class(field_t), intent(inout) :: f
-      real(dp), dimension(:, :, :), intent(in) :: arr
+      real(dp), dimension(:, :, :), intent(inout) :: data
 
-      select type(f); type is (cuda_field_t); f%data_d = arr; end select
+      select type(f); type is (cuda_field_t); f%data_d = data; end select
+   end subroutine copy_data_to_f_cuda
 
-   end subroutine set_field_cuda
-
-   subroutine get_field_cuda(self, arr, f)
-      implicit none
-
-      class(cuda_backend_t) :: self
-      real(dp), dimension(:, :, :), intent(out) :: arr
+   subroutine copy_f_to_data_cuda(self, data, f)
+      class(cuda_backend_t), intent(inout) :: self
+      real(dp), dimension(:, :, :), intent(out) :: data
       class(field_t), intent(in) :: f
 
-      select type(f); type is (cuda_field_t); arr = f%data_d; end select
-
-   end subroutine get_field_cuda
+      select type(f); type is (cuda_field_t); data = f%data_d; end select
+   end subroutine copy_f_to_data_cuda
 
    subroutine init_cuda_poisson_fft(self, xdirps, ydirps, zdirps)
       implicit none

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -6,7 +6,8 @@ module m_cuda_backend
    use m_allocator, only: allocator_t, field_t
    use m_base_backend, only: base_backend_t
    use m_common, only: dp, globs_t, &
-                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y
+                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
+                       RDR_C2X, RDR_X2C
    use m_poisson_fft, only: poisson_fft_t
    use m_tdsops, only: dirps_t, tdsops_t
 
@@ -450,6 +451,14 @@ module m_cuda_backend
          threads = dim3(SZ, SZ, 1)
          call reorder_z2y<<<blocks, threads>>>(u_o_d, u_i_d, &
                                                self%nx_loc, self%nz_loc)
+      case (RDR_C2X) ! c2x
+         blocks = dim3(self%nx_loc/SZ, self%ny_loc/SZ, self%nz_loc)
+         threads = dim3(SZ, SZ, 1)
+         call reorder_c2x<<<blocks, threads>>>(u_o_d, u_i_d, self%nz_loc)
+      case (RDR_X2C) ! x2c
+         blocks = dim3(self%nx_loc/SZ, self%ny_loc/SZ, self%nz_loc)
+         threads = dim3(SZ, SZ, 1)
+         call reorder_x2c<<<blocks, threads>>>(u_o_d, u_i_d, self%nz_loc)
       case default
          error stop 'Reorder direction is undefined.'
       end select

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -34,8 +34,8 @@ module m_omp_backend
       procedure :: sum_zintox => sum_zintox_omp
       procedure :: vecadd => vecadd_omp
       procedure :: scalar_product => scalar_product_omp
-      procedure :: set_field => set_field_omp
-      procedure :: get_field => get_field_omp
+      procedure :: copy_data_to_f => copy_data_to_f_omp
+      procedure :: copy_f_to_data => copy_f_to_data_omp
       procedure :: init_poisson_fft => init_omp_poisson_fft
       procedure :: transeq_omp_dist
    end type omp_backend_t
@@ -363,27 +363,21 @@ module m_omp_backend
 
    end subroutine copy_into_buffers
 
-   subroutine set_field_omp(self, f, arr)
-      implicit none
-
-      class(omp_backend_t) :: self
+   subroutine copy_data_to_f_omp(self, f, data)
+      class(omp_backend_t), intent(inout) :: self
       class(field_t), intent(inout) :: f
-      real(dp), dimension(:, :, :), intent(in) :: arr
+      real(dp), dimension(:, :, :), intent(in) :: data
 
-      f%data = arr
+      f%data = data
+   end subroutine copy_data_to_f_omp
 
-   end subroutine set_field_omp
-
-   subroutine get_field_omp(self, arr, f)
-      implicit none
-
-      class(omp_backend_t) :: self
-      real(dp), dimension(:, :, :), intent(out) :: arr
+   subroutine copy_f_to_data_omp(self, data, f)
+      class(omp_backend_t), intent(inout) :: self
+      real(dp), dimension(:, :, :), intent(out) :: data
       class(field_t), intent(in) :: f
 
-      arr = f%data
-
-   end subroutine get_field_omp
+      data = f%data
+   end subroutine copy_f_to_data_omp
 
    subroutine init_omp_poisson_fft(self, xdirps, ydirps, zdirps)
       implicit none

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -133,9 +133,9 @@ contains
          end do
       end do
 
-      call solver%backend%set_field(solver%u, u_init)
-      call solver%backend%set_field(solver%v, v_init)
-      call solver%backend%set_field(solver%w, w_init)
+      call solver%backend%set_field_data(solver%u, u_init, 1)
+      call solver%backend%set_field_data(solver%v, v_init, 1)
+      call solver%backend%set_field_data(solver%w, w_init, 1)
 
       deallocate(u_init, v_init, w_init)
       print*, 'initial conditions are set'
@@ -595,7 +595,7 @@ contains
       div_u => self%backend%allocator%get_block(DIR_Z)
 
       call self%divergence_v2p(div_u, self%u, self%v, self%w)
-      call self%backend%get_field(u_out, div_u)
+      call self%backend%get_field_data(u_out, div_u, 3)
 
       call self%backend%allocator%release_block(div_u)
 
@@ -671,9 +671,9 @@ contains
 
       print*, 'run end'
 
-      call self%backend%get_field(u_out, self%u)
-      call self%backend%get_field(v_out, self%v)
-      call self%backend%get_field(w_out, self%w)
+      call self%backend%get_field_data(u_out, self%u, 1)
+      call self%backend%get_field_data(v_out, self%v, 1)
+      call self%backend%get_field_data(w_out, self%w, 1)
 
    end subroutine run
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -589,7 +589,7 @@ contains
       div_u => self%backend%allocator%get_block(DIR_Z)
 
       call self%divergence_v2p(div_u, self%u, self%v, self%w)
-      call self%backend%get_field_data(u_out, div_u, 3)
+      call self%backend%get_field_data(u_out, div_u)
 
       call self%backend%allocator%release_block(div_u)
 
@@ -665,9 +665,9 @@ contains
 
       print*, 'run end'
 
-      call self%backend%get_field_data(u_out, self%u, 1)
-      call self%backend%get_field_data(v_out, self%v, 1)
-      call self%backend%get_field_data(w_out, self%w, 1)
+      call self%backend%get_field_data(u_out, self%u)
+      call self%backend%get_field_data(v_out, self%v)
+      call self%backend%get_field_data(w_out, self%w)
 
    end subroutine run
 

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -41,6 +41,7 @@ program xcompact
    real(dp), allocatable, dimension(:, :, :) :: u, v, w
 
    real(dp) :: t_start, t_end
+   integer :: dims(3)
    integer :: nrank, nproc, ierr
 
    call MPI_Init(ierr)
@@ -132,9 +133,10 @@ program xcompact
    print*, 'OpenMP backend instantiated'
 #endif
 
-   allocate(u(SZ, globs%nx_loc, globs%n_groups_x))
-   allocate(v(SZ, globs%nx_loc, globs%n_groups_x))
-   allocate(w(SZ, globs%nx_loc, globs%n_groups_x))
+   dims(:) = allocator%cdims_padded
+   allocate (u(dims(1), dims(2), dims(3)))
+   allocate (v(dims(1), dims(2), dims(3)))
+   allocate (w(dims(1), dims(2), dims(3)))
 
    time_integrator = time_intg_t(allocator=allocator, backend=backend)
    print*, 'time integrator instantiated'

--- a/tests/cuda/test_cuda_reorder.f90
+++ b/tests/cuda/test_cuda_reorder.f90
@@ -216,6 +216,24 @@ program test_cuda_reorder
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   blocks = dim3(nx/SZ, ny/SZ, nz)
+   threads = dim3(SZ, SZ, 1)
+   call cpu_time(tstart)
+   do i = 1, n_iters
+      call reorder_x2c<<<blocks, threads>>>(u_c_d, u_i_d, nz)
+   end do
+   call cpu_time(tend)
+
+   call checkperf(tend - tstart, n_iters, ndof, 2._dp)
+
+   call cpu_time(tstart)
+   do i = 1, n_iters
+      call reorder_c2x<<<blocks, threads>>>(u_o_d, u_c_d, nz)
+   end do
+   call cpu_time(tend)
+
+   call checkperf(tend - tstart, n_iters, ndof, 2._dp)
+
    if (allpass) then
       if (nrank == 0) write(stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
    else

--- a/tests/cuda/test_cuda_reorder.f90
+++ b/tests/cuda/test_cuda_reorder.f90
@@ -138,66 +138,74 @@ program test_cuda_reorder
    end if
 
    ! Now the performance checks
+
+   print*, 'Performance test: reorder_x2y'
+   blocks = dim3(nx/SZ, nz, ny/SZ)
+   threads = dim3(SZ, SZ, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
-      blocks = dim3(nx/SZ, nz, ny/SZ)
-      threads = dim3(SZ, SZ, 1)
       call reorder_x2y<<<blocks, threads>>>(u_o_d, u_i_d, nz)
    end do
    call cpu_time(tend)
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_x2z'
+   blocks = dim3(nx, ny/SZ, 1)
+   threads = dim3(SZ, 1, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
-      blocks = dim3(nx, ny/SZ, 1)
-      threads = dim3(SZ, 1, 1)
       call reorder_x2z<<<blocks, threads>>>(u_o_d, u_i_d, nz)
    end do
    call cpu_time(tend)
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_y2x'
+   blocks = dim3(nx/SZ, ny/SZ, nz)
+   threads = dim3(SZ, SZ, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
-      blocks = dim3(nx/SZ, ny/SZ, nz)
-      threads = dim3(SZ, SZ, 1)
       call reorder_y2x<<<blocks, threads>>>(u_o_d, u_i_d, nz)
    end do
    call cpu_time(tend)
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_y2z'
+   blocks = dim3(nx/SZ, ny/SZ, nz)
+   threads = dim3(SZ, SZ, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
-      blocks = dim3(nx/SZ, ny/SZ, nz)
-      threads = dim3(SZ, SZ, 1)
       call reorder_y2z<<<blocks, threads>>>(u_o_d, u_i_d, nx, nz)
    end do
    call cpu_time(tend)
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_z2x'
+   blocks = dim3(nx, ny/SZ, 1)
+   threads = dim3(SZ, 1, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
-      blocks = dim3(nx, ny/SZ, 1)
-      threads = dim3(SZ, 1, 1)
       call reorder_z2x<<<blocks, threads>>>(u_o_d, u_i_d, nz)
    end do
    call cpu_time(tend)
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_z2y'
+   blocks = dim3(nx/SZ, ny/SZ, nz)
+   threads = dim3(SZ, SZ, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
-      blocks = dim3(nx/SZ, ny/SZ, nz)
-      threads = dim3(SZ, SZ, 1)
       call reorder_z2y<<<blocks, threads>>>(u_o_d, u_i_d, nx, nz)
    end do
    call cpu_time(tend)
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_x2c'
    blocks = dim3(nx/SZ, ny/SZ, nz)
    threads = dim3(SZ, SZ, 1)
    call cpu_time(tstart)
@@ -208,6 +216,9 @@ program test_cuda_reorder
 
    call checkperf(tend - tstart, n_iters, ndof, 2._dp)
 
+   print*, 'Performance test: reorder_c2x'
+   blocks = dim3(nx/SZ, ny/SZ, nz)
+   threads = dim3(SZ, SZ, 1)
    call cpu_time(tstart)
    do i = 1, n_iters
       call reorder_c2x<<<blocks, threads>>>(u_o_d, u_c_d, nz)


### PR DESCRIPTION
The idea is we interact with outside world always with Cartesian data order.

Backends require a special data structure, but they are capable of converting the specialist data structure into Cartesian and vice versa, so we can and should always input from and output to Cartesian ordered arrays.
We plan to carry out this operation with the `get_field`/`set_field` subroutines in both backends, but as of now they can't carry out the conversion to and from Cartesian yet. Becase in order to switch to and from Cartesian we need to be able to request a Cartesian shape from the allocator, (#34), and the plan is to merge the PR enables this on Monday after finalising some important decisions.

Although this PR doesn't enables the actual functionality we need, it provides all the necessary kernels. I think the best would be merging this before #34, and making the final minor changes in `get_field`/`set_field` in #34.

