### PR TITLE
Add multi-GPU support for the Poisson solver in CUDA backend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,10 +47,9 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
   set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -traceback -Mbounds -Mchkptr -Ktrap=fp")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fast")
   target_link_options(x3d2 INTERFACE "-cuda")
-  target_link_options(x3d2 INTERFACE "-lcufft")
+  target_link_options(x3d2 INTERFACE "-cudalib=cufftmp")
 
   target_compile_options(xcompact PRIVATE "-DCUDA")
-  #  target_link_options(xcompact INTERFACE "-cuda")
 elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
   set(CMAKE_Fortran_FLAGS "-cpp -std=f2008")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g -Og -Wall -Wpedantic -Werror -Wimplicit-interface -Wimplicit-procedure -Wno-unused-dummy-argument")

--- a/src/cuda/kernels/spectral_processing.f90
+++ b/src/cuda/kernels/spectral_processing.f90
@@ -22,8 +22,12 @@ contains
     !> Spectral equivalence constants
     complex(dp), device, intent(in), dimension(:, :, :) :: waves
     real(dp), device, intent(in), dimension(:) :: ax, bx, ay, by, az, bz
+    !> Grid size in spectral space
+    integer, value, intent(in) :: nx_spec, ny_spec
+    !> Offset in y direction in the permuted slabs in spectral space
+    integer, value, intent(in) :: y_sp_st
     !> Grid size
-    integer, value, intent(in) :: nx_spec, ny_spec, y_sp_st, nx, ny, nz
+    integer, value, intent(in) :: nx, ny, nz
 
     integer :: i, j, k, ix, iy, iz
     real(dp) :: tmp_r, tmp_c, div_r, div_c

--- a/src/cuda/poisson_fft.f90
+++ b/src/cuda/poisson_fft.f90
@@ -84,7 +84,7 @@ contains
     ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
                            worksize)
     if (ierr /= 0) then
-      write (stderr, *), "cuFFT Error Code: ", ierr
+      write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Forward 3D FFT plan generation failed'
     end if
 
@@ -94,7 +94,7 @@ contains
     ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
                            worksize)
     if (ierr /= 0) then
-      write (stderr, *), "cuFFT Error Code: ", ierr
+      write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Backward 3D FFT plan generation failed'
     end if
 
@@ -102,7 +102,7 @@ contains
     ierr = cufftXtMalloc(poisson_fft%plan3D_fw, poisson_fft%xtdesc, &
                          CUFFT_XT_FORMAT_INPLACE)
     if (ierr /= 0) then
-      write (stderr, *), "cuFFT Error Code: ", ierr
+      write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'cufftXtMalloc failed'
     end if
 
@@ -131,7 +131,7 @@ contains
     ierr = cudaMemcpy2D(d_dev, self%nx_loc + 2, flat_dev, self%nx_loc, &
                         self%nx_loc, self%ny_loc*self%nz_loc)
     if (ierr /= 0) then
-      print*, "cudaMemcpy2D error code: ", ierr
+      print *, 'cudaMemcpy2D error code: ', ierr
       error stop 'cudaMemcpy2D failed'
     end if
 
@@ -139,7 +139,7 @@ contains
                                  CUFFT_FORWARD)
 
     if (ierr /= 0) then
-      write (stderr, *), "cuFFT Error Code: ", ierr
+      write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Forward 3D FFT execution failed'
     end if
 
@@ -160,7 +160,7 @@ contains
     ierr = cufftXtExecDescriptor(self%plan3D_bw, self%xtdesc, self%xtdesc, &
                                  CUFFT_INVERSE)
     if (ierr /= 0) then
-      write (stderr, *), "cuFFT Error Code: ", ierr
+      write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Backward 3D FFT execution failed'
     end if
 
@@ -175,7 +175,7 @@ contains
     ierr = cudaMemcpy2D(flat_dev, self%nx_loc, d_dev, self%nx_loc + 2, &
                         self%nx_loc, self%ny_loc*self%nz_loc)
     if (ierr /= 0) then
-      print*, "cudaMemcpy2D error code: ", ierr
+      print *, 'cudaMemcpy2D error code: ', ierr
       error stop 'cudaMemcpy2D failed'
     end if
 

