### PR TITLE
Make BC specifications more verbose in tdsops

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -190,8 +190,8 @@ module m_base_backend
   end interface
 
   abstract interface
-    subroutine alloc_tdsops(self, tdsops, dir, operation, scheme, n_halo, &
-                            from_to, bc_start, bc_end, sym, c_nu, nu0_nu)
+    subroutine alloc_tdsops(self, tdsops, dir, operation, scheme, bc_start, &
+                            bc_end, n_halo, from_to, sym, c_nu, nu0_nu)
       import :: base_backend_t
       import :: dp
       import :: tdsops_t
@@ -201,8 +201,9 @@ module m_base_backend
       class(tdsops_t), allocatable, intent(inout) :: tdsops
       integer, intent(in) :: dir
       character(*), intent(in) :: operation, scheme
+      integer, intent(in) :: bc_start, bc_end
       integer, optional, intent(in) :: n_halo
-      character(*), optional, intent(in) :: from_to, bc_start, bc_end
+      character(*), optional, intent(in) :: from_to
       logical, optional, intent(in) :: sym
       real(dp), optional, intent(in) :: c_nu, nu0_nu
     end subroutine alloc_tdsops

--- a/src/common.f90
+++ b/src/common.f90
@@ -19,7 +19,8 @@ module m_common
                         Y_EDGE = 0100, & ! Data on edges along Y
                         Z_EDGE = 0010, & ! Data on edges along Z
                         none = -0001 ! The location of data isn't specified
