### PR TITLE
Add a vector_calculus class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,14 @@ set(SRC
   allocator.f90
   backend.f90
   common.f90
+  field.f90
+  mesh.f90
+  ordering.f90
   poisson_fft.f90
   solver.f90
   tdsops.f90
   time_integrator.f90
-  ordering.f90
-  mesh.f90
-  field.f90
+  vector_calculus.f90
   omp/backend.f90
   omp/common.f90
   omp/kernels/distributed.f90

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -71,11 +71,10 @@ module m_base_backend
       !! transeq equation obtains the derivatives direction by
       !! direction, and the exact algorithm used to obtain these
       !! derivatives are decided at runtime. Backend implementations
-      !! are responsible from directing calls to transeq_ders into
-      !! the correct algorithm.
+      !! are responsible from directing calls to tds_solve to the
+      !! correct algorithm.
       import :: base_backend_t
       import :: field_t
-      import :: dirps_t
       import :: tdsops_t
       implicit none
 

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -67,12 +67,12 @@ module m_base_backend
   end interface
 
   abstract interface
-    subroutine tds_solve(self, du, u, dirps, tdsops)
-         !! transeq equation obtains the derivatives direction by
-         !! direction, and the exact algorithm used to obtain these
-         !! derivatives are decided at runtime. Backend implementations
-         !! are responsible from directing calls to transeq_ders into
-         !! the correct algorithm.
+    subroutine tds_solve(self, du, u, tdsops)
+      !! transeq equation obtains the derivatives direction by
+      !! direction, and the exact algorithm used to obtain these
+      !! derivatives are decided at runtime. Backend implementations
+      !! are responsible from directing calls to transeq_ders into
+      !! the correct algorithm.
       import :: base_backend_t
       import :: field_t
       import :: dirps_t
@@ -82,7 +82,6 @@ module m_base_backend
       class(base_backend_t) :: self
       class(field_t), intent(inout) :: du
       class(field_t), intent(in) :: u
-      type(dirps_t), intent(in) :: dirps
       class(tdsops_t), intent(in) :: tdsops
     end subroutine tds_solve
   end interface

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -352,35 +352,33 @@ contains
 
   end subroutine transeq_cuda_thom
 
-  subroutine tds_solve_cuda(self, du, u, dirps, tdsops)
+  subroutine tds_solve_cuda(self, du, u, tdsops)
     implicit none
 
     class(cuda_backend_t) :: self
     class(field_t), intent(inout) :: du
     class(field_t), intent(in) :: u
-    type(dirps_t), intent(in) :: dirps
     class(tdsops_t), intent(in) :: tdsops
 
     type(dim3) :: blocks, threads
 
     ! Check if direction matches for both in/out fields and dirps
-    if (dirps%dir /= du%dir .or. u%dir /= du%dir) then
-      error stop 'DIR mismatch between fields and dirps in tds_solve.'
+    if (u%dir /= du%dir) then
+      error stop 'DIR mismatch between fields in tds_solve.'
     end if
 
     blocks = dim3(self%mesh%get_n_groups(u), 1, 1); threads = dim3(SZ, 1, 1)
 
-    call tds_solve_dist(self, du, u, dirps, tdsops, blocks, threads)
+    call tds_solve_dist(self, du, u, tdsops, blocks, threads)
 
   end subroutine tds_solve_cuda
 
-  subroutine tds_solve_dist(self, du, u, dirps, tdsops, blocks, threads)
+  subroutine tds_solve_dist(self, du, u, tdsops, blocks, threads)
     implicit none
 
     class(cuda_backend_t) :: self
     class(field_t), intent(inout) :: du
     class(field_t), intent(in) :: u
-    type(dirps_t), intent(in) :: dirps
     class(tdsops_t), intent(in) :: tdsops
     type(dim3), intent(in) :: blocks, threads
 

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -270,31 +270,29 @@ contains
 
   end subroutine transeq_dist_component
 
-  subroutine tds_solve_omp(self, du, u, dirps, tdsops)
+  subroutine tds_solve_omp(self, du, u, tdsops)
     implicit none
 
     class(omp_backend_t) :: self
     class(field_t), intent(inout) :: du
     class(field_t), intent(in) :: u
-    type(dirps_t), intent(in) :: dirps
     class(tdsops_t), intent(in) :: tdsops
 
-    ! Check if direction matches for both in/out fields and dirps
-    if (dirps%dir /= du%dir .or. u%dir /= du%dir) then
-      error stop 'DIR mismatch between fields and dirps in tds_solve.'
+    ! Check if direction matches for both in/out fields
+    if (u%dir /= du%dir) then
+      error stop 'DIR mismatch between fields in tds_solve.'
     end if
 
-    call tds_solve_dist(self, du, u, dirps, tdsops)
+    call tds_solve_dist(self, du, u, tdsops)
 
   end subroutine tds_solve_omp
 
-  subroutine tds_solve_dist(self, du, u, dirps, tdsops)
+  subroutine tds_solve_dist(self, du, u, tdsops)
     implicit none
 
     class(omp_backend_t) :: self
     class(field_t), intent(inout) :: du
     class(field_t), intent(in) :: u
-    type(dirps_t), intent(in) :: dirps
     class(tdsops_t), intent(in) :: tdsops
     integer :: n_halo, n_groups, dir
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -325,7 +325,7 @@ contains
     class(field_t), intent(inout) :: div_u
     class(field_t), intent(in) :: u, v, w
 
-    call self%vector_calculus%divergence_v2p( &
+    call self%vector_calculus%divergence_v2c( &
       div_u, u, v, w, &
       self%xdirps%stagder_v2p, self%xdirps%interpl_v2p, &
       self%ydirps%stagder_v2p, self%ydirps%interpl_v2p, &
@@ -342,7 +342,7 @@ contains
     class(field_t), intent(inout) :: dpdx, dpdy, dpdz
     class(field_t), intent(in) :: pressure
 
-    call self%vector_calculus%gradient_p2v( &
+    call self%vector_calculus%gradient_c2v( &
       dpdx, dpdy, dpdz, pressure, &
       self%xdirps%stagder_p2v, self%xdirps%interpl_p2v, &
       self%ydirps%stagder_p2v, self%ydirps%interpl_p2v, &

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -333,12 +333,9 @@ contains
     ! Staggared der for u field in x
     ! Interpolation for v field in x
     ! Interpolation for w field in x
-    call self%backend%tds_solve(du_x, u, self%xdirps, &
-                                self%xdirps%stagder_v2p)
-    call self%backend%tds_solve(dv_x, v, self%xdirps, &
-                                self%xdirps%interpl_v2p)
-    call self%backend%tds_solve(dw_x, w, self%xdirps, &
-                                self%xdirps%interpl_v2p)
+    call self%backend%tds_solve(du_x, u, self%xdirps%stagder_v2p)
+    call self%backend%tds_solve(dv_x, v, self%xdirps%interpl_v2p)
+    call self%backend%tds_solve(dw_x, w, self%xdirps%interpl_v2p)
 
     ! request fields from the allocator
     u_y => self%backend%allocator%get_block(DIR_Y, VERT)
@@ -359,12 +356,9 @@ contains
     dw_y => self%backend%allocator%get_block(DIR_Y)
 
     ! similar to the x direction, obtain derivatives in y.
-    call self%backend%tds_solve(du_y, u_y, self%ydirps, &
-                                self%ydirps%interpl_v2p)
-    call self%backend%tds_solve(dv_y, v_y, self%ydirps, &
-                                self%ydirps%stagder_v2p)
-    call self%backend%tds_solve(dw_y, w_y, self%ydirps, &
-                                self%ydirps%interpl_v2p)
+    call self%backend%tds_solve(du_y, u_y, self%ydirps%interpl_v2p)
+    call self%backend%tds_solve(dv_y, v_y, self%ydirps%stagder_v2p)
+    call self%backend%tds_solve(dw_y, w_y, self%ydirps%interpl_v2p)
 
     ! we don't need the velocities in y orientation any more, so release
     ! them to open up space.
@@ -393,10 +387,8 @@ contains
     dw_z => self%backend%allocator%get_block(DIR_Z)
 
     ! get the derivatives in z
-    call self%backend%tds_solve(div_u, u_z, self%zdirps, &
-                                self%zdirps%interpl_v2p)
-    call self%backend%tds_solve(dw_z, w_z, self%zdirps, &
-                                self%zdirps%stagder_v2p)
+    call self%backend%tds_solve(div_u, u_z, self%zdirps%interpl_v2p)
+    call self%backend%tds_solve(dw_z, w_z, self%zdirps%stagder_v2p)
 
     ! div_u = div_u + dw_z
     call self%backend%vecadd(1._dp, dw_z, 1._dp, div_u)
@@ -429,10 +421,8 @@ contains
 
     ! Staggared der for pressure field in z
     ! Interpolation for pressure field in z
-    call self%backend%tds_solve(p_sxy_z, pressure, self%zdirps, &
-                                self%zdirps%interpl_p2v)
-    call self%backend%tds_solve(dpdz_sxy_z, pressure, self%zdirps, &
-                                self%zdirps%stagder_p2v)
+    call self%backend%tds_solve(p_sxy_z, pressure, self%zdirps%interpl_p2v)
+    call self%backend%tds_solve(dpdz_sxy_z, pressure, self%zdirps%stagder_p2v)
 
     ! request fields from the allocator
     p_sxy_y => self%backend%allocator%get_block(DIR_Y)
@@ -450,12 +440,9 @@ contains
     dpdz_sx_y => self%backend%allocator%get_block(DIR_Y)
 
     ! similar to the z direction, obtain derivatives in y.
-    call self%backend%tds_solve(p_sx_y, p_sxy_y, self%ydirps, &
-                                self%ydirps%interpl_p2v)
-    call self%backend%tds_solve(dpdy_sx_y, p_sxy_y, self%ydirps, &
-                                self%ydirps%stagder_p2v)
-    call self%backend%tds_solve(dpdz_sx_y, dpdz_sxy_y, self%ydirps, &
-                                self%ydirps%interpl_p2v)
+    call self%backend%tds_solve(p_sx_y, p_sxy_y, self%ydirps%interpl_p2v)
+    call self%backend%tds_solve(dpdy_sx_y, p_sxy_y, self%ydirps%stagder_p2v)
+    call self%backend%tds_solve(dpdz_sx_y, dpdz_sxy_y, self%ydirps%interpl_p2v)
 
     ! release memory
     call self%backend%allocator%release_block(p_sxy_y)
@@ -477,12 +464,9 @@ contains
     call self%backend%allocator%release_block(dpdz_sx_y)
 
     ! get the derivatives in x
-    call self%backend%tds_solve(dpdx, p_sx_x, self%xdirps, &
-                                self%xdirps%stagder_p2v)
-    call self%backend%tds_solve(dpdy, dpdy_sx_x, self%xdirps, &
-                                self%xdirps%interpl_p2v)
-    call self%backend%tds_solve(dpdz, dpdz_sx_x, self%xdirps, &
-                                self%xdirps%interpl_p2v)
+    call self%backend%tds_solve(dpdx, p_sx_x, self%xdirps%stagder_p2v)
+    call self%backend%tds_solve(dpdy, dpdy_sx_x, self%xdirps%interpl_p2v)
+    call self%backend%tds_solve(dpdz, dpdz_sx_x, self%xdirps%interpl_p2v)
 
     ! release temporary x fields
     call self%backend%allocator%release_block(p_sx_x)
@@ -513,7 +497,7 @@ contains
     w_y => self%backend%allocator%get_block(DIR_Y, VERT)
     dwdy_y => self%backend%allocator%get_block(DIR_Y)
     call self%backend%reorder(w_y, w, RDR_X2Y)
-    call self%backend%tds_solve(dwdy_y, w_y, self%ydirps, self%ydirps%der1st)
+    call self%backend%tds_solve(dwdy_y, w_y, self%ydirps%der1st)
 
     call self%backend%reorder(o_i_hat, dwdy_y, RDR_Y2X)
 
@@ -524,7 +508,7 @@ contains
     v_z => self%backend%allocator%get_block(DIR_Z)
     dvdz_z => self%backend%allocator%get_block(DIR_Z)
     call self%backend%reorder(v_z, v, RDR_X2Z)
-    call self%backend%tds_solve(dvdz_z, v_z, self%zdirps, self%zdirps%der1st)
+    call self%backend%tds_solve(dvdz_z, v_z, self%zdirps%der1st)
 
     dvdz_x => self%backend%allocator%get_block(DIR_X)
     call self%backend%reorder(dvdz_x, dvdz_z, RDR_Z2X)
@@ -542,7 +526,7 @@ contains
     u_z => self%backend%allocator%get_block(DIR_Z, VERT)
     dudz_z => self%backend%allocator%get_block(DIR_Z)
     call self%backend%reorder(u_z, u, RDR_X2Z)
-    call self%backend%tds_solve(dudz_z, u_z, self%zdirps, self%zdirps%der1st)
+    call self%backend%tds_solve(dudz_z, u_z, self%zdirps%der1st)
 
     dudz_x => self%backend%allocator%get_block(DIR_X)
     call self%backend%reorder(dudz_x, dudz_z, RDR_Z2X)
@@ -551,7 +535,7 @@ contains
     call self%backend%allocator%release_block(dudz_z)
 
     ! dw/dx
-    call self%backend%tds_solve(o_j_hat, w, self%xdirps, self%xdirps%der1st)
+    call self%backend%tds_solve(o_j_hat, w, self%xdirps%der1st)
 
     ! omega_j_hat = du/dz - dw/dx
     call self%backend%vecadd(1._dp, dudz_x, -1._dp, o_j_hat)
@@ -560,13 +544,13 @@ contains
 
     ! omega_k_hat
     ! dv/dx
-    call self%backend%tds_solve(o_k_hat, v, self%xdirps, self%xdirps%der1st)
+    call self%backend%tds_solve(o_k_hat, v, self%xdirps%der1st)
 
     ! du/dy
     u_y => self%backend%allocator%get_block(DIR_Y, VERT)
     dudy_y => self%backend%allocator%get_block(DIR_Y)
     call self%backend%reorder(u_y, u, RDR_X2Y)
-    call self%backend%tds_solve(dudy_y, u_y, self%ydirps, self%ydirps%der1st)
+    call self%backend%tds_solve(dudy_y, u_y, self%ydirps%der1st)
 
     dudy_x => self%backend%allocator%get_block(DIR_X)
     call self%backend%reorder(dudy_x, dudy_y, RDR_Y2X)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -10,6 +10,7 @@ module m_solver
                       DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, CELL
   use m_tdsops, only: tdsops_t, dirps_t
   use m_time_integrator, only: time_intg_t
+  use m_vector_calculus, only: vector_calculus_t
   use m_mesh, only: mesh_t
 
   implicit none
@@ -53,6 +54,7 @@ module m_solver
     type(time_intg_t) :: time_integrator
     type(allocator_t), pointer :: host_allocator
     type(dirps_t), pointer :: xdirps, ydirps, zdirps
+    type(vector_calculus_t) :: vector_calculus
     procedure(poisson_solver), pointer :: poisson => null()
   contains
     procedure :: transeq
@@ -114,6 +116,8 @@ contains
     solver%xdirps%dir = DIR_X
     solver%ydirps%dir = DIR_Y
     solver%zdirps%dir = DIR_Z
+
+    solver%vector_calculus = vector_calculus_t(solver%backend)
 
     solver%u => solver%backend%allocator%get_block(DIR_X, VERT)
     solver%v => solver%backend%allocator%get_block(DIR_X, VERT)
@@ -314,170 +318,41 @@ contains
   end subroutine transeq
 
   subroutine divergence_v2p(self, div_u, u, v, w)
-      !! Divergence of a vector field (u, v, w).
-      !! Inputs from velocity grid and outputs to pressure grid.
+    !! Wrapper for divergence_v2p
     implicit none
 
     class(solver_t) :: self
     class(field_t), intent(inout) :: div_u
     class(field_t), intent(in) :: u, v, w
 
-    class(field_t), pointer :: du_x, dv_x, dw_x, &
-      u_y, v_y, w_y, du_y, dv_y, dw_y, &
-      u_z, w_z, dw_z
-
-    du_x => self%backend%allocator%get_block(DIR_X)
-    dv_x => self%backend%allocator%get_block(DIR_X)
-    dw_x => self%backend%allocator%get_block(DIR_X)
-
-    ! Staggared der for u field in x
-    ! Interpolation for v field in x
-    ! Interpolation for w field in x
-    call self%backend%tds_solve(du_x, u, self%xdirps%stagder_v2p)
-    call self%backend%tds_solve(dv_x, v, self%xdirps%interpl_v2p)
-    call self%backend%tds_solve(dw_x, w, self%xdirps%interpl_v2p)
-
-    ! request fields from the allocator
-    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    v_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
-
-    ! reorder data from x orientation to y orientation
-    call self%backend%reorder(u_y, du_x, RDR_X2Y)
-    call self%backend%reorder(v_y, dv_x, RDR_X2Y)
-    call self%backend%reorder(w_y, dw_x, RDR_X2Y)
-
-    call self%backend%allocator%release_block(du_x)
-    call self%backend%allocator%release_block(dv_x)
-    call self%backend%allocator%release_block(dw_x)
-
-    du_y => self%backend%allocator%get_block(DIR_Y)
-    dv_y => self%backend%allocator%get_block(DIR_Y)
-    dw_y => self%backend%allocator%get_block(DIR_Y)
-
-    ! similar to the x direction, obtain derivatives in y.
-    call self%backend%tds_solve(du_y, u_y, self%ydirps%interpl_v2p)
-    call self%backend%tds_solve(dv_y, v_y, self%ydirps%stagder_v2p)
-    call self%backend%tds_solve(dw_y, w_y, self%ydirps%interpl_v2p)
-
-    ! we don't need the velocities in y orientation any more, so release
-    ! them to open up space.
-    ! It is important that this doesn't actually deallocate any memory,
-    ! it just makes the corresponding memory space available for use.
-    call self%backend%allocator%release_block(u_y)
-    call self%backend%allocator%release_block(v_y)
-    call self%backend%allocator%release_block(w_y)
-
-    ! just like in y direction, get some fields for the z derivatives.
-    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
-    w_z => self%backend%allocator%get_block(DIR_Z, VERT)
-
-    ! du_y = dv_y + du_y
-    call self%backend%vecadd(1._dp, dv_y, 1._dp, du_y)
-
-    ! reorder from y to z
-    call self%backend%reorder(u_z, du_y, RDR_Y2Z)
-    call self%backend%reorder(w_z, dw_y, RDR_Y2Z)
-
-    ! release all the unnecessary blocks.
-    call self%backend%allocator%release_block(du_y)
-    call self%backend%allocator%release_block(dv_y)
-    call self%backend%allocator%release_block(dw_y)
-
-    dw_z => self%backend%allocator%get_block(DIR_Z)
-
-    ! get the derivatives in z
-    call self%backend%tds_solve(div_u, u_z, self%zdirps%interpl_v2p)
-    call self%backend%tds_solve(dw_z, w_z, self%zdirps%stagder_v2p)
-
-    ! div_u = div_u + dw_z
-    call self%backend%vecadd(1._dp, dw_z, 1._dp, div_u)
-
-    ! div_u array is in z orientation
-
-    ! there is no need to keep velocities in z orientation around, so release
-    call self%backend%allocator%release_block(u_z)
-    call self%backend%allocator%release_block(w_z)
-    call self%backend%allocator%release_block(dw_z)
+    call self%vector_calculus%divergence_v2p( &
+      div_u, u, v, w, &
+      self%xdirps%stagder_v2p, self%xdirps%interpl_v2p, &
+      self%ydirps%stagder_v2p, self%ydirps%interpl_v2p, &
+      self%zdirps%stagder_v2p, self%zdirps%interpl_v2p &
+      )
 
   end subroutine divergence_v2p
 
   subroutine gradient_p2v(self, dpdx, dpdy, dpdz, pressure)
-      !! Gradient of a scalar field 'pressure'.
-      !! Inputs from pressure grid and outputs to velocity grid.
+    !! Wrapper for gradient_p2v
     implicit none
 
     class(solver_t) :: self
     class(field_t), intent(inout) :: dpdx, dpdy, dpdz
     class(field_t), intent(in) :: pressure
 
-    class(field_t), pointer :: p_sxy_z, dpdz_sxy_z, &
-      p_sxy_y, dpdz_sxy_y, &
-      p_sx_y, dpdy_sx_y, dpdz_sx_y, &
-      p_sx_x, dpdy_sx_x, dpdz_sx_x
-
-    p_sxy_z => self%backend%allocator%get_block(DIR_Z)
-    dpdz_sxy_z => self%backend%allocator%get_block(DIR_Z)
-
-    ! Staggared der for pressure field in z
-    ! Interpolation for pressure field in z
-    call self%backend%tds_solve(p_sxy_z, pressure, self%zdirps%interpl_p2v)
-    call self%backend%tds_solve(dpdz_sxy_z, pressure, self%zdirps%stagder_p2v)
-
-    ! request fields from the allocator
-    p_sxy_y => self%backend%allocator%get_block(DIR_Y)
-    dpdz_sxy_y => self%backend%allocator%get_block(DIR_Y)
-
-    ! reorder data from z orientation to y orientation
-    call self%backend%reorder(p_sxy_y, p_sxy_z, RDR_Z2Y)
-    call self%backend%reorder(dpdz_sxy_y, dpdz_sxy_z, RDR_Z2Y)
-
-    call self%backend%allocator%release_block(p_sxy_z)
-    call self%backend%allocator%release_block(dpdz_sxy_z)
-
-    p_sx_y => self%backend%allocator%get_block(DIR_Y)
-    dpdy_sx_y => self%backend%allocator%get_block(DIR_Y)
-    dpdz_sx_y => self%backend%allocator%get_block(DIR_Y)
-
-    ! similar to the z direction, obtain derivatives in y.
-    call self%backend%tds_solve(p_sx_y, p_sxy_y, self%ydirps%interpl_p2v)
-    call self%backend%tds_solve(dpdy_sx_y, p_sxy_y, self%ydirps%stagder_p2v)
-    call self%backend%tds_solve(dpdz_sx_y, dpdz_sxy_y, self%ydirps%interpl_p2v)
-
-    ! release memory
-    call self%backend%allocator%release_block(p_sxy_y)
-    call self%backend%allocator%release_block(dpdz_sxy_y)
-
-    ! just like in y direction, get some fields for the x derivatives.
-    p_sx_x => self%backend%allocator%get_block(DIR_X)
-    dpdy_sx_x => self%backend%allocator%get_block(DIR_X)
-    dpdz_sx_x => self%backend%allocator%get_block(DIR_X)
-
-    ! reorder from y to x
-    call self%backend%reorder(p_sx_x, p_sx_y, RDR_Y2X)
-    call self%backend%reorder(dpdy_sx_x, dpdy_sx_y, RDR_Y2X)
-    call self%backend%reorder(dpdz_sx_x, dpdz_sx_y, RDR_Y2X)
-
-    ! release all the y directional fields.
-    call self%backend%allocator%release_block(p_sx_y)
-    call self%backend%allocator%release_block(dpdy_sx_y)
-    call self%backend%allocator%release_block(dpdz_sx_y)
-
-    ! get the derivatives in x
-    call self%backend%tds_solve(dpdx, p_sx_x, self%xdirps%stagder_p2v)
-    call self%backend%tds_solve(dpdy, dpdy_sx_x, self%xdirps%interpl_p2v)
-    call self%backend%tds_solve(dpdz, dpdz_sx_x, self%xdirps%interpl_p2v)
-
-    ! release temporary x fields
-    call self%backend%allocator%release_block(p_sx_x)
-    call self%backend%allocator%release_block(dpdy_sx_x)
-    call self%backend%allocator%release_block(dpdz_sx_x)
+    call self%vector_calculus%gradient_p2v( &
+      dpdx, dpdy, dpdz, pressure, &
+      self%xdirps%stagder_p2v, self%xdirps%interpl_p2v, &
+      self%ydirps%stagder_p2v, self%ydirps%interpl_p2v, &
+      self%zdirps%stagder_p2v, self%zdirps%interpl_p2v &
+      )
 
   end subroutine gradient_p2v
 
   subroutine curl(self, o_i_hat, o_j_hat, o_k_hat, u, v, w)
-      !! Curl of a vector field (u, v, w).
-      !! Inputs from velocity grid and outputs to velocity grid.
+    !! Wrapper for curl
     implicit none
 
     class(solver_t) :: self
@@ -485,83 +360,10 @@ contains
     class(field_t), intent(inout) :: o_i_hat, o_j_hat, o_k_hat
     class(field_t), intent(in) :: u, v, w
 
-    class(field_t), pointer :: u_y, u_z, v_z, w_y, dwdy_y, dvdz_z, dvdz_x, &
-      dudz_z, dudz_x, dudy_y, dudy_x
-
-    ! omega_i_hat = dw/dy - dv/dz
-    ! omega_j_hat = du/dz - dw/dx
-    ! omega_k_hat = dv/dx - du/dy
-
-    ! omega_i_hat
-    ! dw/dy
-    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    dwdy_y => self%backend%allocator%get_block(DIR_Y)
-    call self%backend%reorder(w_y, w, RDR_X2Y)
-    call self%backend%tds_solve(dwdy_y, w_y, self%ydirps%der1st)
-
-    call self%backend%reorder(o_i_hat, dwdy_y, RDR_Y2X)
-
-    call self%backend%allocator%release_block(w_y)
-    call self%backend%allocator%release_block(dwdy_y)
-
-    ! dv/dz
-    v_z => self%backend%allocator%get_block(DIR_Z)
-    dvdz_z => self%backend%allocator%get_block(DIR_Z)
-    call self%backend%reorder(v_z, v, RDR_X2Z)
-    call self%backend%tds_solve(dvdz_z, v_z, self%zdirps%der1st)
-
-    dvdz_x => self%backend%allocator%get_block(DIR_X)
-    call self%backend%reorder(dvdz_x, dvdz_z, RDR_Z2X)
-
-    call self%backend%allocator%release_block(v_z)
-    call self%backend%allocator%release_block(dvdz_z)
-
-    ! omega_i_hat = dw/dy - dv/dz
-    call self%backend%vecadd(-1._dp, dvdz_x, 1._dp, o_i_hat)
-
-    call self%backend%allocator%release_block(dvdz_x)
-
-    ! omega_j_hat
-    ! du/dz
-    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
-    dudz_z => self%backend%allocator%get_block(DIR_Z)
-    call self%backend%reorder(u_z, u, RDR_X2Z)
-    call self%backend%tds_solve(dudz_z, u_z, self%zdirps%der1st)
-
-    dudz_x => self%backend%allocator%get_block(DIR_X)
-    call self%backend%reorder(dudz_x, dudz_z, RDR_Z2X)
-
-    call self%backend%allocator%release_block(u_z)
-    call self%backend%allocator%release_block(dudz_z)
-
-    ! dw/dx
-    call self%backend%tds_solve(o_j_hat, w, self%xdirps%der1st)
-
-    ! omega_j_hat = du/dz - dw/dx
-    call self%backend%vecadd(1._dp, dudz_x, -1._dp, o_j_hat)
-
-    call self%backend%allocator%release_block(dudz_x)
-
-    ! omega_k_hat
-    ! dv/dx
-    call self%backend%tds_solve(o_k_hat, v, self%xdirps%der1st)
-
-    ! du/dy
-    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    dudy_y => self%backend%allocator%get_block(DIR_Y)
-    call self%backend%reorder(u_y, u, RDR_X2Y)
-    call self%backend%tds_solve(dudy_y, u_y, self%ydirps%der1st)
-
-    dudy_x => self%backend%allocator%get_block(DIR_X)
-    call self%backend%reorder(dudy_x, dudy_y, RDR_Y2X)
-
-    call self%backend%allocator%release_block(u_y)
-    call self%backend%allocator%release_block(dudy_y)
-
-    ! omega_k_hat = dv/dx - du/dy
-    call self%backend%vecadd(-1._dp, dudy_x, 1._dp, o_k_hat)
-
-    call self%backend%allocator%release_block(dudy_x)
+    call self%vector_calculus%curl( &
+      o_i_hat, o_j_hat, o_k_hat, u, v, w, &
+      self%xdirps%der1st, self%ydirps%der1st, self%zdirps%der1st &
+      )
 
   end subroutine curl
 

--- a/src/vector_calculus.f90
+++ b/src/vector_calculus.f90
@@ -19,7 +19,7 @@ module m_vector_calculus
 
   interface vector_calculus_t
     module procedure init
-  end interface vector_calculus_t 
+  end interface vector_calculus_t
 
 contains
 
@@ -33,7 +33,8 @@ contains
 
   end function init
 
-  subroutine curl(self, o_i_hat, o_j_hat, o_k_hat, u, v, w, x_der1st, y_der1st, z_der1st)
+  subroutine curl(self, o_i_hat, o_j_hat, o_k_hat, u, v, w, &
+                  x_der1st, y_der1st, z_der1st)
     !! Curl of a vector field (u, v, w).
     !! Inputs from velocity grid and outputs to velocity grid.
     implicit none
@@ -124,8 +125,10 @@ contains
 
   end subroutine curl
 
-  subroutine divergence_v2p(self, div_u, u, v, w, x_stagder_v2p, x_interpl_v2p, &
-                            y_stagder_v2p, y_interpl_v2p, z_stagder_v2p, z_interpl_v2p)
+  subroutine divergence_v2p(self, div_u, u, v, w, &
+                            x_stagder_v2p, x_interpl_v2p, &
+                            y_stagder_v2p, y_interpl_v2p, &
+                            z_stagder_v2p, z_interpl_v2p)
     !! Divergence of a vector field (u, v, w).
     !! Inputs from velocity grid and outputs to pressure grid.
     implicit none
@@ -134,8 +137,8 @@ contains
     class(field_t), intent(inout) :: div_u
     class(field_t), intent(in) :: u, v, w
     class(tdsops_t), intent(in) :: x_stagder_v2p, x_interpl_v2p, &
-                                   y_stagder_v2p, y_interpl_v2p, &
-                                   z_stagder_v2p, z_interpl_v2p
+      y_stagder_v2p, y_interpl_v2p, &
+      z_stagder_v2p, z_interpl_v2p
 
     class(field_t), pointer :: du_x, dv_x, dw_x, &
       u_y, v_y, w_y, du_y, dv_y, dw_y, &
@@ -229,8 +232,8 @@ contains
     class(field_t), intent(inout) :: dpdx, dpdy, dpdz
     class(field_t), intent(in) :: pressure
     class(tdsops_t), intent(in) :: x_stagder_p2v, x_interpl_p2v, &
-                                   y_stagder_p2v, y_interpl_p2v, &
-                                   z_stagder_p2v, z_interpl_p2v
+      y_stagder_p2v, y_interpl_p2v, &
+      z_stagder_p2v, z_interpl_p2v
 
     class(field_t), pointer :: p_sxy_z, dpdz_sxy_z, &
       p_sxy_y, dpdz_sxy_y, &

--- a/src/vector_calculus.f90
+++ b/src/vector_calculus.f90
@@ -1,5 +1,5 @@
 module m_vector_calculus
-  use m_alllocator, only: allocator_t, field_t
+  use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
   use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y
@@ -54,7 +54,7 @@ contains
 
     ! omega_i_hat
     ! dw/dy
-    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    w_y => self%backend%allocator%get_block(DIR_Y)
     dwdy_y => self%backend%allocator%get_block(DIR_Y)
     call self%backend%reorder(w_y, w, RDR_X2Y)
     call self%backend%tds_solve(dwdy_y, w_y, y_der1st)
@@ -83,7 +83,7 @@ contains
 
     ! omega_j_hat
     ! du/dz
-    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
+    u_z => self%backend%allocator%get_block(DIR_Z)
     dudz_z => self%backend%allocator%get_block(DIR_Z)
     call self%backend%reorder(u_z, u, RDR_X2Z)
     call self%backend%tds_solve(dudz_z, u_z, z_der1st)
@@ -107,7 +107,7 @@ contains
     call self%backend%tds_solve(o_k_hat, v, x_der1st)
 
     ! du/dy
-    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    u_y => self%backend%allocator%get_block(DIR_Y)
     dudy_y => self%backend%allocator%get_block(DIR_Y)
     call self%backend%reorder(u_y, u, RDR_X2Y)
     call self%backend%tds_solve(dudy_y, u_y, y_der1st)
@@ -156,9 +156,9 @@ contains
     call self%backend%tds_solve(dw_x, w, x_interpl_v2p)
 
     ! request fields from the allocator
-    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    v_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    u_y => self%backend%allocator%get_block(DIR_Y)
+    v_y => self%backend%allocator%get_block(DIR_Y)
+    w_y => self%backend%allocator%get_block(DIR_Y)
 
     ! reorder data from x orientation to y orientation
     call self%backend%reorder(u_y, du_x, RDR_X2Y)
@@ -187,8 +187,8 @@ contains
     call self%backend%allocator%release_block(w_y)
 
     ! just like in y direction, get some fields for the z derivatives.
-    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
-    w_z => self%backend%allocator%get_block(DIR_Z, VERT)
+    u_z => self%backend%allocator%get_block(DIR_Z)
+    w_z => self%backend%allocator%get_block(DIR_Z)
 
     ! du_y = dv_y + du_y
     call self%backend%vecadd(1._dp, dv_y, 1._dp, du_y)
@@ -306,7 +306,7 @@ contains
     class(field_t), intent(inout) :: lapl_u
     class(field_t), intent(in) :: u
 
-    class(tdsops_t), intent(in) :: x_der1st, y_der1st, z_der2nd
+    class(tdsops_t), intent(in) :: x_der2nd, y_der2nd, z_der2nd
 
     class(field_t), pointer :: u_y, d2u_y, u_z, d2u_z
 

--- a/src/vector_calculus.f90
+++ b/src/vector_calculus.f90
@@ -1,0 +1,298 @@
+module m_vector_calculus
+  use m_alllocator, only: allocator_t, field_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, &
+                      RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y
+  use m_tdsops, only: tdsops_t
+
+  implicit none
+
+  type :: vector_calculus_t
+    !! Defines vector calculus operators
+    class(base_backend_t), pointer :: backend
+  contains
+    procedure :: curl
+    procedure :: divergence_v2p
+    procedure :: gradient_p2v
+  end type vector_calculus_t
+
+  interface vector_calculus_t
+    module procedure init
+  end interface vector_calculus_t 
+
+contains
+
+  function init(backend) result(vector_calculus)
+    implicit none
+
+    class(base_backend_t), target, intent(inout) :: backend
+    type(vector_calculus_t) :: vector_calculus
+
+    vector_calculus%backend => backend
+
+  end function init
+
+  subroutine curl(self, o_i_hat, o_j_hat, o_k_hat, u, v, w, x_der1st, y_der1st, z_der1st)
+    !! Curl of a vector field (u, v, w).
+    !! Inputs from velocity grid and outputs to velocity grid.
+    implicit none
+
+    class(vector_calculus_t) :: self
+    !> Vector components of the output vector field Omega
+    class(field_t), intent(inout) :: o_i_hat, o_j_hat, o_k_hat
+    class(field_t), intent(in) :: u, v, w
+    class(tdsops_t), intent(in) :: x_der1st, y_der1st, z_der1st
+
+    class(field_t), pointer :: u_y, u_z, v_z, w_y, dwdy_y, dvdz_z, dvdz_x, &
+      dudz_z, dudz_x, dudy_y, dudy_x
+
+    ! omega_i_hat = dw/dy - dv/dz
+    ! omega_j_hat = du/dz - dw/dx
+    ! omega_k_hat = dv/dx - du/dy
+
+    ! omega_i_hat
+    ! dw/dy
+    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    dwdy_y => self%backend%allocator%get_block(DIR_Y)
+    call self%backend%reorder(w_y, w, RDR_X2Y)
+    call self%backend%tds_solve(dwdy_y, w_y, y_der1st)
+
+    call self%backend%reorder(o_i_hat, dwdy_y, RDR_Y2X)
+
+    call self%backend%allocator%release_block(w_y)
+    call self%backend%allocator%release_block(dwdy_y)
+
+    ! dv/dz
+    v_z => self%backend%allocator%get_block(DIR_Z)
+    dvdz_z => self%backend%allocator%get_block(DIR_Z)
+    call self%backend%reorder(v_z, v, RDR_X2Z)
+    call self%backend%tds_solve(dvdz_z, v_z, z_der1st)
+
+    dvdz_x => self%backend%allocator%get_block(DIR_X)
+    call self%backend%reorder(dvdz_x, dvdz_z, RDR_Z2X)
+
+    call self%backend%allocator%release_block(v_z)
+    call self%backend%allocator%release_block(dvdz_z)
+
+    ! omega_i_hat = dw/dy - dv/dz
+    call self%backend%vecadd(-1._dp, dvdz_x, 1._dp, o_i_hat)
+
+    call self%backend%allocator%release_block(dvdz_x)
+
+    ! omega_j_hat
+    ! du/dz
+    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
+    dudz_z => self%backend%allocator%get_block(DIR_Z)
+    call self%backend%reorder(u_z, u, RDR_X2Z)
+    call self%backend%tds_solve(dudz_z, u_z, z_der1st)
+
+    dudz_x => self%backend%allocator%get_block(DIR_X)
+    call self%backend%reorder(dudz_x, dudz_z, RDR_Z2X)
+
+    call self%backend%allocator%release_block(u_z)
+    call self%backend%allocator%release_block(dudz_z)
+
+    ! dw/dx
+    call self%backend%tds_solve(o_j_hat, w, x_der1st)
+
+    ! omega_j_hat = du/dz - dw/dx
+    call self%backend%vecadd(1._dp, dudz_x, -1._dp, o_j_hat)
+
+    call self%backend%allocator%release_block(dudz_x)
+
+    ! omega_k_hat
+    ! dv/dx
+    call self%backend%tds_solve(o_k_hat, v, x_der1st)
+
+    ! du/dy
+    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    dudy_y => self%backend%allocator%get_block(DIR_Y)
+    call self%backend%reorder(u_y, u, RDR_X2Y)
+    call self%backend%tds_solve(dudy_y, u_y, y_der1st)
+
+    dudy_x => self%backend%allocator%get_block(DIR_X)
+    call self%backend%reorder(dudy_x, dudy_y, RDR_Y2X)
+
+    call self%backend%allocator%release_block(u_y)
+    call self%backend%allocator%release_block(dudy_y)
+
+    ! omega_k_hat = dv/dx - du/dy
+    call self%backend%vecadd(-1._dp, dudy_x, 1._dp, o_k_hat)
+
+    call self%backend%allocator%release_block(dudy_x)
+
+  end subroutine curl
+
+  subroutine divergence_v2p(self, div_u, u, v, w, x_stagder_v2p, x_interpl_v2p, &
+                            y_stagder_v2p, y_interpl_v2p, z_stagder_v2p, z_interpl_v2p)
+    !! Divergence of a vector field (u, v, w).
+    !! Inputs from velocity grid and outputs to pressure grid.
+    implicit none
+
+    class(vector_calculus_t) :: self
+    class(field_t), intent(inout) :: div_u
+    class(field_t), intent(in) :: u, v, w
+    class(tdsops_t), intent(in) :: x_stagder_v2p, x_interpl_v2p, &
+                                   y_stagder_v2p, y_interpl_v2p, &
+                                   z_stagder_v2p, z_interpl_v2p
+
+    class(field_t), pointer :: du_x, dv_x, dw_x, &
+      u_y, v_y, w_y, du_y, dv_y, dw_y, &
+      u_z, w_z, dw_z
+
+    du_x => self%backend%allocator%get_block(DIR_X)
+    dv_x => self%backend%allocator%get_block(DIR_X)
+    dw_x => self%backend%allocator%get_block(DIR_X)
+
+    ! Staggared der for u field in x
+    ! Interpolation for v field in x
+    ! Interpolation for w field in x
+    call self%backend%tds_solve(du_x, u, x_stagder_v2p)
+    call self%backend%tds_solve(dv_x, v, x_interpl_v2p)
+    call self%backend%tds_solve(dw_x, w, x_interpl_v2p)
+
+    ! request fields from the allocator
+    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    v_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
+
+    ! reorder data from x orientation to y orientation
+    call self%backend%reorder(u_y, du_x, RDR_X2Y)
+    call self%backend%reorder(v_y, dv_x, RDR_X2Y)
+    call self%backend%reorder(w_y, dw_x, RDR_X2Y)
+
+    call self%backend%allocator%release_block(du_x)
+    call self%backend%allocator%release_block(dv_x)
+    call self%backend%allocator%release_block(dw_x)
+
+    du_y => self%backend%allocator%get_block(DIR_Y)
+    dv_y => self%backend%allocator%get_block(DIR_Y)
+    dw_y => self%backend%allocator%get_block(DIR_Y)
+
+    ! similar to the x direction, obtain derivatives in y.
+    call self%backend%tds_solve(du_y, u_y, y_interpl_v2p)
+    call self%backend%tds_solve(dv_y, v_y, y_stagder_v2p)
+    call self%backend%tds_solve(dw_y, w_y, y_interpl_v2p)
+
+    ! we don't need the velocities in y orientation any more, so release
+    ! them to open up space.
+    ! It is important that this doesn't actually deallocate any memory,
+    ! it just makes the corresponding memory space available for use.
+    call self%backend%allocator%release_block(u_y)
+    call self%backend%allocator%release_block(v_y)
+    call self%backend%allocator%release_block(w_y)
+
+    ! just like in y direction, get some fields for the z derivatives.
+    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
+    w_z => self%backend%allocator%get_block(DIR_Z, VERT)
+
+    ! du_y = dv_y + du_y
+    call self%backend%vecadd(1._dp, dv_y, 1._dp, du_y)
+
+    ! reorder from y to z
+    call self%backend%reorder(u_z, du_y, RDR_Y2Z)
+    call self%backend%reorder(w_z, dw_y, RDR_Y2Z)
+
+    ! release all the unnecessary blocks.
+    call self%backend%allocator%release_block(du_y)
+    call self%backend%allocator%release_block(dv_y)
+    call self%backend%allocator%release_block(dw_y)
+
+    dw_z => self%backend%allocator%get_block(DIR_Z)
+
+    ! get the derivatives in z
+    call self%backend%tds_solve(div_u, u_z, z_interpl_v2p)
+    call self%backend%tds_solve(dw_z, w_z, z_stagder_v2p)
+
+    ! div_u = div_u + dw_z
+    call self%backend%vecadd(1._dp, dw_z, 1._dp, div_u)
+
+    ! div_u array is in z orientation
+
+    ! there is no need to keep velocities in z orientation around, so release
+    call self%backend%allocator%release_block(u_z)
+    call self%backend%allocator%release_block(w_z)
+    call self%backend%allocator%release_block(dw_z)
+
+  end subroutine divergence_v2p
+
+  subroutine gradient_p2v(self, dpdx, dpdy, dpdz, pressure, &
+                          x_stagder_p2v, x_interpl_p2v, &
+                          y_stagder_p2v, y_interpl_p2v, &
+                          z_stagder_p2v, z_interpl_p2v)
+    !! Gradient of a scalar field 'pressure'.
+    !! Inputs from pressure grid and outputs to velocity grid.
+    implicit none
+
+    class(vector_calculus_t) :: self
+    class(field_t), intent(inout) :: dpdx, dpdy, dpdz
+    class(field_t), intent(in) :: pressure
+    class(tdsops_t), intent(in) :: x_stagder_p2v, x_interpl_p2v, &
+                                   y_stagder_p2v, y_interpl_p2v, &
+                                   z_stagder_p2v, z_interpl_p2v
+
+    class(field_t), pointer :: p_sxy_z, dpdz_sxy_z, &
+      p_sxy_y, dpdz_sxy_y, &
+      p_sx_y, dpdy_sx_y, dpdz_sx_y, &
+      p_sx_x, dpdy_sx_x, dpdz_sx_x
+
+    p_sxy_z => self%backend%allocator%get_block(DIR_Z)
+    dpdz_sxy_z => self%backend%allocator%get_block(DIR_Z)
+
+    ! Staggared der for pressure field in z
+    ! Interpolation for pressure field in z
+    call self%backend%tds_solve(p_sxy_z, pressure, z_interpl_p2v)
+    call self%backend%tds_solve(dpdz_sxy_z, pressure, z_stagder_p2v)
+
+    ! request fields from the allocator
+    p_sxy_y => self%backend%allocator%get_block(DIR_Y)
+    dpdz_sxy_y => self%backend%allocator%get_block(DIR_Y)
+
+    ! reorder data from z orientation to y orientation
+    call self%backend%reorder(p_sxy_y, p_sxy_z, RDR_Z2Y)
+    call self%backend%reorder(dpdz_sxy_y, dpdz_sxy_z, RDR_Z2Y)
+
+    call self%backend%allocator%release_block(p_sxy_z)
+    call self%backend%allocator%release_block(dpdz_sxy_z)
+
+    p_sx_y => self%backend%allocator%get_block(DIR_Y)
+    dpdy_sx_y => self%backend%allocator%get_block(DIR_Y)
+    dpdz_sx_y => self%backend%allocator%get_block(DIR_Y)
+
+    ! similar to the z direction, obtain derivatives in y.
+    call self%backend%tds_solve(p_sx_y, p_sxy_y, y_interpl_p2v)
+    call self%backend%tds_solve(dpdy_sx_y, p_sxy_y, y_stagder_p2v)
+    call self%backend%tds_solve(dpdz_sx_y, dpdz_sxy_y, y_interpl_p2v)
+
+    ! release memory
+    call self%backend%allocator%release_block(p_sxy_y)
+    call self%backend%allocator%release_block(dpdz_sxy_y)
+
+    ! just like in y direction, get some fields for the x derivatives.
+    p_sx_x => self%backend%allocator%get_block(DIR_X)
+    dpdy_sx_x => self%backend%allocator%get_block(DIR_X)
+    dpdz_sx_x => self%backend%allocator%get_block(DIR_X)
+
+    ! reorder from y to x
+    call self%backend%reorder(p_sx_x, p_sx_y, RDR_Y2X)
+    call self%backend%reorder(dpdy_sx_x, dpdy_sx_y, RDR_Y2X)
+    call self%backend%reorder(dpdz_sx_x, dpdz_sx_y, RDR_Y2X)
+
+    ! release all the y directional fields.
+    call self%backend%allocator%release_block(p_sx_y)
+    call self%backend%allocator%release_block(dpdy_sx_y)
+    call self%backend%allocator%release_block(dpdz_sx_y)
+
+    ! get the derivatives in x
+    call self%backend%tds_solve(dpdx, p_sx_x, x_stagder_p2v)
+    call self%backend%tds_solve(dpdy, dpdy_sx_x, x_interpl_p2v)
+    call self%backend%tds_solve(dpdz, dpdz_sx_x, x_interpl_p2v)
+
+    ! release temporary x fields
+    call self%backend%allocator%release_block(p_sx_x)
+    call self%backend%allocator%release_block(dpdy_sx_x)
+    call self%backend%allocator%release_block(dpdz_sx_x)
+
+  end subroutine gradient_p2v
+
+end module m_vector_calculus


### PR DESCRIPTION
This PR moves the vector calculus operations currently implemented inside solver class out to a dedicated new class. This new structure should allow accessing vector calculus operations outside the solver class. Examples include the laplacian operation iterative Poisson solver needs and curl/divergence for postprocessing/monitoring.