### PR TITLE
Add a fill method to field_t

### DIFF
--- a/src/cuda/allocator.f90
+++ b/src/cuda/allocator.f90
@@ -20,6 +20,7 @@ module m_cuda_allocator
     real(dp), device, pointer, contiguous :: data_d(:, :, :)
   contains
     procedure :: fill => fill_cuda
+    procedure :: get_shape => get_shape_cuda
     procedure :: set_shape => set_shape_cuda
   end type cuda_field_t
 
@@ -49,6 +50,16 @@ contains
     self%p_data_d(:) = c
 
   end subroutine fill_cuda
+
+  function get_shape_cuda(self) result(dims)
+    implicit none
+
+    class(cuda_field_t) :: self
+    integer :: dims(3)
+
+    dims = shape(self%data_d)
+
+  end function get_shape_cuda
 
   subroutine set_shape_cuda(self, dims)
     implicit none

--- a/src/cuda/allocator.f90
+++ b/src/cuda/allocator.f90
@@ -19,6 +19,7 @@ module m_cuda_allocator
     real(dp), device, pointer, private :: p_data_d(:)
     real(dp), device, pointer, contiguous :: data_d(:, :, :)
   contains
+    procedure :: fill => fill_cuda
     procedure :: set_shape => set_shape_cuda
   end type cuda_field_t
 
@@ -38,6 +39,16 @@ contains
     f%next => next
     f%id = id
   end function cuda_field_init
+
+  subroutine fill_cuda(self, c)
+    implicit none
+
+    class(cuda_field_t) :: self
+    real(dp), intent(in) :: c
+
+    self%p_data_d(:) = c
+
+  end subroutine fill_cuda
 
   subroutine set_shape_cuda(self, dims)
     implicit none

--- a/src/field.f90
+++ b/src/field.f90
@@ -16,6 +16,7 @@ module m_field
     integer :: refcount = 0
     integer :: id !! An integer identifying the memory block.
   contains
+    procedure :: fill
     procedure :: set_shape
     procedure :: set_data_loc
   end type field_t
@@ -25,6 +26,27 @@ module m_field
   end interface field_t
 
 contains
+
+  function field_init(ngrid, next, id) result(f)
+    integer, intent(in) :: ngrid, id
+    type(field_t), pointer, intent(in) :: next
+    type(field_t) :: f
+
+    allocate (f%p_data(ngrid))
+    f%refcount = 0
+    f%next => next
+    f%id = id
+  end function field_init
+
+  subroutine fill(self, c)
+    implicit none
+
+    class(field_t) :: self
+    real(dp), intent(in) :: c
+
+    self%p_data(:) = c
+
+  end subroutine fill
 
   subroutine set_data_loc(self, data_loc)
     class(field_t) :: self
@@ -43,16 +65,5 @@ contains
     self%data(1:dims(1), 1:dims(2), 1:dims(3)) => self%p_data
 
   end subroutine set_shape
-
-  function field_init(ngrid, next, id) result(f)
-    integer, intent(in) :: ngrid, id
-    type(field_t), pointer, intent(in) :: next
-    type(field_t) :: f
-
-    allocate (f%p_data(ngrid))
-    f%refcount = 0
-    f%next => next
-    f%id = id
-  end function field_init
 
 end module m_field

--- a/src/field.f90
+++ b/src/field.f90
@@ -17,6 +17,7 @@ module m_field
     integer :: id !! An integer identifying the memory block.
   contains
     procedure :: fill
+    procedure :: get_shape
     procedure :: set_shape
     procedure :: set_data_loc
   end type field_t
@@ -55,6 +56,16 @@ contains
     self%data_loc = data_loc
 
   end subroutine
+
+  function get_shape(self) result(dims)
+    implicit none
+
+    class(field_t) :: self
+    integer :: dims(3)
+
+    dims = shape(self%data)
+
+  end function get_shape
 
   subroutine set_shape(self, dims)
     implicit none


### PR DESCRIPTION
`field%fill` method allows easily populating the field data either on the CPU or GPU with a constant float.

Useful in a parallel branch of mine, here demonstrated its use in the time integrator test and cleaned a bit of ifdefs. Merging as soon as tests pass so I can rebase my branch and make use of this.