-  integer, parameter :: BC_PERIODIC = 0, BC_NEUMANN = 1, BC_DIRICHLET = 2
+  integer, parameter :: BC_PERIODIC = 0, BC_NEUMANN = 1, BC_DIRICHLET = 2, &
+                        BC_NULL = -1
   integer, protected :: &
     rdr_map(4, 4) = reshape([0, RDR_Y2X, RDR_Z2X, RDR_C2X, &
                              RDR_X2Y, 0, RDR_Z2Y, RDR_C2Y, &

--- a/src/common.f90
+++ b/src/common.f90
@@ -20,7 +20,7 @@ module m_common
                         Z_EDGE = 0010, & ! Data on edges along Z
                         none = -0001 ! The location of data isn't specified
   integer, parameter :: BC_PERIODIC = 0, BC_NEUMANN = 1, BC_DIRICHLET = 2, &
-                        BC_NULL = -1
+                        BC_HALO = -1
   integer, protected :: &
     rdr_map(4, 4) = reshape([0, RDR_Y2X, RDR_Z2X, RDR_C2X, &
                              RDR_X2Y, 0, RDR_Z2Y, RDR_C2Y, &

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -130,8 +130,8 @@ contains
   end function init
 
   subroutine alloc_cuda_tdsops( &
-    self, tdsops, dir, operation, scheme, &
-    n_halo, from_to, bc_start, bc_end, sym, c_nu, nu0_nu &
+    self, tdsops, dir, operation, scheme, bc_start, bc_end, &
+    n_halo, from_to, sym, c_nu, nu0_nu &
     )
     implicit none
 
@@ -139,8 +139,9 @@ contains
     class(tdsops_t), allocatable, intent(inout) :: tdsops
     integer, intent(in) :: dir
     character(*), intent(in) :: operation, scheme
+    integer, intent(in) :: bc_start, bc_end
     integer, optional, intent(in) :: n_halo
-    character(*), optional, intent(in) :: from_to, bc_start, bc_end
+    character(*), optional, intent(in) :: from_to
     logical, optional, intent(in) :: sym
     real(dp), optional, intent(in) :: c_nu, nu0_nu
     integer :: tds_n
@@ -152,9 +153,8 @@ contains
     type is (cuda_tdsops_t)
       tds_n = get_tds_n(self%mesh, dir, from_to)
       delta = self%mesh%geo%d(dir)
-      tdsops = cuda_tdsops_t(tds_n, delta, operation, &
-                             scheme, n_halo, from_to, &
-                             bc_start, bc_end, sym, c_nu, nu0_nu)
+      tdsops = cuda_tdsops_t(tds_n, delta, operation, scheme, bc_start, &
+                             bc_end, n_halo, from_to, sym, c_nu, nu0_nu)
     end select
 
   end subroutine alloc_cuda_tdsops

--- a/src/cuda/tdsops.f90
+++ b/src/cuda/tdsops.f90
@@ -27,11 +27,10 @@ module m_cuda_tdsops
 
 contains
 
-  function cuda_tdsops_init(n, delta, operation, scheme, n_halo, from_to, &
-                            bc_start, bc_end, sym, c_nu, nu0_nu) &
-    result(tdsops)
-      !! Constructor function for the cuda_tdsops_t class.
-      !! See tdsops_t for details.
+  function cuda_tdsops_init(n, delta, operation, scheme, bc_start, bc_end, &
+                            n_halo, from_to, sym, c_nu, nu0_nu) result(tdsops)
+    !! Constructor function for the cuda_tdsops_t class.
+    !! See tdsops_t for details.
     implicit none
 
     type(cuda_tdsops_t) :: tdsops !! return value of the function
@@ -39,16 +38,16 @@ contains
     integer, intent(in) :: n
     real(dp), intent(in) :: delta
     character(*), intent(in) :: operation, scheme
+    integer, intent(in) :: bc_start, bc_end
     integer, optional, intent(in) :: n_halo
-    character(*), optional, intent(in) :: from_to, bc_start, bc_end
+    character(*), optional, intent(in) :: from_to
     logical, optional, intent(in) :: sym
     real(dp), optional, intent(in) :: c_nu, nu0_nu
 
     integer :: n_stencil
 
-    tdsops%tdsops_t = tdsops_init(n, delta, operation, scheme, n_halo, &
-                                  from_to, bc_start, bc_end, sym, &
-                                  c_nu, nu0_nu)
+    tdsops%tdsops_t = tdsops_init(n, delta, operation, scheme, bc_start, &
+                                  bc_end, n_halo, from_to, sym, c_nu, nu0_nu)
 
     n_stencil = 2*tdsops%n_halo + 1
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -5,7 +5,7 @@ module m_mesh
   use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, &
                       CELL, VERT, X_FACE, Y_FACE, Z_FACE, &
                       X_EDGE, Y_EDGE, Z_EDGE, &
-                      BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET
+                      BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
   use m_field, only: field_t
 
   implicit none
@@ -154,14 +154,17 @@ contains
       is_first_domain = mesh%par%nrank_dir(dir) == 0
       is_last_domain = mesh%par%nrank_dir(dir) + 1 == mesh%par%nproc_dir(dir)
       ! subdomain-subdomain boundaries are identical to periodic BCs
-      if (is_first_domain) then
+      if (is_first_domain .and. is_last_domain) then
         mesh%BCs(dir, 1) = mesh%BCs_global(dir, 1)
-        mesh%BCs(dir, 2) = BC_PERIODIC
+        mesh%BCs(dir, 2) = mesh%BCs_global(dir, 2)
+      else if (is_first_domain) then
+        mesh%BCs(dir, 1) = mesh%BCs_global(dir, 1)
+        mesh%BCs(dir, 2) = BC_HALO
       else if (is_last_domain) then
-        mesh%BCs(dir, 1) = BC_PERIODIC
+        mesh%BCs(dir, 1) = BC_HALO
         mesh%BCs(dir, 2) = mesh%BCs_global(dir, 2)
       else
-        mesh%BCs(dir, :) = BC_PERIODIC
+        mesh%BCs(dir, :) = BC_HALO
       end if
     end do
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -39,8 +39,8 @@ module m_mesh
     integer, dimension(3), private :: vert_dims ! local number of vertices in each direction without padding (cartesian structure)
     integer, dimension(3), private :: cell_dims ! local number of cells in each direction without padding (cartesian structure)
     logical, dimension(3), private :: periodic_BC ! Whether or not a direction has a periodic BC
-    integer, dimension(3, 2), private :: BCs_global
-    integer, dimension(3, 2), private :: BCs
+    integer, dimension(3, 2) :: BCs_global
+    integer, dimension(3, 2) :: BCs
     integer, private :: sz
     type(geo_t), allocatable :: geo ! object containing geometry information
     type(parallel_t), allocatable :: par ! object containing parallel domain decomposition information

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -102,8 +102,8 @@ contains
   end function init
 
   subroutine alloc_omp_tdsops( &
-    self, tdsops, dir, operation, scheme, &
-    n_halo, from_to, bc_start, bc_end, sym, c_nu, nu0_nu &
+    self, tdsops, dir, operation, scheme, bc_start, bc_end, &
+    n_halo, from_to, sym, c_nu, nu0_nu &
     )
     implicit none
 
@@ -111,8 +111,9 @@ contains
     class(tdsops_t), allocatable, intent(inout) :: tdsops
     integer, intent(in) :: dir
     character(*), intent(in) :: operation, scheme
+    integer, intent(in) :: bc_start, bc_end
     integer, optional, intent(in) :: n_halo
-    character(*), optional, intent(in) :: from_to, bc_start, bc_end
+    character(*), optional, intent(in) :: from_to
     logical, optional, intent(in) :: sym
     real(dp), optional, intent(in) :: c_nu, nu0_nu
     integer :: tds_n
@@ -124,8 +125,8 @@ contains
     type is (tdsops_t)
       tds_n = get_tds_n(self%mesh, dir, from_to)
       delta = self%mesh%geo%d(dir)
-      tdsops = tdsops_t(tds_n, delta, operation, scheme, n_halo, from_to, &
-                        bc_start, bc_end, sym, c_nu, nu0_nu)
+      tdsops = tdsops_t(tds_n, delta, operation, scheme, bc_start, bc_end, &
+                        n_halo, from_to, sym, c_nu, nu0_nu)
     end select
 
   end subroutine alloc_omp_tdsops

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -182,13 +182,13 @@ contains
     ! Allocate and set the tdsops
     call allocate_tdsops(solver%xdirps, solver%backend, &
                          der1st_scheme, der2nd_scheme, &
-                         interpl_scheme, stagder_scheme)
+                         interpl_scheme, stagder_scheme, solver%mesh%BCs)
     call allocate_tdsops(solver%ydirps, solver%backend, &
                          der1st_scheme, der2nd_scheme, &
-                         interpl_scheme, stagder_scheme)
+                         interpl_scheme, stagder_scheme, solver%mesh%BCs)
     call allocate_tdsops(solver%zdirps, solver%backend, &
                          der1st_scheme, der2nd_scheme, &
-                         interpl_scheme, stagder_scheme)
+                         interpl_scheme, stagder_scheme, solver%mesh%BCs)
 
     select case (trim(poisson_solver_type))
     case ('FFT')
@@ -207,28 +207,35 @@ contains
   end function init
 
   subroutine allocate_tdsops(dirps, backend, der1st_scheme, der2nd_scheme, &
-                             interpl_scheme, stagder_scheme)
+                             interpl_scheme, stagder_scheme, BCs)
     type(dirps_t), intent(inout) :: dirps
     class(base_backend_t), intent(in) :: backend
     character(*), intent(in) :: der1st_scheme, der2nd_scheme, &
                                 interpl_scheme, stagder_scheme
