### PR TITLE
Set `data_loc` automatically

### DIFF
--- a/src/allocator.f90
+++ b/src/allocator.f90
@@ -1,7 +1,7 @@
 module m_allocator
   use iso_fortran_env, only: stderr => error_unit
 
-  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, none, VERT
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, NULL_LOC, VERT
   use m_mesh, only: mesh_t
   use m_field, only: field_t
 
@@ -141,7 +141,7 @@ contains
     if (present(data_loc)) then
       handle%data_loc = data_loc
     else
-      handle%data_loc = none
+      handle%data_loc = NULL_LOC
     end if
 
     ! Set dims based on direction

--- a/src/common.f90
+++ b/src/common.f90
@@ -47,4 +47,10 @@ contains
     rdr_dir = rdr_map(dir_from, dir_to)
   end function get_rdr_from_dirs
 
+  integer function move_data_loc(in_data_loc, dir, move) result(out_data_loc)
+    integer, intent(in) :: in_data_loc, dir, move
+
+    out_data_loc = in_data_loc + move*(10**dir)
+  end function move_data_loc
+
 end module m_common

--- a/src/common.f90
+++ b/src/common.f90
@@ -18,7 +18,7 @@ module m_common
                         X_EDGE = 1000, & ! Data on edges along X
                         Y_EDGE = 0100, & ! Data on edges along Y
                         Z_EDGE = 0010, & ! Data on edges along Z
-                        none = -0001 ! The location of data isn't specified
+                        NULL_LOC = -0001 ! The location of data isn't specified
   integer, parameter :: BC_PERIODIC = 0, BC_NEUMANN = 1, BC_DIRICHLET = 2, &
                         BC_HALO = -1
   integer, protected :: &

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -5,10 +5,10 @@ module m_cuda_backend
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
-  use m_common, only: dp, &
+  use m_common, only: dp, move_data_loc, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
                       RDR_C2X, RDR_C2Y, RDR_C2Z, RDR_X2C, RDR_Y2C, RDR_Z2C, &
-                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
+                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, NONE
   use m_mesh, only: mesh_t
   use m_poisson_fft, only: poisson_fft_t
   use m_tdsops, only: dirps_t, tdsops_t, get_tds_n
@@ -254,6 +254,10 @@ contains
                                 der1st_sym, der1st, der2nd_sym, dirps%dir, &
                                 blocks, threads)
 
+    call du%set_data_loc(u%data_loc)
+    call dv%set_data_loc(v%data_loc)
+    call dw%set_data_loc(w%data_loc)
+
   end subroutine transeq_cuda_dist
 
   subroutine transeq_halo_exchange(self, u_dev, v_dev, w_dev, dir)
@@ -312,8 +316,8 @@ contains
     real(dp), device, pointer, dimension(:, :, :) :: dud_dev, d2u_dev
 
     ! Get some fields for storing the intermediate results
-    dud => self%allocator%get_block(dir, VERT)
-    d2u => self%allocator%get_block(dir, VERT)
+    dud => self%allocator%get_block(dir)
+    d2u => self%allocator%get_block(dir)
 
     call resolve_field_t(dud_dev, dud)
     call resolve_field_t(d2u_dev, d2u)
@@ -369,6 +373,10 @@ contains
     end if
 
     blocks = dim3(self%mesh%get_n_groups(u), 1, 1); threads = dim3(SZ, 1, 1)
+
+    if (u%data_loc /= none) then
+      call du%set_data_loc(move_data_loc(u%data_loc, u%dir, tdsops%move))
+    end if
 
     call tds_solve_dist(self, du, u, tdsops, blocks, threads)
 
@@ -538,6 +546,9 @@ contains
     case default
       error stop 'Reorder direction is undefined.'
     end select
+
+    ! reorder keeps the data_loc the same
+    call u_o%set_data_loc(u_i%data_loc)
 
   end subroutine reorder_cuda
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -8,7 +8,7 @@ module m_cuda_backend
   use m_common, only: dp, move_data_loc, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
                       RDR_C2X, RDR_C2Y, RDR_C2Z, RDR_X2C, RDR_Y2C, RDR_Z2C, &
-                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, NONE
+                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, NULL_LOC
   use m_mesh, only: mesh_t
   use m_poisson_fft, only: poisson_fft_t
   use m_tdsops, only: dirps_t, tdsops_t, get_tds_n
@@ -374,7 +374,7 @@ contains
 
     blocks = dim3(self%mesh%get_n_groups(u), 1, 1); threads = dim3(SZ, 1, 1)
 
