### PR TITLE
Alternative approach for case support

### DIFF
--- a/examples/TGV/input.x3d
+++ b/examples/TGV/input.x3d
@@ -1,4 +1,7 @@
-&domain_params
+&domain_settings
+! Flow case
+flow_case = 'tgv'
+
 ! Global number of cells in each direction
 L_global = 6.283185307179586d0, 6.283185307179586d0, 6.283185307179586d0
 

--- a/examples/TGV/input.x3d
+++ b/examples/TGV/input.x3d
@@ -1,6 +1,6 @@
 &domain_settings
 ! Flow case
-flow_case = 'tgv'
+flow_case_name = 'tgv'
 
 ! Global number of cells in each direction
 L_global = 6.283185307179586d0, 6.283185307179586d0, 6.283185307179586d0

--- a/examples/generic/input.x3d
+++ b/examples/generic/input.x3d
@@ -1,0 +1,31 @@
+&domain_settings
+! Flow case
+flow_case_name = 'generic'
+
+! Global domain length
+L_global = 10d0, 10d0, 10d0
+
+! Global number of cells in each direction
+dims_global = 256, 256, 256
+
+! Domain decomposition in each direction
+nproc_dir = 1, 1, 2
+
+! BC options are 'periodic' | 'neumann' | 'dirichlet'
+BC_x = 'periodic', 'periodic'
+BC_y = 'periodic', 'periodic'
+BC_z = 'periodic', 'periodic'
+/End
+
+&solver_params
+Re = 1600d0
+time_intg = 'AB3' ! 'AB[1-4]' | 'RK[1-4]'
+dt = 0.001d0
+n_iters = 1000
+n_output = 100
+poisson_solver_type = 'FFT' ! 'FFT' | 'CG'
+der1st_scheme = 'compact6'
+der2nd_scheme = 'compact6' ! 'compact6' | 'compact6-hyperviscous'
+interpl_scheme = 'classic' ! 'classic' | 'optimised' | 'aggressive'
+stagder_scheme = 'compact6'
+/End

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
   tdsops.f90
   time_integrator.f90
   vector_calculus.f90
+  case/generic.f90
   case/tgv.f90
   omp/backend.f90
   omp/common.f90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
   tdsops.f90
   time_integrator.f90
   vector_calculus.f90
+  case/tgv.f90
   omp/backend.f90
   omp/common.f90
   omp/kernels/distributed.f90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
   tdsops.f90
   time_integrator.f90
   vector_calculus.f90
