### PR TITLE
Add Adams-Bashforth time-integration schemes

### DIFF
--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -383,6 +383,8 @@ contains
     real(dp), intent(in) :: b
     class(field_t), intent(inout) :: y
 
+    y%data = a*x%data + b*y%data ! fixme
+
   end subroutine vecadd_omp
 
   real(dp) function scalar_product_omp(self, x, y) result(s)

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -26,12 +26,13 @@ module m_time_integrator
 
 contains
 
-  function init(backend, allocator, nvars)
+  function init(backend, allocator, order, nvars)
     implicit none
 
     type(time_intg_t) :: init
     class(base_backend_t), pointer :: backend
     class(allocator_t), pointer :: allocator
+    integer, intent(in), optional :: order
     integer, intent(in), optional :: nvars
 
     integer :: i, j
@@ -46,6 +47,12 @@ contains
 
     init%backend => backend
     init%allocator => allocator
+
+    if (present(order)) then
+      init%order = order
+    else
+      init%order = 1
+    end if
 
     if (present(nvars)) then
       init%nvars = nvars
@@ -101,7 +108,6 @@ contains
 
     integer :: i, j
     integer :: order
-    class(field_t), pointer :: ptr
 
     order = min(self%istep, self%order)
     do i = 1, self%nvars

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -8,7 +8,7 @@ module m_time_integrator
   private adams_bashforth
 
   type :: time_intg_t
-    integer :: istep, nsteps, nsubsteps, order, nvars, nolds
+    integer :: istep, order, nvars, nolds
     real(dp) :: coeffs(4, 4)
     type(flist_t), allocatable :: olds(:, :)
     type(flist_t), allocatable :: curr(:)

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -152,7 +152,7 @@ contains
     ! rotate pointer
     ptr => sol(n)%ptr
     do i = n, 2, -1
-      sol(n)%ptr => sol(n - 1)%ptr
+      sol(i)%ptr => sol(i - 1)%ptr
     end do
     sol(1)%ptr => ptr
 

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -134,9 +134,9 @@ contains
       call self%backend%vecadd(-0.5_dp*dt, self%olds(i, 1)%ptr, 1._dp, &
                                self%curr(i)%ptr)
 
-      ! for startup
+      ! rotate pointers
       if (self%istep == 1 .and. self%order > 2) then
-        ! rotate pointers
+        ! for startup
         call rotate(self%olds(i, :), 2)
       end if
 
@@ -163,13 +163,12 @@ contains
       call self%backend%vecadd(5._dp/12._dp*dt, self%olds(i, 2)%ptr, &
                                1._dp, self%curr(i)%ptr)
 
-      ! for startup
+      ! rotate pointers
       if (self%istep == 2 .and. self%order > 3) then
-        ! rotate pointers
+        ! for startup
         call rotate(self%olds(i, :), 3)
-        ! after startup
       else
-        ! rotate pointers
+        ! after startup
         call rotate(self%olds(i, :), 2)
       end if
 
@@ -198,13 +197,12 @@ contains
       call self%backend%vecadd(3._dp/8._dp*dt, self%olds(i, 3)%ptr, &
                                1._dp, self%curr(i)%ptr)
 
-      ! for startup
+      ! rotate pointers
       if (self%istep == 3 .and. self%order > 4) then
-        ! rotate pointers
+        ! for startup
         call rotate(self%olds(i, :), 4)
-        ! after startup
       else
-        ! rotate pointers
+        ! after startup
         call rotate(self%olds(i, :), 3)
       end if
 

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -44,7 +44,7 @@ contains
 
     if (present(nvars)) then
       constructor%nvars = nvars
-    else 
+    else
       constructor%nvars = 3
     end if
 
@@ -88,20 +88,18 @@ contains
 
     order = min(self%istep + 1, self%order)
     select case (order)
-      case(1)
-        call self%adams_bashforth_1st(dt)
-      case(2)
-        call self%adams_bashforth_2nd(dt)
-      case(3)
-         call self%adams_bashforth_3rd(dt)
-      case(4)
-        call self%adams_bashforth_4th(dt)
+    case (1)
+      call self%adams_bashforth_1st(dt)
+    case (2)
+      call self%adams_bashforth_2nd(dt)
+    case (3)
+      call self%adams_bashforth_3rd(dt)
+    case (4)
+      call self%adams_bashforth_4th(dt)
     end select
 
-
     ! increment step counter
-    self%istep = self%istep + 1;
-
+    self%istep = self%istep + 1
   end subroutine step
 
   subroutine adams_bashforth_1st(self, dt)
@@ -114,9 +112,10 @@ contains
       call self%backend%vecadd(dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
 
       ! for startup
-      if (self%istep .eq. 0 .and. self%order .gt. 1) then
+      if (self%istep == 0 .and. self%order > 1) then
         ! update olds(1) with new derivative
-        call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+        call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, &
+                                 self%olds(i, 1)%ptr)
       end if
     end do
 