-    if (u%data_loc /= none) then
+    if (u%data_loc /= NULL_LOC) then
       call du%set_data_loc(move_data_loc(u%data_loc, u%dir, tdsops%move))
     end if
 

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -3,7 +3,7 @@ module m_omp_backend
   use m_base_backend, only: base_backend_t
   use m_ordering, only: get_index_reordering
   use m_common, only: dp, get_dirs_from_rdr, move_data_loc, &
-                      DIR_X, DIR_Y, DIR_Z, DIR_C, NONE
+                      DIR_X, DIR_Y, DIR_Z, DIR_C, NULL_LOC
   use m_tdsops, only: dirps_t, tdsops_t, get_tds_n
   use m_omp_exec_dist, only: exec_dist_tds_compact, exec_dist_transeq_compact
   use m_omp_sendrecv, only: sendrecv_fields
@@ -288,7 +288,7 @@ contains
       error stop 'DIR mismatch between fields in tds_solve.'
     end if
 
-    if (u%data_loc /= none) then
+    if (u%data_loc /= NULL_LOC) then
       call du%set_data_loc(move_data_loc(u%data_loc, u%dir, tdsops%move))
     end if
 
@@ -462,7 +462,7 @@ contains
 
     use mpi
 
-    use m_common, only: none, get_rdr_from_dirs
+    use m_common, only: NULL_LOC, get_rdr_from_dirs
 
     implicit none
 
@@ -474,7 +474,7 @@ contains
     integer :: nvec, remstart
     integer :: ierr
 
-    if ((x%data_loc == none) .or. (y%data_loc == none)) then
+    if ((x%data_loc == NULL_LOC) .or. (y%data_loc == NULL_LOC)) then
       error stop "You must set the data_loc before calling scalar product"
     end if
     if (x%data_loc /= y%data_loc) then

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -2,7 +2,8 @@ module m_omp_backend
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
   use m_ordering, only: get_index_reordering
-  use m_common, only: dp, get_dirs_from_rdr, VERT, DIR_X, DIR_Y, DIR_Z, DIR_C
+  use m_common, only: dp, get_dirs_from_rdr, move_data_loc, &
+                      DIR_X, DIR_Y, DIR_Z, DIR_C, NONE
   use m_tdsops, only: dirps_t, tdsops_t, get_tds_n
   use m_omp_exec_dist, only: exec_dist_tds_compact, exec_dist_transeq_compact
   use m_omp_sendrecv, only: sendrecv_fields
@@ -253,8 +254,8 @@ contains
     integer, intent(in) :: dir
     class(field_t), pointer :: d2u, dud
 
-    dud => self%allocator%get_block(dir, VERT)
-    d2u => self%allocator%get_block(dir, VERT)
+    dud => self%allocator%get_block(dir)
+    d2u => self%allocator%get_block(dir)
 
     call exec_dist_transeq_compact( &
       rhs_du%data, dud%data, d2u%data, &
@@ -266,6 +267,8 @@ contains
       tdsops_du, tdsops_dud, tdsops_d2u, self%nu, &
       self%mesh%par%nproc_dir(dir), self%mesh%par%pprev(dir), &
       self%mesh%par%pnext(dir), self%mesh%get_n_groups(dir))
+
+    call rhs_du%set_data_loc(u%data_loc)
 
     call self%allocator%release_block(dud)
     call self%allocator%release_block(d2u)
@@ -283,6 +286,10 @@ contains
     ! Check if direction matches for both in/out fields
     if (u%dir /= du%dir) then
       error stop 'DIR mismatch between fields in tds_solve.'
+    end if
+
+    if (u%data_loc /= none) then
+      call du%set_data_loc(move_data_loc(u%data_loc, u%dir, tdsops%move))
     end if
 
     call tds_solve_dist(self, du, u, tdsops)
@@ -349,6 +356,9 @@ contains
       end do
     end do
     !$omp end parallel do
+
+    ! reorder keeps the data_loc the same
+    call u_%set_data_loc(u%data_loc)
 
   end subroutine reorder_omp
 

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -119,9 +119,9 @@ contains
 
     solver%vector_calculus = vector_calculus_t(solver%backend)
 
-    solver%u => solver%backend%allocator%get_block(DIR_X, VERT)
-    solver%v => solver%backend%allocator%get_block(DIR_X, VERT)
-    solver%w => solver%backend%allocator%get_block(DIR_X, VERT)
+    solver%u => solver%backend%allocator%get_block(DIR_X)
+    solver%v => solver%backend%allocator%get_block(DIR_X)
+    solver%w => solver%backend%allocator%get_block(DIR_X)
 
     ! set defaults
     poisson_solver_type = 'FFT'
