### PR TITLE
Fix null pointer to mesh

### DIFF
--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -39,8 +39,8 @@ module m_mesh
     integer, dimension(3), private :: cell_dims ! local number of cells in each direction without padding (cartesian structure)
     logical, dimension(3), private :: periodic_BC ! Whether or not a direction has a periodic BC
     integer, private :: sz
-    class(geo_t), allocatable :: geo ! object containing geometry information
-    class(parallel_t), allocatable :: par ! object containing parallel domain decomposition information
+    type(geo_t), allocatable :: geo ! object containing geometry information
+    type(parallel_t), allocatable :: par ! object containing parallel domain decomposition information
   contains
     procedure :: get_SZ
 

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -25,7 +25,7 @@ program xcompact
   type(globs_t) :: globs
   class(base_backend_t), pointer :: backend
   class(allocator_t), pointer :: allocator
-  class(mesh_t), allocatable :: mesh
+  type(mesh_t) :: mesh
   type(allocator_t), pointer :: host_allocator
   type(solver_t) :: solver
   type(time_intg_t) :: time_integrator


### PR DESCRIPTION
After compiling with `nvfortran`, the code would fail during runtime with the following error:

```
Parallel run with            1 ranks
0: Null pointer for mesh%geo (/home/jjquinn/projects/xcompact/x3d2/src/xcompact.f90: 71)

--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[8151,1],0]
  Exit code:    127
--------------------------------------------------------------------------
```

The compilation and run steps on Sylvain's Kolmogorov machine are:
```
cmake -DCMAKE_BUILD_TYPE=Debug -B build -DCMAKE_Fortran_COMPILER=mpif90
cmake --build build -j18
mpirun -n 1 build/src/xcompact
```

This PR removes the `allocatable` attribute on `mesh` and changes both `mesh` and its contained `geo` and `par` members to `type` instead of `class`. I'm don't know this feature of Fortran well enough to explain why this works but it fixes the problem...

**Additional nonsense:** The unit test that uses the same pattern or allocatable + class passes fine. No idea why.