--- a/src/cuda/poisson_fft.f90
+++ b/src/cuda/poisson_fft.f90
@@ -2,7 +2,9 @@ module m_cuda_poisson_fft
   use iso_c_binding, only: c_loc, c_ptr, c_f_pointer
   use iso_fortran_env, only: stderr => error_unit
   use cudafor
+  use cufftXt
   use cufft
+  use mpi
 
   use m_allocator, only: field_t
   use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, CELL
@@ -18,8 +20,6 @@ module m_cuda_poisson_fft
   type, extends(poisson_fft_t) :: cuda_poisson_fft_t
     !! FFT based Poisson solver
 
-    !> Local domain sized array to store data in spectral space
-    complex(dp), device, allocatable, dimension(:, :, :) :: c_w_dev
     !> Local domain sized array storing the spectral equivalence constants
     complex(dp), device, allocatable, dimension(:, :, :) :: waves_dev
     !> cufft requires a local domain sized storage
@@ -30,6 +30,8 @@ module m_cuda_poisson_fft
                                                    az_dev, bz_dev
 
     integer :: plan3D_fw, plan3D_bw
+
+    type(cudaLibXtDesc), pointer :: xtdesc
   contains
     procedure :: fft_forward => fft_forward_cuda
     procedure :: fft_backward => fft_backward_cuda
@@ -59,9 +61,13 @@ contains
 
     call poisson_fft%base_init(mesh, xdirps, ydirps, zdirps)
 
-    nx = poisson_fft%nx; ny = poisson_fft%ny; nz = poisson_fft%nz
+    nx = poisson_fft%nx_glob
+    ny = poisson_fft%ny_glob
+    nz = poisson_fft%nz_glob
 
-    allocate (poisson_fft%waves_dev(nx/2 + 1, ny, nz))
+    allocate (poisson_fft%waves_dev(poisson_fft%nx_spec, &
+                                    poisson_fft%ny_spec, &
+                                    poisson_fft%nz_spec))
     poisson_fft%waves_dev = poisson_fft%waves
 
     allocate (poisson_fft%ax_dev(nx), poisson_fft%bx_dev(nx))
@@ -71,26 +77,33 @@ contains
     poisson_fft%ay_dev = poisson_fft%ay; poisson_fft%by_dev = poisson_fft%by
     poisson_fft%az_dev = poisson_fft%az; poisson_fft%bz_dev = poisson_fft%bz
 
-    allocate (poisson_fft%c_w_dev(nx/2 + 1, ny, nz))
-    allocate (poisson_fft%fft_worksize((nx/2 + 1)*ny*nz))
-
     ! 3D plans
     ierr = cufftCreate(poisson_fft%plan3D_fw)
+    ierr = cufftMpAttachComm(poisson_fft%plan3D_fw, CUFFT_COMM_MPI, &
+                             MPI_COMM_WORLD)
     ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
                            worksize)
-    ierr = cufftSetWorkArea(poisson_fft%plan3D_fw, poisson_fft%fft_worksize)
     if (ierr /= 0) then
       write (stderr, *), "cuFFT Error Code: ", ierr
       error stop 'Forward 3D FFT plan generation failed'
     end if
 
     ierr = cufftCreate(poisson_fft%plan3D_bw)
+    ierr = cufftMpAttachComm(poisson_fft%plan3D_bw, CUFFT_COMM_MPI, &
+                             MPI_COMM_WORLD)
     ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
                            worksize)
-    ierr = cufftSetWorkArea(poisson_fft%plan3D_bw, poisson_fft%fft_worksize)
     if (ierr /= 0) then
       write (stderr, *), "cuFFT Error Code: ", ierr
       error stop 'Backward 3D FFT plan generation failed'
+    end if
+
+    ! allocate storage for cuFFTMp
+    ierr = cufftXtMalloc(poisson_fft%plan3D_fw, poisson_fft%xtdesc, &
+                         CUFFT_XT_FORMAT_INPLACE)
+    if (ierr /= 0) then
+      write (stderr, *), "cuFFT Error Code: ", ierr
+      error stop 'cufftXtMalloc failed'
     end if
 
   end function init
@@ -101,21 +114,30 @@ contains
     class(cuda_poisson_fft_t) :: self
     class(field_t), intent(in) :: f
 
-    real(dp), device, pointer, dimension(:, :, :) :: f_dev
-    real(dp), device, pointer :: f_ptr
-    type(c_ptr) :: f_c_ptr
+    real(dp), device, pointer :: flat_dev(:, :), d_dev(:, :, :)
 