@@ -174,6 +174,10 @@ contains
     call solver%backend%set_field_data(solver%u, u_init%data)
     call solver%backend%set_field_data(solver%v, v_init%data)
     call solver%backend%set_field_data(solver%w, w_init%data)
+
+    call solver%u%set_data_loc(VERT)
+    call solver%v%set_data_loc(VERT)
+    call solver%w%set_data_loc(VERT)
 
     call solver%host_allocator%release_block(u_init)
     call solver%host_allocator%release_block(v_init)
@@ -260,9 +264,9 @@ contains
     call self%backend%transeq_x(du, dv, dw, u, v, w, self%xdirps)
 
     ! request fields from the allocator
-    u_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    v_y => self%backend%allocator%get_block(DIR_Y, VERT)
-    w_y => self%backend%allocator%get_block(DIR_Y, VERT)
+    u_y => self%backend%allocator%get_block(DIR_Y)
+    v_y => self%backend%allocator%get_block(DIR_Y)
+    w_y => self%backend%allocator%get_block(DIR_Y)
     du_y => self%backend%allocator%get_block(DIR_Y)
     dv_y => self%backend%allocator%get_block(DIR_Y)
     dw_y => self%backend%allocator%get_block(DIR_Y)
@@ -292,9 +296,9 @@ contains
     call self%backend%allocator%release_block(dw_y)
 
     ! just like in y direction, get some fields for the z derivatives.
-    u_z => self%backend%allocator%get_block(DIR_Z, VERT)
-    v_z => self%backend%allocator%get_block(DIR_Z, VERT)
-    w_z => self%backend%allocator%get_block(DIR_Z, VERT)
+    u_z => self%backend%allocator%get_block(DIR_Z)
+    v_z => self%backend%allocator%get_block(DIR_Z)
+    w_z => self%backend%allocator%get_block(DIR_Z)
     du_z => self%backend%allocator%get_block(DIR_Z)
     dv_z => self%backend%allocator%get_block(DIR_Z)
     dw_z => self%backend%allocator%get_block(DIR_Z)
@@ -501,7 +505,7 @@ contains
 
         call self%divergence_v2p(div_u, self%u, self%v, self%w)
 
-        pressure => self%backend%allocator%get_block(DIR_Z, CELL)
+        pressure => self%backend%allocator%get_block(DIR_Z)
 
         call self%poisson(pressure, div_u)
 

--- a/src/tdsops.f90
+++ b/src/tdsops.f90
@@ -1,7 +1,7 @@
 module m_tdsops
   use iso_fortran_env, only: stderr => error_unit
 
-  use m_common, only: dp, pi, VERT, CELL, none, &
+  use m_common, only: dp, pi, VERT, CELL, &
                       BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET
   use m_mesh, only: mesh_t
 

--- a/src/tdsops.f90
+++ b/src/tdsops.f90
@@ -33,7 +33,7 @@ module m_tdsops
     real(dp) :: alpha, a, b, c = 0._dp, d = 0._dp
     logical :: periodic
     integer :: tds_n
-    integer :: dir
+    integer :: move = 0 ! move between vertices and cell centres
     integer :: n_halo
   contains
     procedure :: deriv_1st, deriv_2nd, interpl_mid, stagder_1st
@@ -134,6 +134,15 @@ contains
     else
       error stop 'operation is not defined'
     end if
+
+    select case (from_to)
+    case ('v2p')
+      tdsops%move = 1
+    case ('p2v')
+      tdsops%move = -1
+    case default
+      tdsops%move = 0
+    end select
 
     if (tdsops%dist_sa(tds_n) > 1d-16) then
       print *, 'There are ', tds_n, 'points in a subdomain, it may be too few!'


### PR DESCRIPTION
closing #98 
This will enable all the fields to have a correct data_loc without requiring any user input (other than only 3 initial u, v, w fields in solver%init.

- [x] `move_data_loc` function figures out the output `data_loc` based on input `data_loc`, operator `dir`, and operator `move` where move is 0 (v2v/p2p), -1 (p2v), or 1 (v2p)
- [x] Set `move` in `tdsops` based on inputs
- [x] tds_solve sets the output fields data_loc
- [x] Reorders set the output field's data_loc based on input field
- [x] transeq can hardcode the output data_loc as VERT
- [x] Check if the output data_loc is valid or not