+    integer, dimension(:, :), intent(in) :: BCs
 
-    call backend%alloc_tdsops(dirps%der1st, dirps%dir, &
-                              'first-deriv', der1st_scheme)
-    call backend%alloc_tdsops(dirps%der1st_sym, dirps%dir, &
-                              'first-deriv', der1st_scheme)
-    call backend%alloc_tdsops(dirps%der2nd, dirps%dir, &
-                              'second-deriv', der2nd_scheme)
-    call backend%alloc_tdsops(dirps%der2nd_sym, dirps%dir, &
-                              'second-deriv', der2nd_scheme)
-    call backend%alloc_tdsops(dirps%interpl_v2p, dirps%dir, &
-                              'interpolate', interpl_scheme, from_to='v2p')
-    call backend%alloc_tdsops(dirps%interpl_p2v, dirps%dir, &
-                              'interpolate', interpl_scheme, from_to='p2v')
-    call backend%alloc_tdsops(dirps%stagder_v2p, dirps%dir, &
-                              'stag-deriv', stagder_scheme, from_to='v2p')
-    call backend%alloc_tdsops(dirps%stagder_p2v, dirps%dir, &
-                              'stag-deriv', stagder_scheme, from_to='p2v')
+    integer :: dir, bc_start, bc_end
+
+    dir = dirps%dir
+    bc_start = BCs(dir, 1)
+    bc_end = BCs(dir, 2)
+
+    call backend%alloc_tdsops(dirps%der1st, dir, 'first-deriv', &
+                              der1st_scheme, bc_start, bc_end)
+    call backend%alloc_tdsops(dirps%der1st_sym, dir, 'first-deriv', &
+                              der1st_scheme, bc_start, bc_end)
+    call backend%alloc_tdsops(dirps%der2nd, dir, 'second-deriv', &
+                              der2nd_scheme, bc_start, bc_end)
+    call backend%alloc_tdsops(dirps%der2nd_sym, dir, 'second-deriv', &
+                              der2nd_scheme, bc_start, bc_end)
+    call backend%alloc_tdsops(dirps%interpl_v2p, dir, 'interpolate', &
+                              interpl_scheme, bc_start, bc_end, from_to='v2p')
+    call backend%alloc_tdsops(dirps%interpl_p2v, dir, 'interpolate', &
+                              interpl_scheme, bc_start, bc_end, from_to='p2v')
+    call backend%alloc_tdsops(dirps%stagder_v2p, dir, 'stag-deriv', &
+                              stagder_scheme, bc_start, bc_end, from_to='v2p')
+    call backend%alloc_tdsops(dirps%stagder_p2v, dir, 'stag-deriv', &
+                              stagder_scheme, bc_start, bc_end, from_to='p2v')
 
   end subroutine
 