-    type(dim3) :: blocks, threads
+    type(cudaXtDesc), pointer :: descriptor
+
     integer :: ierr
 
-    select type (f); type is (cuda_field_t); f_dev => f%data_d; end select
+    select type (f)
+    type is (cuda_field_t)
+      flat_dev(1:self%nx_loc, 1:self%ny_loc*self%nz_loc) => f%data_d
+    end select
 
-    ! Using f_dev directly in cufft call causes a segfault
-    ! Pointer switches below fixes the problem
-    f_c_ptr = c_loc(f_dev)
-    call c_f_pointer(f_c_ptr, f_ptr)
+    call c_f_pointer(self%xtdesc%descriptor, descriptor)
+    call c_f_pointer(descriptor%data(1), d_dev, &
+                     [self%nx_loc + 2, self%ny_loc*self%nz_loc])
+    ierr = cudaMemcpy2D(d_dev, self%nx_loc + 2, flat_dev, self%nx_loc, &
+                        self%nx_loc, self%ny_loc*self%nz_loc)
+    if (ierr /= 0) then
+      print*, "cudaMemcpy2D error code: ", ierr
+      error stop 'cudaMemcpy2D failed'
+    end if
 
-    ierr = cufftExecD2Z(self%plan3D_fw, f_ptr, self%c_w_dev)
+    ierr = cufftXtExecDescriptor(self%plan3D_fw, self%xtdesc, self%xtdesc, &
+                                 CUFFT_FORWARD)
+
     if (ierr /= 0) then
       write (stderr, *), "cuFFT Error Code: ", ierr
       error stop 'Forward 3D FFT execution failed'
@@ -129,24 +151,32 @@ contains
     class(cuda_poisson_fft_t) :: self
     class(field_t), intent(inout) :: f
 
-    real(dp), device, pointer, dimension(:, :, :) :: f_dev
-    real(dp), device, pointer :: f_ptr
-    type(c_ptr) :: f_c_ptr
+    real(dp), device, pointer :: flat_dev(:, :), d_dev(:, :, :)
 
-    type(dim3) :: blocks, threads
+    type(cudaXtDesc), pointer :: descriptor
+
     integer :: ierr
 
-    select type (f); type is (cuda_field_t); f_dev => f%data_d; end select
-
-    ! Using f_dev directly in cufft call causes a segfault
-    ! Pointer switches below fixes the problem
-    f_c_ptr = c_loc(f_dev)
-    call c_f_pointer(f_c_ptr, f_ptr)
-
-    ierr = cufftExecZ2D(self%plan3D_bw, self%c_w_dev, f_ptr)
+    ierr = cufftXtExecDescriptor(self%plan3D_bw, self%xtdesc, self%xtdesc, &
+                                 CUFFT_INVERSE)
     if (ierr /= 0) then
       write (stderr, *), "cuFFT Error Code: ", ierr
       error stop 'Backward 3D FFT execution failed'
+    end if
+
+    select type (f)
+    type is (cuda_field_t)
+      flat_dev(1:self%nx_loc, 1:self%ny_loc*self%nz_loc) => f%data_d
+    end select
+
+    call c_f_pointer(self%xtdesc%descriptor, descriptor)
+    call c_f_pointer(descriptor%data(1), d_dev, &
+                     [self%nx_loc + 2, self%ny_loc*self%nz_loc])
+    ierr = cudaMemcpy2D(flat_dev, self%nx_loc, d_dev, self%nx_loc + 2, &
+                        self%nx_loc, self%ny_loc*self%nz_loc)
+    if (ierr /= 0) then
+      print*, "cudaMemcpy2D error code: ", ierr
+      error stop 'cudaMemcpy2D failed'
     end if
 
   end subroutine fft_backward_cuda
@@ -156,19 +186,27 @@ contains
 
     class(cuda_poisson_fft_t) :: self
 
+    type(cudaXtDesc), pointer :: descriptor
+
     complex(dp), device, dimension(:, :, :), pointer :: c_dev
     type(dim3) :: blocks, threads
     integer :: tsize
 