@@ -130,22 +129,25 @@ contains
     class(field_t), pointer :: ptr
 
     do i = 1, self%nvars
-      call self%backend%vecadd(1.5_dp * dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
-      call self%backend%vecadd(-0.5_dp * dt, self%olds(i,1)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(1.5_dp*dt, self%deriv(i)%ptr, 1._dp, &
+                               self%curr(i)%ptr)
+      call self%backend%vecadd(-0.5_dp*dt, self%olds(i, 1)%ptr, 1._dp, &
+                               self%curr(i)%ptr)
 
       ! for startup
-      if (self%istep .eq. 1 .and. self%order .gt. 2) then
+      if (self%istep == 1 .and. self%order > 2) then
         ! rotate pointers
-        call rotate(self%olds(i,:), 2)
+        call rotate(self%olds(i, :), 2)
       end if
 
       ! update olds(1) with new derivative
-      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, &
+                               self%olds(i, 1)%ptr)
     end do
 
   end subroutine adams_bashforth_2nd
 
-  subroutine adams_bashforth_3rd(self,  dt)
+  subroutine adams_bashforth_3rd(self, dt)
     class(time_intg_t), intent(inout) :: self
     real(dp), intent(in) :: dt
 
@@ -154,22 +156,26 @@ contains
 
     do i = 1, self%nvars
       ! update solution
-      call self%backend%vecadd(23._dp / 12._dp * dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
-      call self%backend%vecadd(-4._dp / 3._dp * dt, self%olds(i,1)%ptr, 1._dp, self%curr(i)%ptr)
-      call self%backend%vecadd(5._dp / 12._dp * dt, self%olds(i,2)%ptr, 1._dp, self%curr(i)%ptr)
-      
+      call self%backend%vecadd(23._dp/12._dp*dt, self%deriv(i)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(-4._dp/3._dp*dt, self%olds(i, 1)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(5._dp/12._dp*dt, self%olds(i, 2)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+
       ! for startup
-      if (self%istep .eq. 2 .and. self%order .gt. 3) then
+      if (self%istep == 2 .and. self%order > 3) then
         ! rotate pointers
-        call rotate(self%olds(i,:), 3)
-      ! after startup
+        call rotate(self%olds(i, :), 3)
+        ! after startup
       else
         ! rotate pointers
-        call rotate(self%olds(i,:), 2)
+        call rotate(self%olds(i, :), 2)
       end if
 
       ! update olds(1) with new derivative
-      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, &
+                               self%olds(i, 1)%ptr)
     end do
 
   end subroutine adams_bashforth_3rd
@@ -183,23 +189,28 @@ contains
 
     do i = 1, self%nvars
       ! update solution
-      call self%backend%vecadd(55._dp / 24._dp * dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
-      call self%backend%vecadd(-59._dp / 24._dp * dt, self%olds(i,1)%ptr, 1._dp, self%curr(i)%ptr)
-      call self%backend%vecadd(37._dp / 24._dp * dt, self%olds(i,2)%ptr, 1._dp, self%curr(i)%ptr)
-      call self%backend%vecadd(3._dp / 8._dp * dt, self%olds(i,3)%ptr, 1._dp, self%curr(i)%ptr)
-      
+      call self%backend%vecadd(55._dp/24._dp*dt, self%deriv(i)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(-59._dp/24._dp*dt, self%olds(i, 1)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(37._dp/24._dp*dt, self%olds(i, 2)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(3._dp/8._dp*dt, self%olds(i, 3)%ptr, &
+                               1._dp, self%curr(i)%ptr)
+
       ! for startup
-      if (self%istep .eq. 3 .and. self%order .gt. 4) then
+      if (self%istep == 3 .and. self%order > 4) then
         ! rotate pointers
-        call rotate(self%olds(i,:), 4)
-      ! after startup
+        call rotate(self%olds(i, :), 4)
+        ! after startup
       else
         ! rotate pointers
-        call rotate(self%olds(i,:), 3)
+        call rotate(self%olds(i, :), 3)
       end if
 
       ! update olds(1) with new derivative
-      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, &
+                               self%olds(i, 1)%ptr)
     end do
 
   end subroutine adams_bashforth_4th
@@ -214,9 +225,9 @@ contains
     ! rotate pointer
     ptr => sol(n)%ptr
     do i = n, 2, -1
-        sol(n)%ptr => sol(n-1)%ptr
+      sol(n)%ptr => sol(n - 1)%ptr
     end do
     sol(1)%ptr => ptr
-   
-   end subroutine rotate
+
+  end subroutine rotate
 end module m_time_integrator

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -5,6 +5,9 @@ module m_time_integrator
 
   implicit none
 
+  private adams_bashforth_1st, adams_bashforth_2nd
+  private adams_bashforth_3rd, adams_bashforth_4th
+
   type :: time_intg_t
     integer :: istep, nsteps, nsubsteps, order, nvars, nolds
     type(flist_t), allocatable :: olds(:, :)
@@ -50,6 +53,8 @@ contains
     constructor%nolds = constructor%order - 1
 
     allocate (constructor%olds(constructor%nvars, constructor%nolds))
+    allocate (constructor%curr(constructor%nvars))
+    allocate (constructor%deriv(constructor%nvars))
 
     ! Request all the storage for old timesteps
     do i = 1, constructor%nvars

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -116,7 +116,7 @@ contains
       end do
 
       ! rotate pointers
-      if (self%order > order) then
+      if (order < self%order) then
         ! for startup
         if (self%istep > 1) then
           call rotate(self%olds(i, :), order)

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -127,7 +127,7 @@ contains
     integer :: i
 
     do i = 1, self%nvars
-      call self%backend%vecadd(dt, self%deriv(1)%ptr, 1._dp, self%curr(1)%ptr)
+      call self%backend%vecadd(dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
 
       ! for startup
       if (self%istep .eq. 0 .and. self%order .gt. 1) then

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -43,7 +43,7 @@ contains
     init%coeffs(:, 3) = &
       [23._dp/12._dp, -4._dp/3._dp, 5._dp/12._dp, 0.0_dp]
     init%coeffs(:, 4) = &
-      [55._dp/24._dp, -59._dp/24._dp, 37._dp/24._dp, 3._dp/8._dp]
+      [55._dp/24._dp, -59._dp/24._dp, 37._dp/24._dp, -3._dp/8._dp]
 
     init%backend => backend
     init%allocator => allocator
@@ -61,7 +61,6 @@ contains
     end if
 
     init%istep = 1
-    init%order = 1
     init%nolds = init%order - 1
 
     allocate (init%olds(init%nvars, init%nolds))

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -151,10 +151,8 @@ contains
 
       ! for startup
       if (self%istep .eq. 1 .and. self%order .gt. 2) then
-        ! roll pointers
-        ptr => self%olds(i,2)%ptr
-        self%olds(i,2)%ptr => self%olds(i,1)%ptr
-        self%olds(i,1)%ptr => ptr
+        ! rotate pointers
+        call rotate(self%olds(i,:), 2)
       end if
 
       ! update olds(1) with new derivative
@@ -178,17 +176,12 @@ contains
       
       ! for startup
       if (self%istep .eq. 2 .and. self%order .gt. 3) then
-        ! roll pointers
-        ptr => self%olds(i,3)%ptr
-        self%olds(i,3)%ptr => self%olds(i,2)%ptr
-        self%olds(i,2)%ptr => self%olds(i,1)%ptr
-        self%olds(i,1)%ptr => ptr
+        ! rotate pointers
+        call rotate(self%olds(i,:), 3)
       ! after startup
       else
-        ! roll pointers
-        ptr => self%olds(i,2)%ptr
-        self%olds(i,2)%ptr => self%olds(i,1)%ptr
-        self%olds(i,1)%ptr => ptr
+        ! rotate pointers
+        call rotate(self%olds(i,:), 2)
       end if
 
       ! update olds(1) with new derivative
@@ -213,19 +206,12 @@ contains
       
       ! for startup
       if (self%istep .eq. 3 .and. self%order .gt. 4) then
-        ! roll pointers
-        ptr => self%olds(i,4)%ptr
-        self%olds(i,4)%ptr => self%olds(i,3)%ptr
-        self%olds(i,3)%ptr => self%olds(i,2)%ptr
-        self%olds(i,2)%ptr => self%olds(i,1)%ptr
-        self%olds(i,1)%ptr => ptr
+        ! rotate pointers
+        call rotate(self%olds(i,:), 4)
       ! after startup
       else
-        ! roll pointers
-        ptr => self%olds(i,3)%ptr
-        self%olds(i,3)%ptr => self%olds(i,2)%ptr
-        self%olds(i,2)%ptr => self%olds(i,1)%ptr
-        self%olds(i,1)%ptr => ptr
+        ! rotate pointers
+        call rotate(self%olds(i,:), 3)
       end if
 
       ! update olds(1) with new derivative
@@ -234,4 +220,19 @@ contains
 
   end subroutine adams_bashforth_4th
 
+  subroutine rotate(sol, n)
+    type(flist_t), intent(inout) :: sol(:)
+    integer, intent(in) :: n
+
+    integer :: i
+    class(field_t), pointer :: ptr
+
+    ! rotate pointer
+    ptr => sol(n)%ptr
+    do i = n, 2, -1
+        sol(n)%ptr => sol(n-1)%ptr
+    end do
+    sol(1)%ptr => ptr
+   
+   end subroutine rotate
 end module m_time_integrator

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -8,10 +8,16 @@ module m_time_integrator
   type :: time_intg_t
     integer :: istep, nsteps, nsubsteps, order, nvars, nolds
     type(flist_t), allocatable :: olds(:, :)
+    type(flist_t), allocatable :: curr(:)
+    type(flist_t), allocatable :: deriv(:)
     class(base_backend_t), pointer :: backend
     class(allocator_t), pointer :: allocator
   contains
     procedure :: step
+    procedure :: adams_bashforth_1st
+    procedure :: adams_bashforth_2nd
+    procedure :: adams_bashforth_3rd
+    procedure :: adams_bashforth_4th
   end type time_intg_t
 
   interface time_intg_t
@@ -35,11 +41,13 @@ contains
 
     if (present(nvars)) then
       constructor%nvars = nvars
-    else
+    else 
       constructor%nvars = 3
     end if
 
-    constructor%nolds = 0
+    constructor%istep = 0
+    constructor%order = 1
+    constructor%nolds = constructor%order - 1
 
     allocate (constructor%olds(constructor%nvars, constructor%nolds))
 
@@ -55,23 +63,175 @@ contains
   subroutine step(self, u, v, w, du, dv, dw, dt)
     implicit none
 
-    class(time_intg_t), intent(in) :: self
-    class(field_t), intent(inout) :: u, v, w
-    class(field_t), intent(in) :: du, dv, dw
+    class(time_intg_t), intent(inout) :: self
+    class(field_t), target, intent(inout) :: u, v, w
+    class(field_t), target, intent(in) :: du, dv, dw
 
     real(dp), intent(in) :: dt
 
-    call self%backend%vecadd(dt, du, 1._dp, u)
-    call self%backend%vecadd(dt, dv, 1._dp, v)
-    call self%backend%vecadd(dt, dw, 1._dp, w)
+    ! assign pointer to variables
+    self%curr(1)%ptr => u
+    self%curr(2)%ptr => v
+    self%curr(3)%ptr => w
+
+    ! assign pointer to variables
+    self%deriv(1)%ptr => du
+    self%deriv(2)%ptr => dv
+    self%deriv(3)%ptr => dw
+
+    ! First-order
+    if (self%order .eq. 1) then
+      call self%adams_bashforth_1st(dt)
+
+    ! Second-order
+    else if (self%order .eq. 2) then
+      if (self%istep .eq. 0) then
+        call self%adams_bashforth_1st(dt)
+      else
+        call self%adams_bashforth_2nd(dt)
+      end if
+
+    ! Third-order
+    else if (self%order .eq. 3) then
+      if (self%istep .eq. 0) then
+        call self%adams_bashforth_1st(dt)
+      else if (self%istep .eq. 1) then
+        call self%adams_bashforth_2nd(dt)
+      else
+         call self%adams_bashforth_3rd(dt)
+      end if
+
+    ! Fourth-order
+    else if (self%order .eq. 4) then
+      if (self%istep .eq. 0) then
+        call self%adams_bashforth_1st(dt)
+      else if (self%istep .eq. 1) then
+        call self%adams_bashforth_2nd(dt)
+      else if (self%istep .eq. 2) then
+        call self%adams_bashforth_3rd(dt)
+      else
+        call self%adams_bashforth_4th(dt)
+      end if
+    end if
+
+
+    ! increment step counter
+    self%istep = self%istep + 1;
 
   end subroutine step
 
-  subroutine adams_bashford_1st(vels, olds, coeffs)
-    type(flist_t) :: vels(:), olds(:)
-    real :: coeffs(:)
+  subroutine adams_bashforth_1st(self, dt)
+    class(time_intg_t), intent(inout) :: self
+    real(dp), intent(in) :: dt
 
-    !call vec_add(vels, olds, coeffs)
-  end subroutine adams_bashford_1st
+    integer :: i
+
+    do i = 1, self%nvars
+      call self%backend%vecadd(dt, self%deriv(1)%ptr, 1._dp, self%curr(1)%ptr)
+
+      ! for startup
+      if (self%istep .eq. 0 .and. self%order .gt. 1) then
+        ! update olds(1) with new derivative
+        call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+      end if
+    end do
+
+  end subroutine adams_bashforth_1st
+
+  subroutine adams_bashforth_2nd(self, dt)
+    class(time_intg_t), intent(inout) :: self
+    real(dp), intent(in) :: dt
+
+    integer :: i
+    class(field_t), pointer :: ptr
+
+    do i = 1, self%nvars
+      call self%backend%vecadd(1.5_dp * dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(-0.5_dp * dt, self%olds(i,1)%ptr, 1._dp, self%curr(i)%ptr)
+
+      ! for startup
+      if (self%istep .eq. 1 .and. self%order .gt. 2) then
+        ! roll pointers
+        ptr => self%olds(i,2)%ptr
+        self%olds(i,2)%ptr => self%olds(i,1)%ptr
+        self%olds(i,1)%ptr => ptr
+      end if
+
+      ! update olds(1) with new derivative
+      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+    end do
+
+  end subroutine adams_bashforth_2nd
+
+  subroutine adams_bashforth_3rd(self,  dt)
+    class(time_intg_t), intent(inout) :: self
+    real(dp), intent(in) :: dt
+
+    integer :: i
+    class(field_t), pointer :: ptr
+
+    do i = 1, self%nvars
+      ! update solution
+      call self%backend%vecadd(23._dp / 12._dp * dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(-4._dp / 3._dp * dt, self%olds(i,1)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(5._dp / 12._dp * dt, self%olds(i,2)%ptr, 1._dp, self%curr(i)%ptr)
+      
+      ! for startup
+      if (self%istep .eq. 2 .and. self%order .gt. 3) then
+        ! roll pointers
+        ptr => self%olds(i,3)%ptr
+        self%olds(i,3)%ptr => self%olds(i,2)%ptr
+        self%olds(i,2)%ptr => self%olds(i,1)%ptr
+        self%olds(i,1)%ptr => ptr
+      ! after startup
+      else
+        ! roll pointers
+        ptr => self%olds(i,2)%ptr
+        self%olds(i,2)%ptr => self%olds(i,1)%ptr
+        self%olds(i,1)%ptr => ptr
+      end if
+
+      ! update olds(1) with new derivative
+      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+    end do
+
+  end subroutine adams_bashforth_3rd
+
+  subroutine adams_bashforth_4th(self, dt)
+    class(time_intg_t), intent(inout) :: self
+    real(dp), intent(in) :: dt
+
+    integer :: i
+    class(field_t), pointer :: ptr
+
+    do i = 1, self%nvars
+      ! update solution
+      call self%backend%vecadd(55._dp / 24._dp * dt, self%deriv(i)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(-59._dp / 24._dp * dt, self%olds(i,1)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(37._dp / 24._dp * dt, self%olds(i,2)%ptr, 1._dp, self%curr(i)%ptr)
+      call self%backend%vecadd(3._dp / 8._dp * dt, self%olds(i,3)%ptr, 1._dp, self%curr(i)%ptr)
+      
+      ! for startup
+      if (self%istep .eq. 3 .and. self%order .gt. 4) then
+        ! roll pointers
+        ptr => self%olds(i,4)%ptr
+        self%olds(i,4)%ptr => self%olds(i,3)%ptr
+        self%olds(i,3)%ptr => self%olds(i,2)%ptr
+        self%olds(i,2)%ptr => self%olds(i,1)%ptr
+        self%olds(i,1)%ptr => ptr
+      ! after startup
+      else
+        ! roll pointers
+        ptr => self%olds(i,3)%ptr
+        self%olds(i,3)%ptr => self%olds(i,2)%ptr
+        self%olds(i,2)%ptr => self%olds(i,1)%ptr
+        self%olds(i,1)%ptr => ptr
+      end if
+
+      ! update olds(1) with new derivative
+      call self%backend%vecadd(1.0_dp, self%deriv(i)%ptr, 0._dp, self%olds(i,1)%ptr)
+    end do
+
+  end subroutine adams_bashforth_4th
 
 end module m_time_integrator

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -45,6 +45,7 @@ contains
     init%coeffs(:, 4) = &
       [55._dp/24._dp, -59._dp/24._dp, 37._dp/24._dp, -3._dp/8._dp]
 
+    ! set variables
     init%backend => backend
     init%allocator => allocator
 
@@ -63,6 +64,7 @@ contains
     init%istep = 1
     init%nolds = init%order - 1
 
+    ! allocate memory
     allocate (init%olds(init%nvars, init%nolds))
     allocate (init%curr(init%nvars))
     allocate (init%deriv(init%nvars))

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -74,6 +74,8 @@ contains
 
     real(dp), intent(in) :: dt
 
+    integer :: order
+
     ! assign pointer to variables
     self%curr(1)%ptr => u
     self%curr(2)%ptr => v
@@ -84,40 +86,17 @@ contains
     self%deriv(2)%ptr => dv
     self%deriv(3)%ptr => dw
 
-    ! First-order
-    if (self%order .eq. 1) then
-      call self%adams_bashforth_1st(dt)
-
-    ! Second-order
-    else if (self%order .eq. 2) then
-      if (self%istep .eq. 0) then
+    order = min(self%istep + 1, self%order)
+    select case (order)
+      case(1)
         call self%adams_bashforth_1st(dt)
-      else
+      case(2)
         call self%adams_bashforth_2nd(dt)
-      end if
-
-    ! Third-order
-    else if (self%order .eq. 3) then
-      if (self%istep .eq. 0) then
-        call self%adams_bashforth_1st(dt)
-      else if (self%istep .eq. 1) then
-        call self%adams_bashforth_2nd(dt)
-      else
+      case(3)
          call self%adams_bashforth_3rd(dt)
-      end if
-
-    ! Fourth-order
-    else if (self%order .eq. 4) then
-      if (self%istep .eq. 0) then
-        call self%adams_bashforth_1st(dt)
-      else if (self%istep .eq. 1) then
-        call self%adams_bashforth_2nd(dt)
-      else if (self%istep .eq. 2) then
-        call self%adams_bashforth_3rd(dt)
-      else
+      case(4)
         call self%adams_bashforth_4th(dt)
-      end if
-    end if
+    end select
 
 
     ! increment step counter

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,14 +26,15 @@ endfunction()
 
 define_test(test_allocator.f90 1 omp)
 define_test(test_reordering.f90 1 omp)
+define_test(test_time_integrator.f90 1 omp)
 define_test(omp/test_omp_tridiag.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(omp/test_omp_transeq.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(omp/test_omp_dist_transeq.f90 ${CMAKE_CTEST_NPROCS} omp)
-define_test(omp/test_omp_adamsbashforth.f90 1 omp)
 
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
     ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")
   define_test(test_reordering.f90 1 cuda)
+  define_test(test_time_integrator.f90 1 cuda)
   define_test(cuda/test_cuda_allocator.f90 1 cuda)
   define_test(cuda/test_cuda_reorder.f90 1 cuda)
   define_test(cuda/test_cuda_tridiag.f90 ${CMAKE_CTEST_NPROCS} cuda)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ define_test(test_reordering.f90 1 omp)
 define_test(omp/test_omp_tridiag.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(omp/test_omp_transeq.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(omp/test_omp_dist_transeq.f90 ${CMAKE_CTEST_NPROCS} omp)
+define_test(omp/test_omp_adamsbashforth.f90 1 omp)
 
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
     ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")

--- a/tests/omp/test_omp_adamsbashforth.f90
+++ b/tests/omp/test_omp_adamsbashforth.f90
@@ -1,0 +1,166 @@
+program test_omp_adamsbashforth
+  use iso_fortran_env, only: stderr => error_unit
+  use mpi
+
+  use m_common, only: dp, globs_t, DIR_X
+  use m_allocator, only: allocator_t, field_t
+  use m_omp_backend, only: omp_backend_t, base_backend_t
+  use m_time_integrator, only: time_intg_t
+
+  implicit none
+
+  logical :: allpass = .true.
+  real(dp), allocatable, dimension(:) :: err
+  real(dp), allocatable, dimension(:) :: norm
+  class(field_t), pointer :: u, v, w
+  class(field_t), pointer :: du, dv, dw
+
+  type(globs_t) :: globs
+  class(base_backend_t), pointer :: backend
+  class(allocator_t), pointer :: allocator
+
+  type(omp_backend_t), target :: omp_backend
+  type(allocator_t), target :: omp_allocator
+  class(time_intg_t), allocatable :: time_integrator
+
+  real(dp) :: dt0 = 0.01_dp, dt, order
+  integer:: i, j, k, istartup, ierr
+  integer:: nstep0 = 64, nstep, nrun = 4, norder = 4
+
+  ! initialize MPI
+  call MPI_Init(ierr)
+
+  ! set globs parameters
+  globs%nx = 1
+  globs%ny = 1
+  globs%nz = 1
+
+  globs%nx_loc = globs%nx
+  globs%ny_loc = globs%ny
+  globs%nz_loc = globs%nz
+
+  globs%n_groups_x = globs%ny_loc*globs%nz_loc
+  globs%n_groups_y = globs%nx_loc*globs%nz_loc
+  globs%n_groups_z = globs%nx_loc*globs%ny_loc
+
+  ! allocate object
+  omp_allocator = allocator_t(globs%nx, globs%ny, globs%nz, 1)
+  allocator => omp_allocator
+  print *, 'OpenMP allocator instantiated'
+
+  omp_backend = omp_backend_t(globs, allocator)
+  backend => omp_backend
+  print *, 'OpenMP backend instantiated'
+
+  time_integrator = time_intg_t(allocator=allocator, backend=backend, order=norder)
+  print *, 'time integrator instantiated'
+
+  ! allocate memory
+  u => allocator%get_block(DIR_X)
+  v => allocator%get_block(DIR_X)
+  w => allocator%get_block(DIR_X)
+
+  du => allocator%get_block(DIR_X)
+  dv => allocator%get_block(DIR_X)
+  dw => allocator%get_block(DIR_X)
+
+  allocate(norm(nrun)) 
+
+  ! compute l2 norm for various step sizes
+  do k = 1, norder
+    time_integrator%order = k
+    dt = dt0
+    nstep = nstep0
+    do j = 1, nrun
+      ! initial condition
+      time_integrator%istep = 1
+
+      ! compute l2 norm for a given step size
+      allocate(err(nstep)) 
+      u%data(1,1,1) = 1.0_dp
+
+      ! startup
+      istartup = k - 1
+      do i = 1, istartup
+        du%data(1,1,1) = rhs(u%data(1,1,1))
+        call time_integrator%step(u, v, w, du, dv, dw, dt)
+        u%data(1,1,1) = exact_sol(real(i, dp) * dt)
+      end do
+
+      ! post-startup
+      do i = 1, nstep
+        du%data(1,1,1) = rhs(u%data(1,1,1))
+        call time_integrator%step(u, v, w, du, dv, dw, dt)
+        err(i) = u%data(1,1,1) - exact_sol(real(i + istartup, dp) * dt)
+      end do
+
+      ! compute l2 norms
+      norm(j) = norm2(err)
+      norm(j) = sqrt(norm(j) * norm(j) / real(nstep, dp))
+      print*, err(nstep)
+      deallocate(err)
+
+      ! refine time stepping
+      dt = dt / 2.0_dp
+      nstep = nstep * 2
+    end do
+
+    ! check order of convergence
+    order = log(norm(nrun - 1)/norm(nrun))/log(2.0_dp)
+    print *, 'order', order
+    if (abs(order - real(k, dp)) > 0.1_dp) then
+      allpass = .false.
+      write (stderr, '(a)') 'Check order... failed'
+    else
+      write (stderr, '(a)') 'Check order... passed'
+    end if
+
+  end do
+
+  if (allpass) then
+    write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
+  else
+    error stop 'SOME TESTS FAILED.'
+  end if
+
+  ! deallocate memory
+  deallocate(norm)
+
+  call allocator%release_block(du)
+  call allocator%release_block(dv)
+  call allocator%release_block(dw)
+
+  call allocator%release_block(u)
+  call allocator%release_block(v)
+  call allocator%release_block(w)
+
+  ! finalize MPI
+  call MPI_Finalize(ierr)
+
+contains 
+  function rhs(u)
+    implicit none
+
+    real(dp):: rhs
+    real(dp), intent(in) :: u
+
+    real(dp) :: lambda = -1.0_dp
+
+    rhs =  lambda * u
+
+  end function rhs
+
+  function exact_sol(time)
+    implicit none
+
+    real(dp):: exact_sol
+    real(dp), intent(in) :: time
+
+    real(dp) :: lambda = -1.0_dp
+
+    exact_sol = exp(lambda * time)
+
+  end function exact_sol
+
+end program test_omp_adamsbashforth
+

--- a/tests/omp/test_omp_adamsbashforth.f90
+++ b/tests/omp/test_omp_adamsbashforth.f90
@@ -10,22 +10,20 @@ program test_omp_adamsbashforth
   implicit none
 
   logical :: allpass = .true.
+  integer :: i, j, k, istartup, ierr
+  integer :: nstep0 = 64, nstep, nrun = 4, norder = 4
   real(dp), allocatable, dimension(:) :: err
   real(dp), allocatable, dimension(:) :: norm
+  real(dp) :: dt0 = 0.01_dp, dt, order
   class(field_t), pointer :: u, v, w
   class(field_t), pointer :: du, dv, dw
 
   type(globs_t) :: globs
   class(base_backend_t), pointer :: backend
   class(allocator_t), pointer :: allocator
-
   type(omp_backend_t), target :: omp_backend
   type(allocator_t), target :: omp_allocator
   class(time_intg_t), allocatable :: time_integrator
-
-  real(dp) :: dt0 = 0.01_dp, dt, order
-  integer :: i, j, k, istartup, ierr
-  integer :: nstep0 = 64, nstep, nrun = 4, norder = 4
 
   ! initialize MPI
   call MPI_Init(ierr)

--- a/tests/omp/test_omp_adamsbashforth.f90
+++ b/tests/omp/test_omp_adamsbashforth.f90
@@ -24,8 +24,8 @@ program test_omp_adamsbashforth
   class(time_intg_t), allocatable :: time_integrator
 
   real(dp) :: dt0 = 0.01_dp, dt, order
-  integer:: i, j, k, istartup, ierr
-  integer:: nstep0 = 64, nstep, nrun = 4, norder = 4
+  integer :: i, j, k, istartup, ierr
+  integer :: nstep0 = 64, nstep, nrun = 4, norder = 4
 
   ! initialize MPI
   call MPI_Init(ierr)
@@ -52,7 +52,8 @@ program test_omp_adamsbashforth
   backend => omp_backend
   print *, 'OpenMP backend instantiated'
 
-  time_integrator = time_intg_t(allocator=allocator, backend=backend, order=norder)
+  time_integrator = time_intg_t(allocator=allocator, &
+                                backend=backend, order=norder)
   print *, 'time integrator instantiated'
 
   ! allocate memory
@@ -64,7 +65,7 @@ program test_omp_adamsbashforth
   dv => allocator%get_block(DIR_X)
   dw => allocator%get_block(DIR_X)
 
-  allocate(norm(nrun)) 
+  allocate (norm(nrun))
 
   ! compute l2 norm for various step sizes
   do k = 1, norder
@@ -76,33 +77,33 @@ program test_omp_adamsbashforth
       time_integrator%istep = 1
 
       ! compute l2 norm for a given step size
-      allocate(err(nstep)) 
-      u%data(1,1,1) = 1.0_dp
+      allocate (err(nstep))
+      u%data(1, 1, 1) = 1.0_dp
 
       ! startup
       istartup = k - 1
       do i = 1, istartup
-        du%data(1,1,1) = rhs(u%data(1,1,1))
+        du%data(1, 1, 1) = rhs(u%data(1, 1, 1))
         call time_integrator%step(u, v, w, du, dv, dw, dt)
-        u%data(1,1,1) = exact_sol(real(i, dp) * dt)
+        u%data(1, 1, 1) = exact_sol(real(i, dp)*dt)
       end do
 
       ! post-startup
       do i = 1, nstep
-        du%data(1,1,1) = rhs(u%data(1,1,1))
+        du%data(1, 1, 1) = rhs(u%data(1, 1, 1))
         call time_integrator%step(u, v, w, du, dv, dw, dt)
-        err(i) = u%data(1,1,1) - exact_sol(real(i + istartup, dp) * dt)
+        err(i) = u%data(1, 1, 1) - exact_sol(real(i + istartup, dp)*dt)
       end do
 
       ! compute l2 norms
       norm(j) = norm2(err)
-      norm(j) = sqrt(norm(j) * norm(j) / real(nstep, dp))
-      print*, err(nstep)
-      deallocate(err)
+      norm(j) = sqrt(norm(j)*norm(j)/real(nstep, dp))
+      print *, err(nstep)
+      deallocate (err)
 
       ! refine time stepping
-      dt = dt / 2.0_dp
-      nstep = nstep * 2
+      dt = dt/2.0_dp
+      nstep = nstep*2
     end do
 
     ! check order of convergence
@@ -124,7 +125,7 @@ program test_omp_adamsbashforth
   end if
 
   ! deallocate memory
-  deallocate(norm)
+  deallocate (norm)
 
   call allocator%release_block(du)
   call allocator%release_block(dv)
@@ -137,28 +138,28 @@ program test_omp_adamsbashforth
   ! finalize MPI
   call MPI_Finalize(ierr)
 
-contains 
+contains
   function rhs(u)
     implicit none
 
-    real(dp):: rhs
+    real(dp) :: rhs
     real(dp), intent(in) :: u
 
     real(dp) :: lambda = -1.0_dp
 
-    rhs =  lambda * u
+    rhs = lambda*u
 
   end function rhs
 
   function exact_sol(time)
     implicit none
 
-    real(dp):: exact_sol
+    real(dp) :: exact_sol
     real(dp), intent(in) :: time
 
     real(dp) :: lambda = -1.0_dp
 
-    exact_sol = exp(lambda * time)
+    exact_sol = exp(lambda*time)
 
   end function exact_sol
 

--- a/tests/omp/test_omp_adamsbashforth.f90
+++ b/tests/omp/test_omp_adamsbashforth.f90
@@ -83,16 +83,17 @@ program test_omp_adamsbashforth
       ! startup
       istartup = k - 1
       do i = 1, istartup
-        du%data(1, 1, 1) = rhs(u%data(1, 1, 1))
+        du%data(1, 1, 1) = dahlquist_rhs(u%data(1, 1, 1))
         call time_integrator%step(u, v, w, du, dv, dw, dt)
-        u%data(1, 1, 1) = exact_sol(real(i, dp)*dt)
+        u%data(1, 1, 1) = dahlquist_exact_sol(real(i, dp)*dt)
       end do
 
       ! post-startup
       do i = 1, nstep
-        du%data(1, 1, 1) = rhs(u%data(1, 1, 1))
+        du%data(1, 1, 1) = dahlquist_rhs(u%data(1, 1, 1))
         call time_integrator%step(u, v, w, du, dv, dw, dt)
-        err(i) = u%data(1, 1, 1) - exact_sol(real(i + istartup, dp)*dt)
+        err(i) = u%data(1, 1, 1) - dahlquist_exact_sol( &
+                 real(i + istartup, dp)*dt)
       end do
 
       ! compute l2 norms
@@ -139,29 +140,29 @@ program test_omp_adamsbashforth
   call MPI_Finalize(ierr)
 
 contains
-  function rhs(u)
+  function dahlquist_rhs(u)
     implicit none
 
-    real(dp) :: rhs
+    real(dp) :: dahlquist_rhs
     real(dp), intent(in) :: u
 
     real(dp) :: lambda = -1.0_dp
 
-    rhs = lambda*u
+    dahlquist_rhs = lambda*u
 
-  end function rhs
+  end function dahlquist_rhs
 
-  function exact_sol(time)
+  function dahlquist_exact_sol(time)
     implicit none
 
-    real(dp) :: exact_sol
+    real(dp) :: dahlquist_exact_sol
     real(dp), intent(in) :: time
 
     real(dp) :: lambda = -1.0_dp
 
-    exact_sol = exp(lambda*time)
+    dahlquist_exact_sol = exp(lambda*time)
 
-  end function exact_sol
+  end function dahlquist_exact_sol
 
 end program test_omp_adamsbashforth
 


### PR DESCRIPTION
This PR implements Adams-Bashforth integration schemes with provision for the start-up phase by successively increasing the time-integration order.

The Dahlquist equation is used to check Adams-Bashforth integration schemes from order 1 to 4. New tests have been added in the following file
`tests/omp/test_omp_adamsbashforth.f90`