--- a/src/tdsops.f90
+++ b/src/tdsops.f90
@@ -1,7 +1,8 @@
 module m_tdsops
   use iso_fortran_env, only: stderr => error_unit
 
-  use m_common, only: dp, pi, VERT, CELL, none
+  use m_common, only: dp, pi, VERT, CELL, none, &
+                      BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET
   use m_mesh, only: mesh_t
 
   implicit none
@@ -55,8 +56,8 @@ module m_tdsops
 
 contains
 
-  function tdsops_init(tds_n, delta, operation, scheme, n_halo, from_to, &
-                       bc_start, bc_end, sym, c_nu, nu0_nu) result(tdsops)
+  function tdsops_init(tds_n, delta, operation, scheme, bc_start, bc_end, &
+                       n_halo, from_to, sym, c_nu, nu0_nu) result(tdsops)
       !! Constructor function for the tdsops_t class.
       !!
       !! 'n', 'delta', 'operation', and 'scheme' are necessary arguments.
@@ -81,9 +82,9 @@ contains
     integer, intent(in) :: tds_n
     real(dp), intent(in) :: delta
     character(*), intent(in) :: operation, scheme
+    integer, intent(in) :: bc_start, bc_end !! Boundary Cond.
     integer, optional, intent(in) :: n_halo !! Number of halo cells
     character(*), optional, intent(in) :: from_to !! 'v2p' or 'p2v'
-    character(*), optional, intent(in) :: bc_start, bc_end !! Boundary Cond.
     logical, optional, intent(in) :: sym !! (==npaire), only for Neumann BCs
     real(dp), optional, intent(in) :: c_nu, nu0_nu !! params for hypervisc.
 