+    ! obtain a pointer to descriptor so that we can carry out postprocessing
+    call c_f_pointer(self%xtdesc%descriptor, descriptor)
+    call c_f_pointer(descriptor%data(1), c_dev, &
+                     [self%nx_spec, self%ny_spec, self%nz_spec])
+
     ! tsize is different than SZ, because here we work on a 3D Cartesian
     ! data structure, and free to specify any suitable thread/block size.
     tsize = 16
-    blocks = dim3((self%ny - 1)/tsize + 1, self%nz, 1)
+    blocks = dim3((self%ny_spec - 1)/tsize + 1, self%nz_spec, 1)
     threads = dim3(tsize, 1, 1)
 
     ! Postprocess div_u in spectral space
     call process_spectral_div_u<<<blocks, threads>>>( & !&
-      self%c_w_dev, self%waves_dev, self%nx, self%ny, self%nz, &
+      c_dev, self%waves_dev, self%nx_spec, self%ny_spec, self%y_sp_st, &
+      self%nx_glob, self%ny_glob, self%nz_glob, &
       self%ax_dev, self%bx_dev, self%ay_dev, self%by_dev, &
       self%az_dev, self%bz_dev &
       )

--- a/src/cuda/poisson_fft.f90
+++ b/src/cuda/poisson_fft.f90
@@ -22,13 +22,11 @@ module m_cuda_poisson_fft
 
     !> Local domain sized array storing the spectral equivalence constants
     complex(dp), device, allocatable, dimension(:, :, :) :: waves_dev
-    !> cufft requires a local domain sized storage
-    complex(dp), device, allocatable, dimension(:) :: fft_worksize
     !> Wave numbers in x, y, and z
     real(dp), device, allocatable, dimension(:) :: ax_dev, bx_dev, &
                                                    ay_dev, by_dev, &
                                                    az_dev, bz_dev
-
+    !> Forward and backward FFT transform plans
     integer :: plan3D_fw, plan3D_bw
 
     !> cuFFTMp object manages decomposition and data storage

--- a/src/cuda/poisson_fft.f90
+++ b/src/cuda/poisson_fft.f90
@@ -24,13 +24,14 @@ module m_cuda_poisson_fft
     complex(dp), device, allocatable, dimension(:, :, :) :: waves_dev
     !> cufft requires a local domain sized storage
     complex(dp), device, allocatable, dimension(:) :: fft_worksize
-
+    !> Wave numbers in x, y, and z
     real(dp), device, allocatable, dimension(:) :: ax_dev, bx_dev, &
                                                    ay_dev, by_dev, &
                                                    az_dev, bz_dev
 
     integer :: plan3D_fw, plan3D_bw
 
+    !> cuFFTMp object manages decomposition and data storage
     type(cudaLibXtDesc), pointer :: xtdesc
   contains
     procedure :: fft_forward => fft_forward_cuda

--- a/src/poisson_fft.f90
+++ b/src/poisson_fft.f90
@@ -8,12 +8,19 @@ module m_poisson_fft
 
   type, abstract :: poisson_fft_t
     !! FFT based Poisson solver
+    !> Global dimensions
     integer :: nx_glob, ny_glob, nz_glob
+    !> Local dimensions
     integer :: nx_loc, ny_loc, nz_loc
+    !> Local dimensions in the permuted slabs
     integer :: nx_perm, ny_perm, nz_perm
+    !> Local dimensions in the permuted slabs in spectral space
     integer :: nx_spec, ny_spec, nz_spec
+    !> Offset in y direction in the permuted slabs in spectral space
     integer :: y_sp_st
+    !> Local domain sized array storing the spectral equivalence constants
     complex(dp), allocatable, dimension(:, :, :) :: waves
+    !> Wave numbers in x, y, and z
     complex(dp), allocatable, dimension(:) :: ax, bx, ay, by, az, bz
   contains
     procedure(fft_forward), deferred :: fft_forward

--- a/src/poisson_fft.f90
+++ b/src/poisson_fft.f90
@@ -74,8 +74,8 @@ contains
     self%nx_loc = dims(1); self%ny_loc = dims(2); self%nz_loc = dims(3)
 
     ! 1D decomposition along Z in real domain, and along Y in spectral space