+  case/base_case.f90
   case/generic.f90
   case/tgv.f90
   omp/backend.f90

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -1,0 +1,210 @@
+module m_base_case
+  use mpi
+
+  use m_allocator, only: allocator_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, DIR_X, DIR_Z, DIR_C, VERT
+  use m_field, only: field_t
+  use m_mesh, only: mesh_t
+  use m_solver, only: solver_t, init
+
+  implicit none
+
+  type, abstract :: base_case_t
+    class(solver_t), allocatable :: solver
+  contains
+    procedure(boundary_conditions), deferred :: boundary_conditions
+    procedure(initial_conditions), deferred :: initial_conditions
+    procedure(post_transeq), deferred :: post_transeq
+    procedure(postprocess), deferred :: postprocess
+    procedure :: case_init
+    procedure :: run
+    procedure :: print_enstrophy
+    procedure :: print_div_max_mean
+  end type base_case_t
+
+  abstract interface
+    subroutine boundary_conditions(self)
+      import :: base_case_t
+      implicit none
+
+      class(base_case_t) :: self
+    end subroutine boundary_conditions
+
+    subroutine initial_conditions(self)
+      import :: base_case_t
+      implicit none
+
+      class(base_case_t) :: self
+    end subroutine initial_conditions
+
+    subroutine post_transeq(self, du, dv, dw)
+      import :: base_case_t
+      import :: field_t
+      implicit none
+
+      class(base_case_t) :: self
+      class(field_t), intent(inout) :: du, dv, dw
+    end subroutine post_transeq
+
+    subroutine postprocess(self, t)
+      import :: base_case_t
+      import :: dp
+      implicit none
+
+      class(base_case_t) :: self
+      real(dp), intent(in) :: t
+    end subroutine postprocess
+  end interface
+
+contains
+
+  subroutine case_init(self, backend, mesh, host_allocator)
+    implicit none
+
+    class(base_case_t) :: self
+    class(base_backend_t), target, intent(inout) :: backend
+    type(mesh_t), target, intent(inout) :: mesh
+    type(allocator_t), target, intent(inout) :: host_allocator
+
+    self%solver = init(backend, mesh, host_allocator)
+
+    call self%initial_conditions()
+
+  end subroutine case_init
+
+  subroutine print_enstrophy(self, u, v, w)
+    implicit none
+
+    class(base_case_t), intent(in) :: self
+    class(field_t), intent(in) :: u, v, w
+
+    class(field_t), pointer :: du, dv, dw
+    real(dp) :: enstrophy
+
+    du => self%solver%backend%allocator%get_block(DIR_X, VERT)
+    dv => self%solver%backend%allocator%get_block(DIR_X, VERT)
+    dw => self%solver%backend%allocator%get_block(DIR_X, VERT)
+
+    call self%solver%curl(du, dv, dw, u, v, w)
+    enstrophy = 0.5_dp*(self%solver%backend%scalar_product(du, du) &
+                        + self%solver%backend%scalar_product(dv, dv) &
+                        + self%solver%backend%scalar_product(dw, dw)) &
+                /self%solver%ngrid
+    if (self%solver%mesh%par%is_root()) print *, 'enstrophy:', enstrophy
+
+    call self%solver%backend%allocator%release_block(du)
+    call self%solver%backend%allocator%release_block(dv)
+    call self%solver%backend%allocator%release_block(dw)
+
+  end subroutine print_enstrophy
+
+  subroutine print_div_max_mean(self, u, v, w)
+    implicit none
+
+    class(base_case_t), intent(in) :: self
+    class(field_t), intent(in) :: u, v, w
+
+    class(field_t), pointer :: div_u
+    class(field_t), pointer :: u_out
+    real(dp) :: div_u_max, div_u_mean
+    integer :: ierr
+
+    div_u => self%solver%backend%allocator%get_block(DIR_Z)
+
+    call self%solver%divergence_v2p(div_u, u, v, w)
+
+    u_out => self%solver%host_allocator%get_block(DIR_C)
+    call self%solver%backend%get_field_data(u_out%data, div_u)
+
+    call self%solver%backend%allocator%release_block(div_u)
+
+    div_u_max = maxval(abs(u_out%data))
+    div_u_mean = sum(abs(u_out%data))/self%solver%ngrid
+
+    call self%solver%host_allocator%release_block(u_out)
+
+    call MPI_Allreduce(MPI_IN_PLACE, div_u_max, 1, MPI_DOUBLE_PRECISION, &
+                       MPI_MAX, MPI_COMM_WORLD, ierr)
+    call MPI_Allreduce(MPI_IN_PLACE, div_u_mean, 1, MPI_DOUBLE_PRECISION, &
+                       MPI_SUM, MPI_COMM_WORLD, ierr)
+    if (self%solver%mesh%par%is_root()) &
+      print *, 'div u max mean:', div_u_max, div_u_mean
+
+  end subroutine print_div_max_mean
+
+  subroutine run(self)
+    implicit none
+
+    class(base_case_t), intent(inout) :: self
+
+    class(field_t), pointer :: du, dv, dw
+    class(field_t), pointer :: u_out, v_out, w_out
+
+    real(dp) :: t
+    integer :: i, j
+
+    if (self%solver%mesh%par%is_root()) print *, 'initial conditions'
+    t = 0._dp
+    call self%postprocess(t)
+
+    if (self%solver%mesh%par%is_root()) print *, 'start run'
+
+    do i = 1, self%solver%n_iters
+      do j = 1, self%solver%time_integrator%nstage
+        ! first apply case-specific BCs
+        call self%boundary_conditions()
+
+        du => self%solver%backend%allocator%get_block(DIR_X)
+        dv => self%solver%backend%allocator%get_block(DIR_X)
+        dw => self%solver%backend%allocator%get_block(DIR_X)
+
+        call self%solver%transeq(du, dv, dw, &
+                                 self%solver%u, self%solver%v, self%solver%w)
+
+        ! models that introduce source terms handled here
+        call self%post_transeq(du, dv, dw)
+
+        ! time integration
+        call self%solver%time_integrator%step( &
+          self%solver%u, self%solver%v, self%solver%w, du, dv, dw, &
+          self%solver%dt &
+          )
+
+        call self%solver%backend%allocator%release_block(du)
+        call self%solver%backend%allocator%release_block(dv)
+        call self%solver%backend%allocator%release_block(dw)
+
+        call self%solver%pressure_correction(self%solver%u, self%solver%v, &
+                                             self%solver%w)
+      end do
+
+      if (mod(i, self%solver%n_output) == 0) then
+        t = i*self%solver%dt
+        call self%postprocess(t)
+      end if
+    end do
+
+    if (self%solver%mesh%par%is_root()) print *, 'run end'
+
+    ! Below is for demonstrating purpuses only, to be removed when we have
+    ! proper I/O in place.
+    u_out => self%solver%host_allocator%get_block(DIR_C)
+    v_out => self%solver%host_allocator%get_block(DIR_C)
+    w_out => self%solver%host_allocator%get_block(DIR_C)
+
+    call self%solver%backend%get_field_data(u_out%data, self%solver%u)
+    call self%solver%backend%get_field_data(v_out%data, self%solver%v)
+    call self%solver%backend%get_field_data(w_out%data, self%solver%w)
+
+    if (self%solver%mesh%par%is_root()) then
+      print *, 'norms', norm2(u_out%data), norm2(v_out%data), norm2(w_out%data)
+    end if
+
+    call self%solver%host_allocator%release_block(u_out)
+    call self%solver%host_allocator%release_block(v_out)
+    call self%solver%host_allocator%release_block(w_out)
+
+  end subroutine run
+
+end module m_base_case

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -1,4 +1,7 @@
 module m_base_case
+  !! Provides the base case for running a simulation. New cases are
+  !! implemented by extending this to specify the initial and boundary
+  !! conditions, forcing terms and case-specific postprocessing and analysis.
   use mpi
 
   use m_allocator, only: allocator_t
@@ -25,6 +28,7 @@ module m_base_case
 
   abstract interface
     subroutine boundary_conditions(self)
+      !! Applies case-specific boundary coinditions
       import :: base_case_t
       implicit none
 