@@ -119,7 +120,7 @@ contains
     allocate (tdsops%coeffs_s(n_stencil, tdsops%n_halo))
     allocate (tdsops%coeffs_e(n_stencil, tdsops%n_halo))
 
-    tdsops%periodic = bc_start == 'periodic' .and. bc_end == 'periodic'
+    tdsops%periodic = bc_start == BC_PERIODIC .and. bc_end == BC_PERIODIC
 
     if (operation == 'first-deriv') then
       call tdsops%deriv_1st(delta, scheme, bc_start, bc_end, sym)
@@ -161,7 +162,7 @@ contains
     class(tdsops_t), intent(inout) :: self
     real(dp), intent(in) :: delta
     character(*), intent(in) :: scheme
-    character(*), optional, intent(in) :: bc_start, bc_end
+    integer, intent(in) :: bc_start, bc_end
     logical, optional, intent(in) :: sym
 
     real(dp), allocatable :: dist_b(:)
@@ -209,7 +210,7 @@ contains
     dist_b(:) = 1._dp
 
     select case (bc_start)
-    case ('neumann')
+    case (BC_NEUMANN)
       if (symmetry) then
         ! sym == .true.; d(uu)/dx, dv/dx, dw/dx
         !                d(vv)/dy, du/dy, dw/dy
@@ -235,7 +236,7 @@ contains
                                bfi, &
                                afi, bfi, 0._dp, 0._dp]
       end if
-    case ('dirichlet')
+    case (BC_DIRICHLET)
       ! first line
       self%dist_sa(1) = 0._dp
       self%dist_sc(1) = 2._dp
@@ -253,7 +254,7 @@ contains
     end select
 
     select case (bc_end)
-    case ('neumann')
+    case (BC_NEUMANN)
       if (symmetry) then
         ! sym == .true.; d(uu)/dx, dv/dx, dw/dx
         !                d(vv)/dy, du/dy, dw/dy
@@ -279,7 +280,7 @@ contains
                                         -bfi, &
                                         afi, 0._dp, 0._dp, 0._dp]
       end if
-    case ('dirichlet')
+    case (BC_DIRICHLET)
       ! last line
       self%dist_sa(n) = 2._dp
       self%dist_sc(n) = 0._dp
@@ -308,7 +309,7 @@ contains
     class(tdsops_t), intent(inout) :: self
     real(dp), intent(in) :: delta
     character(*), intent(in) :: scheme
-    character(*), optional, intent(in) :: bc_start, bc_end
+    integer, intent(in) :: bc_start, bc_end
     logical, optional, intent(in) :: sym
     real(dp), optional, intent(in) :: c_nu, nu0_nu
 
@@ -380,7 +381,7 @@ contains
     dist_b(:) = 1._dp
 
     select case (bc_start)
-    case ('neumann')
+    case (BC_NEUMANN)
       if (symmetry) then
         ! sym == .true.; d2v/dx2, d2w/dx2
         !                d2u/dy2, d2w/dy2
@@ -418,7 +419,7 @@ contains
                                -2*asi - 2*bsi - 2*csi - 2*dsi, &
                                asi, bsi, csi, dsi]
       end if
-    case ('dirichlet')
+    case (BC_DIRICHLET)
       ! first line
       self%dist_sa(1) = 0._dp
       self%dist_sc(1) = 11._dp
@@ -445,7 +446,7 @@ contains
     end select
 
     select case (bc_end)
-    case ('neumann')
+    case (BC_NEUMANN)
       if (symmetry) then
         ! sym == .true.; d2v/dx2, d2w/dx2
         !                d2u/dy2, d2w/dy2
@@ -483,7 +484,7 @@ contains
                                -2*asi - 2*bsi - 2*csi - 2*dsi, &
                                asi, bsi - dsi, -csi, 0._dp]
       end if
-    case ('dirichlet')
+    case (BC_DIRICHLET)
       ! last line
       self%dist_sa(n) = 11._dp
       self%dist_sc(n) = 0._dp