-    if (mesh%par%nproc_dir(1) /= 1) print*, 'nproc_dir in x-dir must be 1'
-    if (mesh%par%nproc_dir(2) /= 1) print*, 'nproc_dir in y-dir must be 1'
+    if (mesh%par%nproc_dir(1) /= 1) print *, 'nproc_dir in x-dir must be 1'
+    if (mesh%par%nproc_dir(2) /= 1) print *, 'nproc_dir in y-dir must be 1'
     self%nx_perm = self%nx_loc/mesh%par%nproc_dir(2)
     self%ny_perm = self%ny_loc/mesh%par%nproc_dir(3)
     self%nz_perm = self%nz_glob
@@ -117,7 +117,7 @@ contains
 
     integer :: i, j, k
 
-    nx = xdirps%n_glob; ny = ydirps%n_glob; nz = zdirps%n_glob
+    nx = self%nx_glob; ny = self%ny_glob; nz = self%nz_glob
 
     do i = 1, nx
       self%ax(i) = sin((i - 1)*pi/nx)

--- a/src/poisson_fft.f90
+++ b/src/poisson_fft.f90
@@ -8,7 +8,11 @@ module m_poisson_fft
 
   type, abstract :: poisson_fft_t
     !! FFT based Poisson solver
-    integer :: nx, ny, nz
+    integer :: nx_glob, ny_glob, nz_glob
+    integer :: nx_loc, ny_loc, nz_loc
+    integer :: nx_perm, ny_perm, nz_perm
+    integer :: nx_spec, ny_spec, nz_spec
+    integer :: y_sp_st
     complex(dp), allocatable, dimension(:, :, :) :: waves
     complex(dp), allocatable, dimension(:) :: ax, bx, ay, by, az, bz
   contains
@@ -58,14 +62,28 @@ contains
     integer :: dims(3)
 
     dims = mesh%get_global_dims(CELL)
-    self%nx = dims(1); self%ny = dims(2); self%nz = dims(3)
+    self%nx_glob = dims(1); self%ny_glob = dims(2); self%nz_glob = dims(3)
+    dims = mesh%get_dims(CELL)
+    self%nx_loc = dims(1); self%ny_loc = dims(2); self%nz_loc = dims(3)
 
-    allocate (self%ax(self%nx), self%bx(self%nx))
-    allocate (self%ay(self%ny), self%by(self%ny))
-    allocate (self%az(self%nz), self%bz(self%nz))
+    ! 1D decomposition along Z in real domain, and along Y in spectral space
+    if (mesh%par%nproc_dir(1) /= 1) print*, 'nproc_dir in x-dir must be 1'
+    if (mesh%par%nproc_dir(2) /= 1) print*, 'nproc_dir in y-dir must be 1'
+    self%nx_perm = self%nx_loc/mesh%par%nproc_dir(2)
+    self%ny_perm = self%ny_loc/mesh%par%nproc_dir(3)
+    self%nz_perm = self%nz_glob
+    self%nx_spec = self%nx_loc/2 + 1
+    self%ny_spec = self%ny_perm
+    self%nz_spec = self%nz_perm
+
+    self%y_sp_st = (self%ny_loc/mesh%par%nproc_dir(3))*mesh%par%nrank_dir(3)
+
+    allocate (self%ax(self%nx_glob), self%bx(self%nx_glob))
+    allocate (self%ay(self%ny_glob), self%by(self%ny_glob))
+    allocate (self%az(self%nz_glob), self%bz(self%nz_glob))
 
     ! cuFFT 3D transform halves the first index.
-    allocate (self%waves(self%nx/2 + 1, self%ny, self%nz))
+    allocate (self%waves(self%nx_spec, self%ny_spec, self%nz_spec))
 
     ! waves_set requires some of the preprocessed tdsops variables.
     call self%waves_set(mesh%geo, xdirps, ydirps, zdirps)
@@ -85,14 +103,14 @@ contains
     complex(dp), allocatable, dimension(:) :: xkx, xk2, yky, yk2, zkz, zk2, &
                                               exs, eys, ezs
 
-    integer :: nx, ny, nz
+    integer :: nx, ny, nz, ix, iy, iz
     real(dp) :: w, wp, rlexs, rleys, rlezs, xtt, ytt, ztt, xt1, yt1, zt1
     complex(dp) :: xt2, yt2, zt2, xyzk
     real(dp) :: d, L
 
     integer :: i, j, k
 
-    nx = self%nx; ny = self%ny; nz = self%nz
+    nx = xdirps%n_glob; ny = ydirps%n_glob; nz = zdirps%n_glob
 
     do i = 1, nx
       self%ax(i) = sin((i - 1)*pi/nx)