@@ -32,6 +36,7 @@ module m_base_case
     end subroutine boundary_conditions
 
     subroutine initial_conditions(self)
+      !! Sets case-specific initial conditions
       import :: base_case_t
       implicit none
 
@@ -39,6 +44,7 @@ module m_base_case
     end subroutine initial_conditions
 
     subroutine post_transeq(self, du, dv, dw)
+      !! Applies case-specific or model realated forcings after transeq
       import :: base_case_t
       import :: field_t
       implicit none
@@ -48,6 +54,7 @@ module m_base_case
     end subroutine post_transeq
 
     subroutine postprocess(self, t)
+      !! Triggers case-specific postprocessings at user specified intervals
       import :: base_case_t
       import :: dp
       implicit none
@@ -74,6 +81,7 @@ contains
   end subroutine case_init
 
   subroutine print_enstrophy(self, u, v, w)
+    !! Reports the enstrophy
     implicit none
 
     class(base_case_t), intent(in) :: self
@@ -100,6 +108,7 @@ contains
   end subroutine print_enstrophy
 
   subroutine print_div_max_mean(self, u, v, w)
+    !! Reports the div(u) at cell centres
     implicit none
 
     class(base_case_t), intent(in) :: self
@@ -134,6 +143,8 @@ contains
   end subroutine print_div_max_mean
 
   subroutine run(self)
+    !! Runs the solver forwards in time from t=t_0 to t=T, performing
+    !! postprocessing/IO and reporting diagnostics.
     implicit none
 
     class(base_case_t), intent(inout) :: self

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -53,13 +53,14 @@ module m_base_case
       class(field_t), intent(inout) :: du, dv, dw
     end subroutine forcings
 
-    subroutine postprocess(self, t)
+    subroutine postprocess(self, i, t)
       !! Triggers case-specific postprocessings at user specified intervals
       import :: base_case_t
       import :: dp
       implicit none
 
       class(base_case_t) :: self
+      integer, intent(in) :: i
       real(dp), intent(in) :: t
     end subroutine postprocess
   end interface
@@ -157,7 +158,7 @@ contains
 
     if (self%solver%mesh%par%is_root()) print *, 'initial conditions'
     t = 0._dp
-    call self%postprocess(t)
+    call self%postprocess(0, t)
 
     if (self%solver%mesh%par%is_root()) print *, 'start run'
 
@@ -192,7 +193,7 @@ contains
 
       if (mod(i, self%solver%n_output) == 0) then
         t = i*self%solver%dt
-        call self%postprocess(t)
+        call self%postprocess(i, t)
       end if
     end do
 

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -18,7 +18,7 @@ module m_base_case
   contains
     procedure(boundary_conditions), deferred :: boundary_conditions
     procedure(initial_conditions), deferred :: initial_conditions
-    procedure(post_transeq), deferred :: post_transeq
+    procedure(forcings), deferred :: forcings
     procedure(postprocess), deferred :: postprocess
     procedure :: case_init
     procedure :: run
@@ -43,7 +43,7 @@ module m_base_case
       class(base_case_t) :: self
     end subroutine initial_conditions
 
-    subroutine post_transeq(self, du, dv, dw)
+    subroutine forcings(self, du, dv, dw)
       !! Applies case-specific or model realated forcings after transeq
       import :: base_case_t
       import :: field_t
@@ -51,7 +51,7 @@ module m_base_case
 
       class(base_case_t) :: self
       class(field_t), intent(inout) :: du, dv, dw
-    end subroutine post_transeq
+    end subroutine forcings
 
     subroutine postprocess(self, t)
       !! Triggers case-specific postprocessings at user specified intervals
@@ -174,7 +174,7 @@ contains
                                  self%solver%u, self%solver%v, self%solver%w)
 
         ! models that introduce source terms handled here