@@ -519,7 +520,7 @@ contains
 
     class(tdsops_t), intent(inout) :: self
     character(*), intent(in) :: scheme, from_to
-    character(*), optional, intent(in) :: bc_start, bc_end
+    integer, intent(in) :: bc_start, bc_end
     logical, optional, intent(in) :: sym
 
     real(dp), allocatable :: dist_b(:)
@@ -580,7 +581,7 @@ contains
     allocate (dist_b(n))
     dist_b(:) = 1._dp
 
-    if ((bc_start == 'dirichlet') .or. (bc_start == 'neumann')) then
+    if ((bc_start == BC_DIRICHLET) .or. (bc_start == BC_NEUMANN)) then
       self%dist_sa(1) = 0._dp
 
       select case (from_to)
@@ -614,7 +615,7 @@ contains
       end select
     end if
 
-    if ((bc_end == 'dirichlet') .or. (bc_end == 'neumann')) then
+    if ((bc_end == BC_DIRICHLET) .or. (bc_end == BC_NEUMANN)) then
       self%dist_sc(n) = 0._dp
 
       select case (from_to)
@@ -659,7 +660,7 @@ contains
     class(tdsops_t), intent(inout) :: self
     real(dp), intent(in) :: delta
     character(*), intent(in) :: scheme, from_to
-    character(*), optional, intent(in) :: bc_start, bc_end
+    integer, intent(in) :: bc_start, bc_end
     logical, optional, intent(in) :: sym
 
     real(dp), allocatable :: dist_b(:)
@@ -706,7 +707,7 @@ contains
     allocate (dist_b(n))
     dist_b(:) = 1._dp
 
-    if ((bc_start == 'dirichlet') .or. (bc_start == 'neumann')) then
+    if ((bc_start == BC_DIRICHLET) .or. (bc_start == BC_NEUMANN)) then
       self%dist_sa(1) = 0._dp
 
       select case (from_to)
@@ -731,7 +732,7 @@ contains
       end select
     end if
 
-    if ((bc_end == 'dirichlet') .or. (bc_end == 'neumann')) then
+    if ((bc_end == BC_DIRICHLET) .or. (bc_end == BC_NEUMANN)) then
       self%dist_sc(n) = 0._dp
 
       select case (from_to)

--- a/tests/cuda/test_cuda_transeq.f90
+++ b/tests/cuda/test_cuda_transeq.f90
@@ -3,7 +3,7 @@ program test_cuda_tridiag
   use cudafor
   use mpi
 
-  use m_common, only: dp, pi
+  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_NULL
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields, sendrecv_3fields
@@ -106,9 +106,11 @@ program test_cuda_tridiag
 
   ! preprocess the operator and coefficient arrays
   der1st = cuda_tdsops_t(n, dx_per, operation='first-deriv', &
-                         scheme='compact6')
+                         scheme='compact6', &
+                         bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
   der2nd = cuda_tdsops_t(n, dx_per, operation='second-deriv', &
-                         scheme='compact6')
+                         scheme='compact6', &
+                         bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
 
   blocks = dim3(n_block, 1, 1)
   threads = dim3(SZ, 1, 1)

--- a/tests/cuda/test_cuda_tridiag.f90
+++ b/tests/cuda/test_cuda_tridiag.f90
@@ -3,7 +3,7 @@ program test_cuda_tridiag
   use cudafor
   use mpi
 
-  use m_common, only: dp, pi
+  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_NULL
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
@@ -81,7 +81,8 @@ program test_cuda_tridiag
 
   ! preprocess the operator and coefficient arrays
   tdsops = cuda_tdsops_init(n, dx_per, operation='second-deriv', &
-                            scheme='compact6')
+                            scheme='compact6', &
+                            bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
 
   blocks = dim3(n_block, 1, 1)
   threads = dim3(SZ, 1, 1)