@@ -172,14 +190,13 @@ contains
       zk2(i) = zk2(nz - i + 2)
     end do
 
-    print *, 'waves array is correctly set only for a single rank run'
-    ! TODO: do loop ranges below are valid only for single rank runs
-    do i = 1, nx/2 + 1
-      do j = 1, ny
-        do k = 1, nz
-          rlexs = real(exs(i), kind=dp)*geo%d(1)
-          rleys = real(eys(j), kind=dp)*geo%d(2)
-          rlezs = real(ezs(k), kind=dp)*geo%d(3)
+    do i = 1, self%nx_spec
+      do j = 1, self%ny_spec
+        do k = 1, self%nz_spec
+          ix = i; iy = j + self%y_sp_st; iz = k
+          rlexs = real(exs(ix), kind=dp)*geo%d(1)
+          rleys = real(eys(iy), kind=dp)*geo%d(2)
+          rlezs = real(ezs(iz), kind=dp)*geo%d(3)
 
           xtt = 2*(xdirps%interpl_v2p%a*cos(rlexs*0.5_dp) &
                    + xdirps%interpl_v2p%b*cos(rlexs*1.5_dp) &
@@ -198,9 +215,9 @@ contains
           yt1 = 1._dp + 2*ydirps%interpl_v2p%alpha*cos(rleys)
           zt1 = 1._dp + 2*zdirps%interpl_v2p%alpha*cos(rlezs)
 
-          xt2 = xk2(i)*(((ytt/yt1)*(ztt/zt1))**2)
-          yt2 = yk2(j)*(((xtt/xt1)*(ztt/zt1))**2)
-          zt2 = zk2(k)*(((xtt/xt1)*(ytt/yt1))**2)
+          xt2 = xk2(ix)*(((ytt/yt1)*(ztt/zt1))**2)
+          yt2 = yk2(iy)*(((xtt/xt1)*(ztt/zt1))**2)
+          zt2 = zk2(iz)*(((xtt/xt1)*(ytt/yt1))**2)
 
           xyzk = xt2 + yt2 + zt2
           self%waves(i, j, k) = xyzk

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -117,7 +117,7 @@ contains
     solver%backend%nu = globs%nu
     solver%n_iters = globs%n_iters
     solver%n_output = globs%n_output
-    solver%ngrid = product(solver%mesh%get_dims(VERT))
+    solver%ngrid = product(solver%mesh%get_global_dims(VERT))
 
     dims = solver%mesh%get_dims(VERT)
     u_init => solver%host_allocator%get_block(DIR_C)
@@ -626,7 +626,6 @@ contains
                        MPI_MAX, MPI_COMM_WORLD, ierr)
     call MPI_Allreduce(MPI_IN_PLACE, div_u_mean, 1, MPI_DOUBLE_PRECISION, &
                        MPI_SUM, MPI_COMM_WORLD, ierr)
-    div_u_mean = div_u_mean/self%mesh%par%nproc
     if (self%mesh%par%is_root()) &
       print *, 'div u max mean:', div_u_max, div_u_mean
 

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -70,10 +70,6 @@ program xcompact
 
   mesh = mesh_t(dims_global, nproc_dir, L_global)
 
-  xdirps%n_glob = globs%nx
-  ydirps%n_glob = globs%ny
-  zdirps%n_glob = globs%nz
-
   globs%dt = 0.001_dp
   globs%nu = 1._dp/1600._dp
   globs%n_iters = 20000

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -66,9 +66,13 @@ program xcompact
   L_global = [2*pi, 2*pi, 2*pi]
 
   ! Domain decomposition in each direction
-  nproc_dir = [1, 1, 1]
+  nproc_dir = [1, 1, nproc]
 
   mesh = mesh_t(dims_global, nproc_dir, L_global)
+
+  xdirps%n_glob = globs%nx
+  ydirps%n_glob = globs%ny
+  zdirps%n_glob = globs%nz
 
   globs%dt = 0.001_dp
   globs%nu = 1._dp/1600._dp


### PR DESCRIPTION
Adds slab decomposition support via cuFFTMp library.

The slab decomposition is in `PHYSICAL_IN_X` setup in 2DECOMP&FFT terminology.