-        call self%post_transeq(du, dv, dw)
+        call self%forcings(du, dv, dw)
 
         ! time integration
         call self%solver%time_integrator%step( &

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -6,7 +6,7 @@ module m_case_generic
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
   use m_base_case, only: base_case_t
-  use m_common, only: dp
+  use m_common, only: dp, VERT
   use m_mesh, only: mesh_t
   use m_solver, only: init
 
@@ -53,6 +53,10 @@ contains
     call self%solver%u%fill(1._dp)
     call self%solver%v%fill(0._dp)
     call self%solver%w%fill(0._dp)
+
+    call self%solver%u%set_data_loc(VERT)
+    call self%solver%v%set_data_loc(VERT)
+    call self%solver%w%set_data_loc(VERT)
 
   end subroutine initial_conditions_generic
 

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -32,7 +32,8 @@ contains
     type(allocator_t), target, intent(inout) :: host_allocator
     type(case_generic_t) :: flow_case
 
-    flow_case%solver = init(backend, mesh, host_allocator)
+    call flow_case%case_init(backend, mesh, host_allocator)
+
   end function case_generic_init
 
   subroutine boundary_conditions_generic(self)

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -16,7 +16,7 @@ module m_case_generic
   contains
     procedure :: boundary_conditions => boundary_conditions_generic
     procedure :: initial_conditions => initial_conditions_generic
-    procedure :: post_transeq => post_transeq_generic
+    procedure :: forcings => forcings_generic
     procedure :: postprocess => postprocess_generic
   end type case_generic_t
 
@@ -68,12 +68,12 @@ contains
 
   end subroutine postprocess_generic
 
-  subroutine post_transeq_generic(self, du, dv, dw)
+  subroutine forcings_generic(self, du, dv, dw)
     implicit none
 
     class(case_generic_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
 
-  end subroutine post_transeq_generic
+  end subroutine forcings_generic
 
 end module m_case_generic

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -1,22 +1,20 @@
 module m_case_generic
   use iso_fortran_env, only: stderr => error_unit
-  use mpi
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
+  use m_base_case, only: base_case_t
   use m_common, only: dp
   use m_mesh, only: mesh_t
-  use m_solver, only: solver_t, init
-  use m_tdsops, only: tdsops_t, dirps_t
-  use m_time_integrator, only: time_intg_t
-  use m_vector_calculus, only: vector_calculus_t
+  use m_solver, only: init
 
   implicit none
 
-  type, extends(solver_t) :: case_generic_t
+  type, extends(base_case_t) :: case_generic_t
   contains
-    procedure :: post_transeq => post_transeq_generic
     procedure :: boundary_conditions => boundary_conditions_generic
+    procedure :: initial_conditions => initial_conditions_generic
+    procedure :: post_transeq => post_transeq_generic
     procedure :: postprocess => postprocess_generic
   end type case_generic_t
 
@@ -26,15 +24,15 @@ module m_case_generic
 
 contains
 
-  function case_generic_init(backend, mesh, host_allocator) result(solver)
+  function case_generic_init(backend, mesh, host_allocator) result(flow_case)
     implicit none
 
     class(base_backend_t), target, intent(inout) :: backend
     type(mesh_t), target, intent(inout) :: mesh
     type(allocator_t), target, intent(inout) :: host_allocator
-    type(case_generic_t) :: solver
+    type(case_generic_t) :: flow_case
 
-    solver%solver_t = init(backend, mesh, host_allocator)
+    flow_case%solver = init(backend, mesh, host_allocator)
   end function case_generic_init
 
   subroutine boundary_conditions_generic(self)
@@ -42,9 +40,22 @@ contains
 
     class(case_generic_t) :: self
 
-    call self%solver_t%boundary_conditions()
-
   end subroutine boundary_conditions_generic
+
+  subroutine initial_conditions_generic(self)
+    implicit none
+
+    class(case_generic_t) :: self
+
+  end subroutine initial_conditions_generic
+
+  subroutine postprocess_generic(self, t)
+    implicit none
+
+    class(case_generic_t) :: self
+    real(dp), intent(in) :: t
+
+  end subroutine postprocess_generic
 
   subroutine post_transeq_generic(self, du, dv, dw)
     implicit none
@@ -52,19 +63,6 @@ contains
     class(case_generic_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
 
-    ! first call the parent class
-    call self%solver_t%post_transeq(du, dv, dw)
-
   end subroutine post_transeq_generic
-
-  subroutine postprocess_generic(self, t)
-    implicit none
-
-    class(case_generic_t), intent(in) :: self
-    real(dp), intent(in) :: t
-
-    call self%solver_t%postprocess(t)
-
-  end subroutine postprocess_generic
 
 end module m_case_generic

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -1,4 +1,6 @@
 module m_case_generic
+  !! An example case set up to run and sustain a freestream flow.
+  !! This is a good place to start for adding a new flow case.
   use iso_fortran_env, only: stderr => error_unit
 
   use m_allocator, only: allocator_t, field_t

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -1,0 +1,70 @@
+module m_case_generic
+  use iso_fortran_env, only: stderr => error_unit
+  use mpi
+
+  use m_allocator, only: allocator_t, field_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp
+  use m_mesh, only: mesh_t
+  use m_solver, only: solver_t, init
+  use m_tdsops, only: tdsops_t, dirps_t
+  use m_time_integrator, only: time_intg_t
+  use m_vector_calculus, only: vector_calculus_t
+
+  implicit none
+
+  type, extends(solver_t) :: case_generic_t
+  contains
+    procedure :: post_transeq => post_transeq_generic
+    procedure :: boundary_conditions => boundary_conditions_generic
+    procedure :: postprocess => postprocess_generic
+  end type case_generic_t
+
+  interface case_generic_t
+    module procedure case_generic_init
+  end interface case_generic_t
+
+contains
+
+  function case_generic_init(backend, mesh, host_allocator) result(solver)
+    implicit none
+
+    class(base_backend_t), target, intent(inout) :: backend
+    type(mesh_t), target, intent(inout) :: mesh
+    type(allocator_t), target, intent(inout) :: host_allocator
+    type(case_generic_t) :: solver
+
+    solver%solver_t = init(backend, mesh, host_allocator)
+  end function case_generic_init
+
+  subroutine boundary_conditions_generic(self)
+    implicit none
+
+    class(case_generic_t) :: self
+
+    call self%solver_t%boundary_conditions()
+
+  end subroutine boundary_conditions_generic
+
+  subroutine post_transeq_generic(self, du, dv, dw)
+    implicit none
+
+    class(case_generic_t) :: self
+    class(field_t), intent(inout) :: du, dv, dw
+
+    ! first call the parent class
+    call self%solver_t%post_transeq(du, dv, dw)
+
+  end subroutine post_transeq_generic
+
+  subroutine postprocess_generic(self, t)
+    implicit none
+
+    class(case_generic_t), intent(in) :: self
+    real(dp), intent(in) :: t
+
+    call self%solver_t%postprocess(t)
+
+  end subroutine postprocess_generic
+
+end module m_case_generic

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -48,6 +48,10 @@ contains
 
     class(case_generic_t) :: self
 
+    call self%solver%u%fill(1._dp)
+    call self%solver%v%fill(0._dp)
+    call self%solver%w%fill(0._dp)
+
   end subroutine initial_conditions_generic
 
   subroutine postprocess_generic(self, t)
@@ -55,6 +59,10 @@ contains
 
     class(case_generic_t) :: self
     real(dp), intent(in) :: t
+
+    if (self%solver%mesh%par%is_root()) print *, 'time =', t
+    call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
+    call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
 
   end subroutine postprocess_generic
 

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -56,13 +56,14 @@ contains
 
   end subroutine initial_conditions_generic
 
-  subroutine postprocess_generic(self, t)
+  subroutine postprocess_generic(self, i, t)
     implicit none
 
     class(case_generic_t) :: self
+    integer, intent(in) :: i
     real(dp), intent(in) :: t
 
-    if (self%solver%mesh%par%is_root()) print *, 'time =', t
+    if (self%solver%mesh%par%is_root()) print *, 'time =', t, 'iteration =', i
     call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
     call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
 

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -1,0 +1,51 @@
+module m_case_tgv
+  use iso_fortran_env, only: stderr => error_unit
+  use mpi
+
+  use m_allocator, only: allocator_t, field_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp
+  use m_mesh, only: mesh_t
+  use m_solver, only: solver_t, init
+  use m_tdsops, only: tdsops_t, dirps_t
+  use m_time_integrator, only: time_intg_t
+  use m_vector_calculus, only: vector_calculus_t
+
+  implicit none
+
+  type, extends(solver_t) :: case_tgv_t
+  contains
+    procedure :: post_transeq => post_transeq_tgv
+  end type case_tgv_t
+
+  interface case_tgv_t
+    module procedure case_tgv_init
+  end interface case_tgv_t
+
+contains
+
+
+  function case_tgv_init(backend, mesh, host_allocator) result(solver)
+    implicit none
+
+    class(base_backend_t), target, intent(inout) :: backend
+    type(mesh_t), target, intent(inout) :: mesh
+    type(allocator_t), target, intent(inout) :: host_allocator
+    type(case_tgv_t) :: solver
+
+    solver%solver_t = init(backend, mesh, host_allocator)
+  end function case_tgv_init
+
+  subroutine post_transeq_tgv(self, du, dv, dw)
+    implicit none
+
+    class(case_tgv_t) :: self
+    class(field_t), intent(inout) :: du, dv, dw
+
+    ! first call the parent class
+    call self%solver_t%post_transeq(du, dv, dw)
+
+    print *, 'post_transeq for the tgv case'
+  end subroutine post_transeq_tgv
+
+end module m_case_tgv

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -105,10 +105,8 @@ contains
     class(case_tgv_t) :: self
     real(dp), intent(in) :: t
 
-    call self%solver%print_enstrophy(self%solver%u, self%solver%v, &
-                                     self%solver%w)
-    call self%solver%print_div_max_mean(self%solver%u, self%solver%v, &
-                                        self%solver%w)
+    call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
+    call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
 
   end subroutine postprocess_tgv
 

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -1,17 +1,21 @@
 module m_case_tgv
   use iso_fortran_env, only: stderr => error_unit
-  use mpi
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
+  use m_base_case, only: base_case_t
   use m_common, only: dp
   use m_mesh, only: mesh_t
-  use m_solver, only: solver_t, init
+  use m_solver, only: init
 
   implicit none
 
-  type, extends(solver_t) :: case_tgv_t
+  type, extends(base_case_t) :: case_tgv_t
   contains
+    procedure :: boundary_conditions => boundary_conditions_tgv
+    procedure :: initial_conditions => initial_conditions_tgv
+    procedure :: post_transeq => post_transeq_tgv
+    procedure :: postprocess => postprocess_tgv
   end type case_tgv_t
 
   interface case_tgv_t
@@ -20,15 +24,53 @@ module m_case_tgv
 
 contains
 
-  function case_tgv_init(backend, mesh, host_allocator) result(solver)
+  function case_tgv_init(backend, mesh, host_allocator) result(flow_case)
     implicit none
 
     class(base_backend_t), target, intent(inout) :: backend
     type(mesh_t), target, intent(inout) :: mesh
     type(allocator_t), target, intent(inout) :: host_allocator
-    type(case_tgv_t) :: solver
+    type(case_tgv_t) :: flow_case
 
-    solver%solver_t = init(backend, mesh, host_allocator)
+    flow_case%solver = init(backend, mesh, host_allocator)
   end function case_tgv_init
+
+  subroutine initial_conditions_tgv(self)
+    implicit none
+
+    class(case_tgv_t) :: self
+
+    ! set initial conditions for the TGV case
+  end subroutine initial_conditions_tgv
+
+  subroutine boundary_conditions_tgv(self)
+    implicit none
+
+    class(case_tgv_t) :: self
+
+    ! do nothing for TGV case
+  end subroutine boundary_conditions_tgv
+
+  subroutine post_transeq_tgv(self, du, dv, dw)
+    implicit none
+
+    class(case_tgv_t) :: self
+    class(field_t), intent(inout) :: du, dv, dw
+
+    ! do nothing for TGV case
+  end subroutine post_transeq_tgv
+
+  subroutine postprocess_tgv(self, t)
+    implicit none
+
+    class(case_tgv_t) :: self
+    real(dp), intent(in) :: t
+
+    call self%solver%print_enstrophy(self%solver%u, self%solver%v, &
+                                     self%solver%w)
+    call self%solver%print_div_max_mean(self%solver%u, self%solver%v, &
+                                        self%solver%w)
+
+  end subroutine postprocess_tgv
 
 end module m_case_tgv

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -97,13 +97,14 @@ contains
     ! do nothing for TGV case
   end subroutine forcings_tgv
 
-  subroutine postprocess_tgv(self, t)
+  subroutine postprocess_tgv(self, i, t)
     implicit none
 
     class(case_tgv_t) :: self
+    integer, intent(in) :: i
     real(dp), intent(in) :: t
 
-    if (self%solver%mesh%par%is_root()) print *, 'time =', t
+    if (self%solver%mesh%par%is_root()) print *, 'time =', t, 'iteration =', i
     call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
     call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
 

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -14,7 +14,7 @@ module m_case_tgv
   contains
     procedure :: boundary_conditions => boundary_conditions_tgv
     procedure :: initial_conditions => initial_conditions_tgv
-    procedure :: post_transeq => post_transeq_tgv
+    procedure :: forcings => forcings_tgv
     procedure :: postprocess => postprocess_tgv
   end type case_tgv_t
 
@@ -88,14 +88,14 @@ contains
     ! do nothing for TGV case
   end subroutine boundary_conditions_tgv
 
-  subroutine post_transeq_tgv(self, du, dv, dw)
+  subroutine forcings_tgv(self, du, dv, dw)
     implicit none
 
     class(case_tgv_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
 
     ! do nothing for TGV case
-  end subroutine post_transeq_tgv
+  end subroutine forcings_tgv
 
   subroutine postprocess_tgv(self, t)
     implicit none

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -32,9 +32,7 @@ contains
     type(allocator_t), target, intent(inout) :: host_allocator
     type(case_tgv_t) :: flow_case
 
-    flow_case%solver = init(backend, mesh, host_allocator)
-
-    call flow_case%initial_conditions()
+    call flow_case%case_init(backend, mesh, host_allocator)
 
   end function case_tgv_init
 
@@ -105,6 +103,7 @@ contains
     class(case_tgv_t) :: self
     real(dp), intent(in) :: t
 
+    if (self%solver%mesh%par%is_root()) print *, 'time =', t
     call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
     call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
 

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -41,44 +41,33 @@ contains
 
     class(case_tgv_t) :: self
 
-    class(field_t), pointer :: u_init, v_init, w_init
-
-    integer :: i, j, k, dims(3)
-    real(dp) :: xloc(3), x, y, z
-
-    dims = self%solver%mesh%get_dims(VERT)
-    u_init => self%solver%host_allocator%get_block(DIR_C)
-    v_init => self%solver%host_allocator%get_block(DIR_C)
-    w_init => self%solver%host_allocator%get_block(DIR_C)
-
-    do k = 1, dims(3)
-      do j = 1, dims(2)
-        do i = 1, dims(1)
-          xloc = self%solver%mesh%get_coordinates(i, j, k)
-          x = xloc(1)
-          y = xloc(2)
-          z = xloc(3)
-
-          u_init%data(i, j, k) = sin(x)*cos(y)*cos(z)
-          v_init%data(i, j, k) = -cos(x)*sin(y)*cos(z)
-          w_init%data(i, j, k) = 0
-        end do
-      end do
-    end do
-
-    call self%solver%backend%set_field_data(self%solver%u, u_init%data)
-    call self%solver%backend%set_field_data(self%solver%v, v_init%data)
-    call self%solver%backend%set_field_data(self%solver%w, w_init%data)
+    call self%set_init(self%solver%u, u_func)
+    call self%set_init(self%solver%v, v_func)
+    call self%solver%w%fill(0._dp)
 
     call self%solver%u%set_data_loc(VERT)
     call self%solver%v%set_data_loc(VERT)
     call self%solver%w%set_data_loc(VERT)
 
-    call self%solver%host_allocator%release_block(u_init)
-    call self%solver%host_allocator%release_block(v_init)
-    call self%solver%host_allocator%release_block(w_init)
-
   end subroutine initial_conditions_tgv
+
+  pure function u_func(coords) result(r)
+    implicit none
+
+    real(dp), intent(in) :: coords(3)
+    real(dp) :: r
+
+    r = sin(coords(1))*cos(coords(2))*cos(coords(3))
+  end function u_func
+
+  pure function v_func(coords) result(r)
+    implicit none
+
+    real(dp), intent(in) :: coords(3)
+    real(dp) :: r
+
+    r = -cos(coords(1))*sin(coords(2))*cos(coords(3))
+  end function v_func
 
   subroutine boundary_conditions_tgv(self)
     implicit none

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -7,15 +7,11 @@ module m_case_tgv
   use m_common, only: dp
   use m_mesh, only: mesh_t
   use m_solver, only: solver_t, init
-  use m_tdsops, only: tdsops_t, dirps_t
-  use m_time_integrator, only: time_intg_t
-  use m_vector_calculus, only: vector_calculus_t
 
   implicit none
 
   type, extends(solver_t) :: case_tgv_t
   contains
-    procedure :: post_transeq => post_transeq_tgv
   end type case_tgv_t
 
   interface case_tgv_t
@@ -23,7 +19,6 @@ module m_case_tgv
   end interface case_tgv_t
 
 contains
-
 
   function case_tgv_init(backend, mesh, host_allocator) result(solver)
     implicit none
@@ -35,16 +30,5 @@ contains
 
     solver%solver_t = init(backend, mesh, host_allocator)
   end function case_tgv_init
-
-  subroutine post_transeq_tgv(self, du, dv, dw)
-    implicit none
-
-    class(case_tgv_t) :: self
-    class(field_t), intent(inout) :: du, dv, dw
-
-    ! first call the parent class
-    call self%solver_t%post_transeq(du, dv, dw)
-
-  end subroutine post_transeq_tgv
 
 end module m_case_tgv

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -45,7 +45,6 @@ contains
     ! first call the parent class
     call self%solver_t%post_transeq(du, dv, dw)
 
-    print *, 'post_transeq for the tgv case'
   end subroutine post_transeq_tgv
 
 end module m_case_tgv

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -4,7 +4,7 @@ module m_case_tgv
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
   use m_base_case, only: base_case_t
-  use m_common, only: dp
+  use m_common, only: dp, VERT, DIR_C
   use m_mesh, only: mesh_t
   use m_solver, only: init
 
@@ -33,6 +33,9 @@ contains
     type(case_tgv_t) :: flow_case
 
     flow_case%solver = init(backend, mesh, host_allocator)
+
+    call flow_case%initial_conditions()
+
   end function case_tgv_init
 
   subroutine initial_conditions_tgv(self)
@@ -40,7 +43,43 @@ contains
 
     class(case_tgv_t) :: self
 
-    ! set initial conditions for the TGV case
+    class(field_t), pointer :: u_init, v_init, w_init
+
+    integer :: i, j, k, dims(3)
+    real(dp) :: xloc(3), x, y, z
+
+    dims = self%solver%mesh%get_dims(VERT)
+    u_init => self%solver%host_allocator%get_block(DIR_C)
+    v_init => self%solver%host_allocator%get_block(DIR_C)
+    w_init => self%solver%host_allocator%get_block(DIR_C)
+
+    do k = 1, dims(3)
+      do j = 1, dims(2)
+        do i = 1, dims(1)
+          xloc = self%solver%mesh%get_coordinates(i, j, k)
+          x = xloc(1)
+          y = xloc(2)
+          z = xloc(3)
+
+          u_init%data(i, j, k) = sin(x)*cos(y)*cos(z)
+          v_init%data(i, j, k) = -cos(x)*sin(y)*cos(z)
+          w_init%data(i, j, k) = 0
+        end do
+      end do
+    end do
+
+    call self%solver%backend%set_field_data(self%solver%u, u_init%data)
+    call self%solver%backend%set_field_data(self%solver%v, v_init%data)
+    call self%solver%backend%set_field_data(self%solver%w, w_init%data)
+
+    call self%solver%u%set_data_loc(VERT)
+    call self%solver%v%set_data_loc(VERT)
+    call self%solver%w%set_data_loc(VERT)
+
+    call self%solver%host_allocator%release_block(u_init)
+    call self%solver%host_allocator%release_block(v_init)
+    call self%solver%host_allocator%release_block(w_init)
+
   end subroutine initial_conditions_tgv
 
   subroutine boundary_conditions_tgv(self)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -58,6 +58,7 @@ module m_solver
     procedure(poisson_solver), pointer :: poisson => null()
   contains
     procedure :: transeq
+    procedure :: post_transeq
     procedure :: pressure_correction
     procedure :: divergence_v2p
     procedure :: gradient_p2v
@@ -329,6 +330,16 @@ contains
 
   end subroutine transeq
 
+  subroutine post_transeq(self, du, dv, dw)
+    implicit none
+
+    class(solver_t) :: self
+    class(field_t), intent(inout) :: du, dv, dw
+
+    print*, 'base post_transeq'
+
+  end subroutine post_transeq
+
   subroutine divergence_v2p(self, div_u, u, v, w)
     !! Wrapper for divergence_v2p
     implicit none
@@ -528,6 +539,8 @@ contains
         dw => self%backend%allocator%get_block(DIR_X)
 
         call self%transeq(du, dv, dw, self%u, self%v, self%w)
+
+        call self%post_transeq(du, dv, dw)
 
         ! time integration
         call self%time_integrator%step(self%u, self%v, self%w, &

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -439,16 +439,17 @@ contains
 
   end subroutine poisson_cg
 
-  subroutine pressure_correction(self)
+  subroutine pressure_correction(self, u, v, w)
     implicit none
 
     class(solver_t) :: self
+    class(field_t), intent(inout) :: u, v, w
 
     class(field_t), pointer :: div_u, pressure, dpdx, dpdy, dpdz
 
     div_u => self%backend%allocator%get_block(DIR_Z)
 
-    call self%divergence_v2p(div_u, self%u, self%v, self%w)
+    call self%divergence_v2p(div_u, u, v, w)
 
     pressure => self%backend%allocator%get_block(DIR_Z)
 
@@ -465,9 +466,9 @@ contains
     call self%backend%allocator%release_block(pressure)
 
     ! velocity correction
-    call self%backend%vecadd(-1._dp, dpdx, 1._dp, self%u)
-    call self%backend%vecadd(-1._dp, dpdy, 1._dp, self%v)
-    call self%backend%vecadd(-1._dp, dpdz, 1._dp, self%w)
+    call self%backend%vecadd(-1._dp, dpdx, 1._dp, u)
+    call self%backend%vecadd(-1._dp, dpdy, 1._dp, v)
+    call self%backend%vecadd(-1._dp, dpdz, 1._dp, w)
 
     call self%backend%allocator%release_block(dpdx)
     call self%backend%allocator%release_block(dpdy)
@@ -552,7 +553,7 @@ contains
 
     class(solver_t), intent(inout) :: self
 
-    class(field_t), pointer :: du, dv, dw, div_u, pressure, dpdx, dpdy, dpdz
+    class(field_t), pointer :: du, dv, dw
     class(field_t), pointer :: u_out, v_out, w_out
 
     real(dp) :: t
@@ -582,7 +583,7 @@ contains
         call self%backend%allocator%release_block(dv)
         call self%backend%allocator%release_block(dw)
 
-        call self%pressure_correction()
+        call self%pressure_correction(self%u, self%v, self%w)
       end do
 
       if (mod(i, self%n_output) == 0) then

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -50,8 +50,8 @@ program xcompact
   real(dp), dimension(3) :: L_global
   integer :: nrank, nproc, ierr
 
-  namelist /domain_settings/ flow_case_name, L_global, dims_global, nproc_dir, &
-    BC_x, BC_y, BC_z
+  namelist /domain_settings/ flow_case_name, L_global, dims_global, &
+    nproc_dir, BC_x, BC_y, BC_z
 
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -7,6 +7,7 @@ program xcompact
   use m_solver, only: solver_t
   use m_tdsops, only: tdsops_t
   use m_mesh
+  use m_case_tgv, only: case_tgv_t
 
 #ifdef CUDA
   use m_cuda_allocator
@@ -24,7 +25,7 @@ program xcompact
   class(allocator_t), pointer :: allocator
   type(mesh_t) :: mesh
   type(allocator_t), pointer :: host_allocator
-  type(solver_t) :: solver
+  class(solver_t), allocatable :: solver
 
 #ifdef CUDA
   type(cuda_backend_t), target :: cuda_backend
@@ -99,7 +100,9 @@ program xcompact
   if (nrank == 0) print *, 'OpenMP backend instantiated'
 #endif
 
-  solver = solver_t(backend, mesh, host_allocator)
+  !solver = solver_t(backend, mesh, host_allocator)
+  !allocate(solver :: case_tgv_t)
+  solver = case_tgv_t(backend, mesh, host_allocator)
   if (nrank == 0) print *, 'solver instantiated'
 
   call cpu_time(t_start)

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -49,7 +49,7 @@ program xcompact
   integer :: nrank, nproc, ierr
 
   namelist /domain_settings/ flow_case, L_global, dims_global, nproc_dir, &
-                             BC_x, BC_y, BC_z
+    BC_x, BC_y, BC_z
 
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
@@ -105,12 +105,12 @@ program xcompact
 
   if (nrank == 0) print *, 'Flow case: ', flow_case
 
-  select case(trim(flow_case))
-  case('generic')
-    allocate(case_generic_t :: solver)
+  select case (trim(flow_case))
+  case ('generic')
+    allocate (case_generic_t :: solver)
     solver = case_generic_t(backend, mesh, host_allocator)
-  case('tgv')
-    allocate(case_tgv_t :: solver)
+  case ('tgv')
+    allocate (case_tgv_t :: solver)
     solver = case_tgv_t(backend, mesh, host_allocator)
   case default
     error stop 'Undefined flow_case.'

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -5,8 +5,6 @@ program xcompact
   use m_base_backend
   use m_base_case, only: base_case_t
   use m_common, only: pi
-  use m_solver, only: solver_t
-  use m_tdsops, only: tdsops_t
   use m_mesh
   use m_case_generic, only: case_generic_t
   use m_case_tgv, only: case_tgv_t
@@ -15,7 +13,6 @@ program xcompact
   use m_cuda_allocator
   use m_cuda_backend
   use m_cuda_common, only: SZ
-  use m_cuda_tdsops, only: cuda_tdsops_t
 #else
   use m_omp_backend
   use m_omp_common, only: SZ
@@ -27,7 +24,6 @@ program xcompact
   class(allocator_t), pointer :: allocator
   type(mesh_t) :: mesh
   type(allocator_t), pointer :: host_allocator
-  !class(solver_t), allocatable :: solver
   class(base_case_t), allocatable :: flow_case
 
 #ifdef CUDA

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -107,8 +107,10 @@ program xcompact
 
   select case(trim(flow_case))
   case('generic')
+    allocate(case_generic_t :: solver)
     solver = case_generic_t(backend, mesh, host_allocator)
   case('tgv')
+    allocate(case_tgv_t :: solver)
     solver = case_tgv_t(backend, mesh, host_allocator)
   case default
     error stop 'Undefined flow_case.'


### PR DESCRIPTION
#121 implements a new class that contains solver, and allows users to extend this new class for any custom case.

In this PR I tried a similar approach by extending the `solver` class directly. Functionality is similar, and I think this is a bit more clear. For a custom case users will be able to write a custom forcing, BC, or postprocessing functions in a dedicated file/module.