--- a/tests/cuda/test_thom.f90
+++ b/tests/cuda/test_thom.f90
@@ -2,7 +2,7 @@ program test_thom
   use iso_fortran_env, only: stderr => error_unit
   use cudafor
 
-  use m_common, only: dp, pi
+  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_NULL
   use m_cuda_common, only: SZ
   use m_cuda_exec_thom, only: exec_thom_tds_compact
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
@@ -49,7 +49,7 @@ program test_thom
   ! preprocess the operator and coefficient arrays
   tdsops = cuda_tdsops_init(n, dx_per, operation='second-deriv', &
                             scheme='compact6', &
-                            bc_start='periodic', bc_end='periodic')
+                            bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
 
   blocks = dim3(n_block, 1, 1)
   threads = dim3(SZ, 1, 1)
@@ -93,7 +93,7 @@ program test_thom
   ! preprocess the operator and coefficient arrays
   tdsops = cuda_tdsops_init(n, dx, operation='second-deriv', &
                             scheme='compact6', &
-                            bc_start='dirichlet', bc_end='dirichlet')
+                            bc_start=BC_DIRICHLET, bc_end=BC_DIRICHLET)
   call cpu_time(tstart)
   do i = 1, n_iters
     call exec_thom_tds_compact(du_dev, u_dev, tdsops, blocks, threads)

--- a/tests/omp/test_omp_dist_transeq.f90
+++ b/tests/omp/test_omp_dist_transeq.f90
@@ -2,7 +2,7 @@ program test_transeq
   use iso_fortran_env, only: stderr => error_unit
   use mpi
 
-  use m_common, only: dp, pi
+  use m_common, only: dp, pi, BC_PERIODIC
   use m_omp_common, only: SZ
   use m_omp_exec_dist, only: exec_dist_transeq_compact
   use m_omp_sendrecv, only: sendrecv_fields
@@ -88,10 +88,10 @@ program test_transeq
   allocate (d2u_recv_s(SZ, 1, n_block), d2u_recv_e(SZ, 1, n_block))
 
   ! preprocess the operator and coefficient arrays
-  der1st = tdsops_t(n, dx_per, operation='first-deriv', &
-                    scheme='compact6')
-  der2nd = tdsops_t(n, dx_per, operation='second-deriv', &
-                    scheme='compact6')
+  der1st = tdsops_t(n, dx_per, operation='first-deriv', scheme='compact6', &
+                    bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
+  der2nd = tdsops_t(n, dx_per, operation='second-deriv', scheme='compact6', &
+                    bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
 
   u_send_s(:, :, :) = u(:, 1:4, :)
   u_send_e(:, :, :) = u(:, n - n_halo + 1:n, :)

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -94,7 +94,7 @@ program test_omp_transeq
   w%data(:, :, :) = 0.d0
 
   call allocate_tdsops(xdirps, omp_backend, 'compact6', 'compact6', &
-                       'classic', 'compact6')
+                       'classic', 'compact6', mesh%BCs)
 
   call cpu_time(tstart)
   call transeq_x_omp(omp_backend, du, dv, dw, u, v, w, xdirps)

--- a/tests/omp/test_omp_tridiag.f90
+++ b/tests/omp/test_omp_tridiag.f90
@@ -3,7 +3,7 @@ program test_omp_tridiag
   use mpi
   use omp_lib
 
-  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_NULL
+  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
   use m_omp_common, only: SZ
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_exec_dist, only: exec_dist_tds_compact
@@ -143,12 +143,12 @@ program test_omp_tridiag
   if (nrank == 0) then
     bc_start = BC_DIRICHLET
   else
-    bc_start = BC_NULL
+    bc_start = BC_HALO
   end if
   if (nrank == nproc - 1) then
     bc_end = BC_NEUMANN
   else
-    bc_end = BC_NULL
+    bc_end = BC_HALO
   end if
 
   tdsops = tdsops_init(n, dx, operation='first-deriv', scheme='compact6', &


### PR DESCRIPTION
Continuation of #111. Ended up passing BCs as integer parameters.