### PR TITLE
Channel case

### DIFF
--- a/examples/channel/input.x3d
+++ b/examples/channel/input.x3d
@@ -1,0 +1,38 @@
+&domain_settings
+! Flow case
+flow_case_name = 'channel'
+
+! Global domain length
+L_global = 4d0, 2d0, 2d0
+
+! Global number of cells in each direction
+dims_global = 64, 361, 32
+
+! Domain decomposition in each direction
+nproc_dir = 1, 1, 1
+
+! BC options are 'periodic' | 'neumann' | 'dirichlet'
+BC_x = 'periodic', 'periodic'
+BC_y = 'dirichlet', 'dirichlet'
+BC_z = 'periodic', 'periodic'
+/End
+
+&solver_params
+Re = 4200d0
+time_intg = 'RK3' ! 'AB[1-4]' | 'RK[1-4]'
+dt = 0.005d0
+n_iters = 20000
+n_output = 1000
+poisson_solver_type = 'FFT' ! 'FFT' | 'CG'
+der1st_scheme = 'compact6'
+der2nd_scheme = 'compact6' ! 'compact6' | 'compact6-hyperviscous'
+interpl_scheme = 'classic' ! 'classic' | 'optimised' | 'aggressive'
+stagder_scheme = 'compact6'
+/End
+
+&channel_nml
+noise = 0.125d0
+rotation = T
+omega_rot = 0.12d0
+n_rotate = 5000
+/End

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SRC
   field.f90
   vector_calculus.f90
   case/base_case.f90
+  case/channel.f90
   case/generic.f90
   case/tgv.f90
   omp/common.f90

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -42,6 +42,7 @@ module m_base_backend
     procedure(field_max_mean), deferred :: field_max_mean
     procedure(field_ops), deferred :: field_scale
     procedure(field_ops), deferred :: field_shift
+    procedure(field_set_face), deferred :: field_set_face
     procedure(copy_data_to_f), deferred :: copy_data_to_f
     procedure(copy_f_to_data), deferred :: copy_f_to_data
     procedure(alloc_tdsops), deferred :: alloc_tdsops
@@ -176,6 +177,26 @@ module m_base_backend
       class(field_t), intent(in) :: f
       integer, optional, intent(in) :: enforced_data_loc
     end subroutine field_max_mean
+  end interface
+
+  abstract interface
+    subroutine field_set_face(self, f, c_start, c_end, face)
+      !! A field is a subdomain with a rectangular cuboid shape.
+      !! It has 6 faces, and these faces are either a subdomain boundary
+      !! or a global domain boundary based on the location of the subdomain.
+      !! This subroutine allows us to set any of these faces to a value,
+      !! 'c_start' and 'c_end' for faces at opposite sides.
+      !! 'face' is one of X_FACE, Y_FACE, Z_FACE from common.f90
+      import :: base_backend_t
+      import :: dp
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(inout) :: f
+      real(dp), intent(in) :: c_start, c_end
+      integer, intent(in) :: face
+    end subroutine field_set_face
   end interface
 
   abstract interface

--- a/src/backend.f90
+++ b/src/backend.f90
@@ -42,6 +42,7 @@ module m_base_backend
     procedure(field_max_mean), deferred :: field_max_mean
     procedure(field_ops), deferred :: field_scale
     procedure(field_ops), deferred :: field_shift
+    procedure(field_reduce), deferred :: field_volume_integral
     procedure(field_set_face), deferred :: field_set_face
     procedure(copy_data_to_f), deferred :: copy_data_to_f
     procedure(copy_f_to_data), deferred :: copy_f_to_data
@@ -162,6 +163,19 @@ module m_base_backend
       class(field_t), intent(in) :: f
       real(dp), intent(in) :: a
     end subroutine field_ops
+  end interface
+
+  abstract interface
+    real(dp) function field_reduce(self, f) result(s)
+      !! Reduces field to a scalar, example: volume integral
+      import :: base_backend_t
+      import :: dp
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(in) :: f
+    end function field_reduce
   end interface
 
   abstract interface

--- a/src/case/channel.f90
+++ b/src/case/channel.f90
@@ -1,0 +1,166 @@
+module m_case_channel
+  use iso_fortran_env, only: stderr => error_unit
+  use mpi
+
+  use m_allocator, only: allocator_t, field_t
+  use m_base_backend, only: base_backend_t
+  use m_base_case, only: base_case_t
+  use m_common, only: dp, get_argument, DIR_C, VERT, CELL, Y_FACE
+  use m_config, only: channel_config_t
+  use m_mesh, only: mesh_t
+  use m_solver, only: init
+
+  implicit none
+
+  type, extends(base_case_t) :: case_channel_t
+    type(channel_config_t) :: channel_cfg
+  contains
+    procedure :: boundary_conditions => boundary_conditions_channel
+    procedure :: initial_conditions => initial_conditions_channel
+    procedure :: forcings => forcings_channel
+    procedure :: pre_correction => pre_correction_channel
+    procedure :: postprocess => postprocess_channel
+  end type case_channel_t
+
+  interface case_channel_t
+    module procedure case_channel_init
+  end interface case_channel_t
+
+contains
+
+  function case_channel_init(backend, mesh, host_allocator) result(flow_case)
+    implicit none
+
+    class(base_backend_t), target, intent(inout) :: backend
+    type(mesh_t), target, intent(inout) :: mesh
+    type(allocator_t), target, intent(inout) :: host_allocator
+    type(case_channel_t) :: flow_case
+
+    call flow_case%channel_cfg%read(nml_file=get_argument(1))
+
+    call flow_case%case_init(backend, mesh, host_allocator)
+
+  end function case_channel_init
+
+  subroutine boundary_conditions_channel(self)
+    implicit none
+
+    class(case_channel_t) :: self
+
+    real(dp) :: can, ub
+    integer :: ierr
+
+    ub = self%solver%backend%field_volume_integral(self%solver%u)
+
+    ub = ub/(product(self%solver%mesh%get_global_dims(CELL)))
+    call MPI_Allreduce(MPI_IN_PLACE, ub, 1, MPI_DOUBLE_PRECISION, &
+                       MPI_SUM, MPI_COMM_WORLD, ierr)
+
+    can = 2._dp/3._dp - ub
+
+    call self%solver%backend%field_shift(self%solver%u, can)
+
+  end subroutine boundary_conditions_channel
+
+  subroutine initial_conditions_channel(self)
+    implicit none
+
+    class(case_channel_t) :: self
+
+    class(field_t), pointer :: u_init, v_init, w_init
+
+    integer :: i, j, k, dims(3)
+    real(dp) :: xloc(3), y, noise, um
+
+    dims = self%solver%mesh%get_dims(VERT)
+    u_init => self%solver%host_allocator%get_block(DIR_C)
+    v_init => self%solver%host_allocator%get_block(DIR_C)
+    w_init => self%solver%host_allocator%get_block(DIR_C)
+
+    call random_number(u_init%data(1:dims(1), 1:dims(2), 1:dims(3)))
+    call random_number(v_init%data(1:dims(1), 1:dims(2), 1:dims(3)))
+    call random_number(w_init%data(1:dims(1), 1:dims(2), 1:dims(3)))
+
+    noise = self%channel_cfg%noise
+    do k = 1, dims(3)
+      do j = 1, dims(2)
+        do i = 1, dims(1)
+          xloc = self%solver%mesh%get_coordinates(i, j, k)
+          y = xloc(2) - self%solver%mesh%geo%L(2)/2._dp
+          um = exp(-0.2_dp*y*y)
+
+          u_init%data(i, j, k) = 1._dp - y*y &
+                                 + noise*um*(2*u_init%data(i, j, k) - 1._dp)
+          v_init%data(i, j, k) = noise*um*(2*v_init%data(i, j, k) - 1._dp)
+          w_init%data(i, j, k) = noise*um*(2*w_init%data(i, j, k) - 1._dp)
+        end do
+      end do
+    end do
+
+    u_init%data(:, 1, :) = 0
+    v_init%data(:, 1, :) = 0
+    w_init%data(:, 1, :) = 0
+    u_init%data(:, dims(2), :) = 0
+    v_init%data(:, dims(2), :) = 0
+    w_init%data(:, dims(2), :) = 0
+
+    call self%solver%backend%set_field_data(self%solver%u, u_init%data)
+    call self%solver%backend%set_field_data(self%solver%v, v_init%data)
+    call self%solver%backend%set_field_data(self%solver%w, w_init%data)
+
+    call self%solver%host_allocator%release_block(u_init)
+    call self%solver%host_allocator%release_block(v_init)
+    call self%solver%host_allocator%release_block(w_init)
+
+    call self%solver%u%set_data_loc(VERT)
+    call self%solver%v%set_data_loc(VERT)
+    call self%solver%w%set_data_loc(VERT)
+
+  end subroutine initial_conditions_channel
+
+  subroutine forcings_channel(self, du, dv, dw, iter)
+    implicit none
+
+    class(case_channel_t) :: self
+    class(field_t), intent(inout) :: du, dv, dw
+    integer, intent(in) :: iter
+
+    real(dp) :: rot
+
+    if (self%channel_cfg%rotation .and. iter < self%channel_cfg%n_rotate) then
+      rot = self%channel_cfg%omega_rot
+      call self%solver%backend%vecadd(-rot, self%solver%v, 1._dp, du)
+      call self%solver%backend%vecadd(rot, self%solver%u, 1._dp, dv)
+    end if
+
+  end subroutine forcings_channel
+
+  subroutine pre_correction_channel(self, u, v, w)
+    implicit none
+
+    class(case_channel_t) :: self
+    class(field_t), intent(inout) :: u, v, w
+
+    call self%solver%backend%field_set_face(u, 0._dp, 0._dp, Y_FACE)
+    call self%solver%backend%field_set_face(v, 0._dp, 0._dp, Y_FACE)
+    call self%solver%backend%field_set_face(w, 0._dp, 0._dp, Y_FACE)
+
+  end subroutine pre_correction_channel
+
+  subroutine postprocess_channel(self, iter, t)
+    implicit none
+
+    class(case_channel_t) :: self
+    integer, intent(in) :: iter
+    real(dp), intent(in) :: t
+
+    if (self%solver%mesh%par%is_root()) then
+      print *, 'time =', t, 'iteration =', iter
+    end if
+
+    call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
+    call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
+
+  end subroutine postprocess_channel
+
+end module m_case_channel

--- a/src/case/generic.f90
+++ b/src/case/generic.f90
@@ -18,6 +18,7 @@ module m_case_generic
     procedure :: boundary_conditions => boundary_conditions_generic
     procedure :: initial_conditions => initial_conditions_generic
     procedure :: forcings => forcings_generic
+    procedure :: pre_correction => pre_correction_generic
     procedure :: postprocess => postprocess_generic
   end type case_generic_t
 
@@ -61,25 +62,37 @@ contains
 
   end subroutine initial_conditions_generic
 
-  subroutine postprocess_generic(self, i, t)
-    implicit none
-
-    class(case_generic_t) :: self
-    integer, intent(in) :: i
-    real(dp), intent(in) :: t
-
-    if (self%solver%mesh%par%is_root()) print *, 'time =', t, 'iteration =', i
-    call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
-    call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
-
-  end subroutine postprocess_generic
-
-  subroutine forcings_generic(self, du, dv, dw)
+  subroutine forcings_generic(self, du, dv, dw, iter)
     implicit none
 
     class(case_generic_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
+    integer, intent(in) :: iter
 
   end subroutine forcings_generic
+
+  subroutine pre_correction_generic(self, u, v, w)
+    implicit none
+
+    class(case_generic_t) :: self
+    class(field_t), intent(inout) :: u, v, w
+
+  end subroutine pre_correction_generic
+
+  subroutine postprocess_generic(self, iter, t)
+    implicit none
+
+    class(case_generic_t) :: self
+    integer, intent(in) :: iter
+    real(dp), intent(in) :: t
+
+    if (self%solver%mesh%par%is_root()) then
+      print *, 'time =', t, 'iteration =', iter
+    end if
+
+    call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
+    call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
+
+  end subroutine postprocess_generic
 
 end module m_case_generic

--- a/src/case/tgv.f90
+++ b/src/case/tgv.f90
@@ -16,6 +16,7 @@ module m_case_tgv
     procedure :: boundary_conditions => boundary_conditions_tgv
     procedure :: initial_conditions => initial_conditions_tgv
     procedure :: forcings => forcings_tgv
+    procedure :: pre_correction => pre_correction_tgv
     procedure :: postprocess => postprocess_tgv
   end type case_tgv_t
 
@@ -78,23 +79,36 @@ contains
     ! do nothing for TGV case
   end subroutine boundary_conditions_tgv
 
-  subroutine forcings_tgv(self, du, dv, dw)
+  subroutine forcings_tgv(self, du, dv, dw, iter)
     implicit none
 
     class(case_tgv_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
+    integer, intent(in) :: iter
 
     ! do nothing for TGV case
   end subroutine forcings_tgv
 
-  subroutine postprocess_tgv(self, i, t)
+  subroutine pre_correction_tgv(self, u, v, w)
     implicit none
 
     class(case_tgv_t) :: self
-    integer, intent(in) :: i
+    class(field_t), intent(inout) :: u, v, w
+
+    ! do nothing for TGV case
+  end subroutine pre_correction_tgv
+
+  subroutine postprocess_tgv(self, iter, t)
+    implicit none
+
+    class(case_tgv_t) :: self
+    integer, intent(in) :: iter
     real(dp), intent(in) :: t
 
-    if (self%solver%mesh%par%is_root()) print *, 'time =', t, 'iteration =', i
+    if (self%solver%mesh%par%is_root()) then
+      print *, 'time =', t, 'iteration =', iter
+    end if
+
     call self%print_enstrophy(self%solver%u, self%solver%v, self%solver%w)
     call self%print_div_max_mean(self%solver%u, self%solver%v, self%solver%w)
 

--- a/src/config.f90
+++ b/src/config.f90
@@ -31,6 +31,14 @@ module m_config
     procedure :: read => read_solver_nml
   end type solver_config_t
 
+  type, extends(base_config_t) :: channel_config_t
+    real(dp) :: noise, omega_rot
+    logical :: rotation
+    integer :: n_rotate
+  contains
+    procedure :: read => read_channel_nml
+  end type channel_config_t
+
   abstract interface
     subroutine read(self, nml_file, nml_string) !&
       !! Assigns the member variables either from a file or text source.
@@ -135,6 +143,42 @@ contains
     self%stagder_scheme = stagder_scheme
 
   end subroutine read_solver_nml
+
+  subroutine read_channel_nml(self, nml_file, nml_string)
+    implicit none
+
+    class(channel_config_t) :: self
+    character(*), optional, intent(in) :: nml_file
+    character(*), optional, intent(in) :: nml_string
+
+    integer :: unit
+
+    real(dp) :: noise, omega_rot
+    logical :: rotation
+    integer :: n_rotate
+
+    namelist /channel_nml/ noise, rotation, omega_rot, n_rotate
+
+    if (present(nml_file) .and. present(nml_string)) then
+      error stop 'Reading channel config failed! &
+                 &Provide only a file name or source, not both.'
+    else if (present(nml_file)) then
+      open (newunit=unit, file=nml_file)
+      read (unit, nml=channel_nml)
+      close (unit)
+    else if (present(nml_string)) then
+      read (nml_string, nml=channel_nml)
+    else
+      error stop 'Reading channel config failed! &
+                 &Provide at least one of the following: file name or source'
+    end if
+
+    self%noise = noise
+    self%rotation = rotation
+    self%omega_rot = omega_rot
+    self%n_rotate = n_rotate
+
+  end subroutine read_channel_nml
 
 end module m_config
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -8,7 +8,8 @@ module m_cuda_backend
   use m_common, only: dp, move_data_loc, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
                       RDR_C2X, RDR_C2Y, RDR_C2Z, RDR_X2C, RDR_Y2C, RDR_Z2C, &
-                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, NULL_LOC
+                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, NULL_LOC, &
+                      X_FACE, Y_FACE, Z_FACE
   use m_field, only: field_t
   use m_mesh, only: mesh_t
   use m_tdsops, only: dirps_t, tdsops_t
@@ -21,7 +22,8 @@ module m_cuda_backend
   use m_cuda_tdsops, only: cuda_tdsops_t
   use m_cuda_kernels_dist, only: transeq_3fused_dist, transeq_3fused_subs
   use m_cuda_kernels_fieldops, only: axpby, buffer_copy, field_scale, &
-                                     field_shift, scalar_product, field_max_sum
+                                     field_shift, scalar_product, &
+                                     field_max_sum, field_set_y_face
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c, &
@@ -56,6 +58,7 @@ module m_cuda_backend
     procedure :: field_max_mean => field_max_mean_cuda
     procedure :: field_scale => field_scale_cuda
     procedure :: field_shift => field_shift_cuda
+    procedure :: field_set_face => field_set_face_cuda
     procedure :: copy_data_to_f => copy_data_to_f_cuda
     procedure :: copy_f_to_data => copy_f_to_data_cuda
     procedure :: init_poisson_fft => init_cuda_poisson_fft
@@ -786,6 +789,47 @@ contains
     call field_shift<<<blocks, threads>>>(f_d, a, n) !&
 
   end subroutine field_shift_cuda
+
+  subroutine field_set_face_cuda(self, f, c_start, c_end, face)
+    !! [[m_base_backend(module):field_set_face(subroutine)]]
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(inout) :: f
+    real(dp), intent(in) :: c_start, c_end
+    integer, intent(in) :: face
+
+    real(dp), device, pointer, dimension(:, :, :) :: f_d
+    type(dim3) :: blocks, threads
+    integer :: dims(3), nx, ny, nz
+
+    if (f%dir /= DIR_X) then
+      error stop 'Setting a field face is only supported for DIR_X fields.'
+    end if
+
+    if (f%data_loc == NULL_LOC) then
+      error stop 'field_set_face require a valid data_loc.'
+    end if
+
+    call resolve_field_t(f_d, f)
+
+    dims = self%mesh%get_dims(f%data_loc)
+
+    select case (face)
+    case (X_FACE)
+      error stop 'Setting X_FACE is not yet supported.'
+    case (Y_FACE)
+      blocks = dim3((dims(1) - 1)/64 + 1, dims(3), 1)
+      threads = dim3(64, 1, 1)
+      call field_set_y_face<<<blocks, threads>>>(f_d, c_start, c_end, & !&
+                                                 dims(1), dims(2), dims(3))
+    case (Z_FACE)
+      error stop 'Setting Z_FACE is not yet supported.'
+    case default
+      error stop 'face is undefined.'
+    end select
+
+  end subroutine field_set_face_cuda
 
   subroutine copy_data_to_f_cuda(self, f, data)
     class(cuda_backend_t), intent(inout) :: self

--- a/src/cuda/kernels/spectral_processing.f90
+++ b/src/cuda/kernels/spectral_processing.f90
@@ -126,4 +126,163 @@ contains
 
   end subroutine process_spectral_000
 
+  attributes(global) subroutine process_spectral_010( &
+    div_u, waves, nx_spec, ny_spec, y_sp_st, nx, ny, nz, &
+    ax, bx, ay, by, az, bz &
+    )
+    !! Post-processes the divergence of velocity in spectral space, including
+    !! scaling w.r.t. grid size.
+    !!
+    !! Ref. JCP 228 (2009), 5989–6015, Sec 4
+    implicit none
+
+    !> Divergence of velocity in spectral space
+    complex(dp), device, intent(inout), dimension(:, :, :) :: div_u
+    !> Spectral equivalence constants
+    complex(dp), device, intent(in), dimension(:, :, :) :: waves
+    real(dp), device, intent(in), dimension(:) :: ax, bx, ay, by, az, bz
+    !> Grid size in spectral space
+    integer, value, intent(in) :: nx_spec, ny_spec
+    !> Offset in y direction in the permuted slabs in spectral space
+    integer, value, intent(in) :: y_sp_st
+    !> Grid size
+    integer, value, intent(in) :: nx, ny, nz
+
+    integer :: i, j, k, ix, iy, iz, iy_rev
+    real(dp) :: tmp_r, tmp_c, div_r, div_c, l_r, l_c, r_r, r_c
+
+    i = threadIdx%x + (blockIdx%x - 1)*blockDim%x
+    k = blockIdx%y ! nz_spec
+
+    if (i <= nx_spec) then
+      do j = 1, ny_spec
+        ix = i; iy = j + y_sp_st; iz = k
+
+        ! normalisation
+        div_r = real(div_u(i, j, k), kind=dp)/nx/ny/nz
+        div_c = aimag(div_u(i, j, k))/nx/ny/nz
+
+        ! postprocess in z
+        tmp_r = div_r
+        tmp_c = div_c
+        div_r = tmp_r*bz(iz) + tmp_c*az(iz)
+        div_c = tmp_c*bz(iz) - tmp_r*az(iz)
+        if (iz > nz/2 + 1) div_r = -div_r
+        if (iz > nz/2 + 1) div_c = -div_c
+
+        ! postprocess in x
+        tmp_r = div_r
+        tmp_c = div_c
+        div_r = tmp_r*bx(ix) + tmp_c*ax(ix)
+        div_c = tmp_c*bx(ix) - tmp_r*ax(ix)
+        if (ix > nx/2 + 1) div_r = -div_r
+        if (ix > nx/2 + 1) div_c = -div_c
+
+        ! update the entry
+        div_u(i, j, k) = cmplx(div_r, div_c, kind=dp)
+      end do
+    end if
+
+    if (i <= nx_spec) then
+      do j = 2, ny_spec/2 + 1
+        ix = i; iy = j + y_sp_st; iz = k
+        iy_rev = ny_spec - j + 2 + y_sp_st
+
+        l_r = real(div_u(i, j, k), kind=dp)
+        l_c = aimag(div_u(i, j, k))
+        r_r = real(div_u(i, ny_spec - j + 2, k), kind=dp)
+        r_c = aimag(div_u(i, ny_spec - j + 2, k))
+
+        ! update the entry
+        div_u(i, j, k) = 0.5_dp*cmplx( & !&
+         l_r*by(iy) + l_c*ay(iy) + r_r*by(iy) - r_c*ay(iy), &
+         -l_r*ay(iy) + l_c*by(iy) + r_r*ay(iy) + r_c*by(iy), kind=dp &
+         )
+        div_u(i, ny_spec - j + 2, k) = 0.5_dp*cmplx( & !&
+         r_r*by(iy_rev) + r_c*ay(iy_rev) + l_r*by(iy_rev) - l_c*ay(iy_rev), &
+         -r_r*ay(iy_rev) + r_c*by(iy_rev) + l_r*ay(iy_rev) + l_c*by(iy_rev), &
+         kind=dp &
+         )
+      end do
+    end if
+
+    ! Solve Poisson
+    if (i <= nx_spec) then
+      do j = 1, ny_spec
+        div_r = real(div_u(i, j, k), kind=dp)
+        div_c = aimag(div_u(i, j, k))
+
+        tmp_r = real(waves(i, j, k), kind=dp)
+        tmp_c = aimag(waves(i, j, k))
+        if (abs(tmp_r) < 1.e-16_dp) then
+          div_r = 0._dp
+        else
+          div_r = -div_r/tmp_r
+        end if
+        if (abs(tmp_c) < 1.e-16_dp) then
+          div_c = 0._dp
+        else
+          div_c = -div_c/tmp_c
+        end if
+
+        ! update the entry
+        div_u(i, j, k) = cmplx(div_r, div_c, kind=dp)
+        if (i == nx/2 + 1 .and. k == nz/2 + 1) div_u(i, j, k) = 0._dp
+      end do
+    end if
+
+    ! post-process backward
+    if (i <= nx_spec) then
+      do j = 2, ny_spec/2 + 1
+        ix = i; iy = j + y_sp_st; iz = k
+        iy_rev = ny_spec - j + 2 + y_sp_st
+
+        l_r = real(div_u(i, j, k), kind=dp)
+        l_c = aimag(div_u(i, j, k))
+        r_r = real(div_u(i, ny_spec - j + 2, k), kind=dp)
+        r_c = aimag(div_u(i, ny_spec - j + 2, k))
+
+        ! update the entry
+        div_u(i, j, k) = cmplx( & !&
+          l_r*by(iy) - l_c*ay(iy) + r_r*ay(iy) + r_c*by(iy), &
+          l_r*ay(iy) + l_c*by(iy) - r_r*by(iy) + r_c*ay(iy), kind=dp &
+          )
+        div_u(i, ny_spec - j + 2, k) = cmplx( & !&
+          r_r*by(iy_rev) - r_c*ay(iy_rev) + l_r*ay(iy_rev) + l_c*by(iy_rev), &
+          r_r*ay(iy_rev) + r_c*by(iy_rev) - l_r*by(iy_rev) + l_c*ay(iy_rev), &
+          kind=dp &
+          )
+      end do
+    end if
+
+    if (i <= nx_spec) then
+      do j = 1, ny_spec
+        ix = i; iy = j + y_sp_st; iz = k
+
+        div_r = real(div_u(i, j, k), kind=dp)
+        div_c = aimag(div_u(i, j, k))
+
+        ! post-process in z
+        tmp_r = div_r
+        tmp_c = div_c
+        div_r = tmp_r*bz(iz) - tmp_c*az(iz)
+        div_c = tmp_c*bz(iz) + tmp_r*az(iz)
+        if (iz > nz/2 + 1) div_r = -div_r
+        if (iz > nz/2 + 1) div_c = -div_c
+
+        ! post-process in x
+        tmp_r = div_r
+        tmp_c = div_c
+        div_r = tmp_r*bx(ix) - tmp_c*ax(ix)
+        div_c = tmp_c*bx(ix) + tmp_r*ax(ix)
+        if (ix > nx/2 + 1) div_r = -div_r
+        if (ix > nx/2 + 1) div_c = -div_c
+
+        ! update the entry
+        div_u(i, j, k) = cmplx(div_r, div_c, kind=dp)
+      end do
+    end if
+
+  end subroutine process_spectral_010
+
 end module m_cuda_spectral

--- a/src/cuda/kernels/spectral_processing.f90
+++ b/src/cuda/kernels/spectral_processing.f90
@@ -27,7 +27,7 @@ contains
     end if
   end subroutine memcpy3D
 
-  attributes(global) subroutine process_spectral_div_u( &
+  attributes(global) subroutine process_spectral_000( &
     div_u, waves, nx_spec, ny_spec, y_sp_st, nx, ny, nz, &
     ax, bx, ay, by, az, bz &
     )
@@ -124,6 +124,6 @@ contains
       end do
     end if
 
-  end subroutine process_spectral_div_u
+  end subroutine process_spectral_000
 
 end module m_cuda_spectral

--- a/src/cuda/kernels/spectral_processing.f90
+++ b/src/cuda/kernels/spectral_processing.f90
@@ -285,4 +285,44 @@ contains
 
   end subroutine process_spectral_010
 
+  attributes(global) subroutine enforce_periodicity_y(f_out, f_in, ny)
+    implicit none
+
+    real(dp), device, intent(out), dimension(:, :, :) :: f_out
+    real(dp), device, intent(in), dimension(:, :, :) :: f_in
+    integer, value, intent(in) :: ny
+
+    integer :: i, j, k
+
+    i = threadIdx%x
+    k = blockIdx%x
+
+    do j = 1, ny/2
+      f_out(i, j, k) = f_in(i, 2*j - 1, k)
+    end do
+    do j = ny/2 + 1, ny
+      f_out(i, j, k) = f_in(i, 2*ny - 2*j + 2, k)
+    end do
+
+  end subroutine enforce_periodicity_y
+
+  attributes(global) subroutine undo_periodicity_y(f_out, f_in, ny)
+    implicit none
+
+    real(dp), device, intent(out), dimension(:, :, :) :: f_out
+    real(dp), device, intent(in), dimension(:, :, :) :: f_in
+    integer, value, intent(in) :: ny
+
+    integer :: i, j, k
+
+    i = threadIdx%x
+    k = blockIdx%x
+
+    do j = 1, ny/2
+      f_out(i, 2*j - 1, k) = f_in(i, j, k)
+      f_out(i, 2*j, k) = f_in(i, ny - j + 1, k)
+    end do
+
+  end subroutine undo_periodicity_y
+
 end module m_cuda_spectral

--- a/src/cuda/poisson_fft.f90
+++ b/src/cuda/poisson_fft.f90
@@ -34,7 +34,8 @@ module m_cuda_poisson_fft
   contains
     procedure :: fft_forward => fft_forward_cuda
     procedure :: fft_backward => fft_backward_cuda
-    procedure :: fft_postprocess => fft_postprocess_cuda
+    procedure :: fft_postprocess_000 => fft_postprocess_000_cuda
+
   end type cuda_poisson_fft_t
 
   interface cuda_poisson_fft_t
@@ -202,7 +203,7 @@ contains
 
   end subroutine fft_backward_cuda
 
-  subroutine fft_postprocess_cuda(self)
+  subroutine fft_postprocess_000_cuda(self)
     implicit none
 
     class(cuda_poisson_fft_t) :: self
@@ -232,6 +233,6 @@ contains
       self%az_dev, self%bz_dev &
       )
 
-  end subroutine fft_postprocess_cuda
+  end subroutine fft_postprocess_000_cuda
 
 end module m_cuda_poisson_fft

--- a/src/cuda/poisson_fft.f90
+++ b/src/cuda/poisson_fft.f90
@@ -13,7 +13,7 @@ module m_cuda_poisson_fft
   use m_tdsops, only: dirps_t
 
   use m_cuda_allocator, only: cuda_field_t
-  use m_cuda_spectral, only: process_spectral_div_u, memcpy3D
+  use m_cuda_spectral, only: process_spectral_000, memcpy3D
 
   implicit none
 
@@ -225,7 +225,7 @@ contains
     threads = dim3(tsize, 1, 1)
 
     ! Postprocess div_u in spectral space
-    call process_spectral_div_u<<<blocks, threads>>>( & !&
+    call process_spectral_000<<<blocks, threads>>>( & !&
       c_dev, self%waves_dev, self%nx_spec, self%ny_spec, self%y_sp_st, &
       self%nx_glob, self%ny_glob, self%nz_glob, &
       self%ax_dev, self%bx_dev, self%ay_dev, self%by_dev, &

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -44,6 +44,7 @@ module m_omp_backend
     procedure :: field_scale => field_scale_omp
     procedure :: field_shift => field_shift_omp
     procedure :: field_set_face => field_set_face_omp
+    procedure :: field_volume_integral => field_volume_integral_omp
     procedure :: copy_data_to_f => copy_data_to_f_omp
     procedure :: copy_f_to_data => copy_f_to_data_omp
     procedure :: init_poisson_fft => init_omp_poisson_fft
@@ -683,6 +684,51 @@ contains
     end select
 
   end subroutine field_set_face_omp
+
+  real(dp) function field_volume_integral_omp(self, f) result(s)
+    !! volume integral of a field
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(in) :: f
+
+    real(dp) :: sum_p, sum_pncl
+    integer :: dims(3), stacked, i, j, k, k_i, k_j, ierr
+
+    if (f%data_loc == NULL_LOC) then
+      error stop 'You must set the data_loc before calling volume integral.'
+    end if
+    if (f%dir /= DIR_X) then
+      error stop 'Volume integral can only be called on DIR_X fields.'
+    end if
+
+    dims = self%mesh%get_dims(f%data_loc)
+    stacked = (dims(2) - 1)/SZ + 1
+
+    sum_p = 0._dp
+    !$omp parallel do collapse(2) reduction(+:sum_p) private(k, sum_pncl)
+    do k_j = 1, stacked ! loop over stacked groups
+      do k_i = 1, dims(3)
+        k = k_j + (k_i - 1)*stacked
+        sum_pncl = 0._dp
+        do j = 1, dims(1)
+          ! loop over only non-padded entries in the present group
+          do i = 1, min(SZ, dims(2) - (k_j - 1)*SZ)
+            sum_pncl = sum_pncl + f%data(i, j, k)
+          end do
+        end do
+        sum_p = sum_p + sum_pncl
+      end do
+    end do
+    !$omp end parallel do
+
+    ! rank-local values
+    s = sum_p
+
+    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+                       MPI_COMM_WORLD, ierr)
+
+  end function field_volume_integral_omp
 
   subroutine copy_data_to_f_omp(self, f, data)
     class(omp_backend_t), intent(inout) :: self

--- a/src/omp/kernels/spectral_processing.f90
+++ b/src/omp/kernels/spectral_processing.f90
@@ -3,16 +3,26 @@ module m_omp_spectral
   implicit none
 
 contains
-  subroutine process_spectral_div_u( &
+
+  subroutine process_spectral_000( &
     div_u, waves, nx_spec, ny_spec, nz_spec, x_sp_st, y_sp_st, z_sp_st, &
     nx, ny, nz, ax, bx, ay, by, az, bz &
     )
+    !! Post-process div U* in spectral space for all periodic BCs.
+    !!
+    !! Ref. JCP 228 (2009), 5989–6015, Sec 4
+    implicit none
 
+    !> Divergence of velocity in spectral space
     complex(dp), intent(inout), dimension(:, :, :) :: div_u
+    !> Spectral equivalence constants
     complex(dp), intent(in), dimension(:, :, :) :: waves
     real(dp), intent(in), dimension(:) :: ax, bx, ay, by, az, bz
+    !> Grid size in spectral space
     integer, intent(in) :: nx_spec, ny_spec, nz_spec
+    !> Offsets in the permuted pencils in spectral space
     integer, intent(in) :: x_sp_st, y_sp_st, z_sp_st
+    !> Global cell size
     integer, intent(in) :: nx, ny, nz
 
     integer :: i, j, k, ix, iy, iz
@@ -93,6 +103,183 @@ contains
     end do
     !$omp end parallel do
 
-  end subroutine
+  end subroutine process_spectral_000
+
+  subroutine process_spectral_010( &
+    div_u, waves, nx_spec, ny_spec, nz_spec, x_sp_st, y_sp_st, z_sp_st, &
+    nx, ny, nz, ax, bx, ay, by, az, bz &
+    )
+    !! Post-process div U* in spectral space, for non-periodic BC in y-dir.
+    !!
+    !! Ref. JCP 228 (2009), 5989–6015, Sec 4
+    implicit none
+
+    !> Divergence of velocity in spectral space
+    complex(dp), intent(inout), dimension(:, :, :) :: div_u
+    !> Spectral equivalence constants
+    complex(dp), intent(in), dimension(:, :, :) :: waves
+    real(dp), intent(in), dimension(:) :: ax, bx, ay, by, az, bz
+    !> Grid size in spectral space
+    integer, intent(in) :: nx_spec, ny_spec, nz_spec
+    !> Offsets in the permuted pencils in spectral space
+    integer, intent(in) :: x_sp_st, y_sp_st, z_sp_st
+    !> Global cell size
+    integer, intent(in) :: nx, ny, nz
+
+    integer :: i, j, k, ix, iy, iz, iy_r
+    real(dp) :: tmp_r, tmp_c, div_r, div_c, l_r, l_c, r_r, r_c
+
+    !$omp parallel do private(div_r, div_c, ix, iz, tmp_r, tmp_c) collapse(3)
+    do k = 1, nz_spec
+      do j = 1, ny_spec
+        do i = 1, nx_spec
+          ix = i + x_sp_st
+          iz = k + z_sp_st
+
+          ! normalisation
+          div_r = real(div_u(i, j, k), kind=dp)/nx/ny/nz
+          div_c = aimag(div_u(i, j, k))/nx/ny/nz
+
+          ! postprocess in z
+          tmp_r = div_r
+          tmp_c = div_c
+          div_r = tmp_r*bz(iz) + tmp_c*az(iz)
+          div_c = tmp_c*bz(iz) - tmp_r*az(iz)
+          if (iz > nz/2 + 1) div_r = -div_r
+          if (iz > nz/2 + 1) div_c = -div_c
+
+          ! postprocess in x
+          tmp_r = div_r
+          tmp_c = div_c
+          div_r = tmp_r*bx(ix) + tmp_c*ax(ix)
+          div_c = tmp_c*bx(ix) - tmp_r*ax(ix)
+          if (ix > nx/2 + 1) div_r = -div_r
+          if (ix > nx/2 + 1) div_c = -div_c
+
+          ! update the entry
+          div_u(i, j, k) = cmplx(div_r, div_c, kind=dp)
+        end do
+      end do
+    end do
+    !$omp end parallel do
+
+    !$omp parallel do private(div_r, div_c, iy, iy_r, l_r, l_c, r_r, r_c) collapse(3)
+    do k = 1, nz_spec
+      do j = 2, ny_spec/2 + 1
+        do i = 1, nx_spec
+          iy = j + y_sp_st
+          iy_r = ny_spec - j + 2 + y_sp_st
+
+          l_r = real(div_u(i, j, k), kind=dp)
+          l_c = aimag(div_u(i, j, k))
+          r_r = real(div_u(i, ny_spec - j + 2, k), kind=dp)
+          r_c = aimag(div_u(i, ny_spec - j + 2, k))
+
+          ! update the entry
+          div_u(i, j, k) = 0.5_dp*cmplx( & !&
+            l_r*by(iy) + l_c*ay(iy) + r_r*by(iy) - r_c*ay(iy), &
+            -l_r*ay(iy) + l_c*by(iy) + r_r*ay(iy) + r_c*by(iy), kind=dp &
+            )
+          div_u(i, ny_spec - j + 2, k) = 0.5_dp*cmplx( & !&
+            r_r*by(iy_r) + r_c*ay(iy_r) + l_r*by(iy_r) - l_c*ay(iy_r), &
+            -r_r*ay(iy_r) + r_c*by(iy_r) + l_r*ay(iy_r) + l_c*by(iy_r), &
+           kind=dp &
+           )
+        end do
+      end do
+    end do
+    !$omp end parallel do
+
+    ! Solve Poisson
+    !$omp parallel do private(div_r, div_c, tmp_r, tmp_c) collapse(3)
+    do k = 1, nz_spec
+      do j = 1, ny_spec
+        do i = 1, nx_spec
+          div_r = real(div_u(i, j, k), kind=dp)
+          div_c = aimag(div_u(i, j, k))
+
+          tmp_r = real(waves(i, j, k), kind=dp)
+          tmp_c = aimag(waves(i, j, k))
+          if (abs(tmp_r) < 1.e-16_dp) then
+            div_r = 0._dp
+          else
+            div_r = -div_r/tmp_r
+          end if
+          if (abs(tmp_c) < 1.e-16_dp) then
+            div_c = 0._dp
+          else
+            div_c = -div_c/tmp_c
+          end if
+
+          ! update the entry
+          div_u(i, j, k) = cmplx(div_r, div_c, kind=dp)
+          if (i == nx/2 + 1 .and. k == nz/2 + 1) div_u(i, j, k) = 0._dp
+        end do
+      end do
+    end do
+    !$omp end parallel do
+
+    ! post-process backward
+    !$omp parallel do private(div_r, div_c, iy, iy_r, l_r, l_c, r_r, r_c) collapse(3)
+    do k = 1, nz_spec
+      do j = 2, ny_spec/2 + 1
+        do i = 1, nx_spec
+          iy = j + y_sp_st
+          iy_r = ny_spec - j + 2 + y_sp_st
+
+          l_r = real(div_u(i, j, k), kind=dp)
+          l_c = aimag(div_u(i, j, k))
+          r_r = real(div_u(i, ny_spec - j + 2, k), kind=dp)
+          r_c = aimag(div_u(i, ny_spec - j + 2, k))
+
+          ! update the entry
+          div_u(i, j, k) = cmplx( & !&
+            l_r*by(iy) - l_c*ay(iy) + r_r*ay(iy) + r_c*by(iy), &
+            l_r*ay(iy) + l_c*by(iy) - r_r*by(iy) + r_c*ay(iy), kind=dp &
+            )
+          div_u(i, ny_spec - j + 2, k) = cmplx( & !&
+            r_r*by(iy_r) - r_c*ay(iy_r) + l_r*ay(iy_r) + l_c*by(iy_r), &
+            r_r*ay(iy_r) + r_c*by(iy_r) - l_r*by(iy_r) + l_c*ay(iy_r), &
+            kind=dp &
+            )
+        end do
+      end do
+    end do
+    !$omp end parallel do
+
+    !$omp parallel do private(div_r, div_c, ix, iz, tmp_r, tmp_c) collapse(3)
+    do k = 1, nz_spec
+      do j = 1, ny_spec
+        do i = 1, nx_spec
+          ix = i + x_sp_st
+          iz = k + z_sp_st
+
+          div_r = real(div_u(i, j, k), kind=dp)
+          div_c = aimag(div_u(i, j, k))
+
+          ! post-process in z
+          tmp_r = div_r
+          tmp_c = div_c
+          div_r = tmp_r*bz(iz) - tmp_c*az(iz)
+          div_c = tmp_c*bz(iz) + tmp_r*az(iz)
+          if (iz > nz/2 + 1) div_r = -div_r
+          if (iz > nz/2 + 1) div_c = -div_c
+
+          ! post-process in x
+          tmp_r = div_r
+          tmp_c = div_c
+          div_r = tmp_r*bx(ix) - tmp_c*ax(ix)
+          div_c = tmp_c*bx(ix) + tmp_r*ax(ix)
+          if (ix > nx/2 + 1) div_r = -div_r
+          if (ix > nx/2 + 1) div_c = -div_c
+
+          ! update the entry
+          div_u(i, j, k) = cmplx(div_r, div_c, kind=dp)
+        end do
+      end do
+    end do
+    !$omp end parallel do
+
+  end subroutine process_spectral_010
 
 end module m_omp_spectral

--- a/src/omp/poisson_fft.f90
+++ b/src/omp/poisson_fft.f90
@@ -21,6 +21,9 @@ module m_omp_poisson_fft
     procedure :: fft_forward => fft_forward_omp
     procedure :: fft_backward => fft_backward_omp
     procedure :: fft_postprocess_000 => fft_postprocess_000_omp
+    procedure :: fft_postprocess_010 => fft_postprocess_010_omp
+    procedure :: enforce_periodicity_y => enforce_periodicity_y_omp
+    procedure :: undo_periodicity_y => undo_periodicity_y_omp
   end type omp_poisson_fft_t
 
   interface omp_poisson_fft_t
@@ -90,5 +93,29 @@ contains
       )
 
   end subroutine fft_postprocess_000_omp
+
+  subroutine fft_postprocess_010_omp(self)
+    implicit none
+
+    class(omp_poisson_fft_t) :: self
+  end subroutine fft_postprocess_010_omp
+
+  subroutine enforce_periodicity_y_omp(self, f_out, f_in)
+    implicit none
+
+    class(omp_poisson_fft_t) :: self
+    class(field_t), intent(inout) :: f_out
+    class(field_t), intent(in) :: f_in
+
+  end subroutine enforce_periodicity_y_omp
+
+  subroutine undo_periodicity_y_omp(self, f_out, f_in)
+    implicit none
+
+    class(omp_poisson_fft_t) :: self
+    class(field_t), intent(inout) :: f_out
+    class(field_t), intent(in) :: f_in
+
+  end subroutine undo_periodicity_y_omp
 
 end module m_omp_poisson_fft

--- a/src/omp/poisson_fft.f90
+++ b/src/omp/poisson_fft.f90
@@ -20,7 +20,7 @@ module m_omp_poisson_fft
   contains
     procedure :: fft_forward => fft_forward_omp
     procedure :: fft_backward => fft_backward_omp
-    procedure :: fft_postprocess => fft_postprocess_omp
+    procedure :: fft_postprocess_000 => fft_postprocess_000_omp
   end type omp_poisson_fft_t
 
   interface omp_poisson_fft_t
@@ -77,7 +77,7 @@ contains
 
   end subroutine fft_backward_omp
 
-  subroutine fft_postprocess_omp(self)
+  subroutine fft_postprocess_000_omp(self)
     implicit none
 
     class(omp_poisson_fft_t) :: self
@@ -89,6 +89,6 @@ contains
       self%ax, self%bx, self%ay, self%by, self%az, self%bz &
       )
 
-  end subroutine fft_postprocess_omp
+  end subroutine fft_postprocess_000_omp
 
 end module m_omp_poisson_fft

--- a/src/poisson_fft.f90
+++ b/src/poisson_fft.f90
@@ -148,40 +148,50 @@ contains
       zdirps%stagder_v2p%a, zdirps%stagder_v2p%b, zdirps%stagder_v2p%alpha &
       )
 
-    do k = 1, self%nz_spec
-      do j = 1, self%ny_spec
-        do i = 1, self%nx_spec
-          ix = i + self%x_sp_st; iy = j + self%y_sp_st; iz = k + self%z_sp_st
-          rlexs = real(exs(ix), kind=dp)*geo%d(1)
-          rleys = real(eys(iy), kind=dp)*geo%d(2)
-          rlezs = real(ezs(iz), kind=dp)*geo%d(3)
+    if (self%periodic_z) then
+      ! poisson 000, 100, 010, 110
+      do k = 1, self%nz_spec
+        do j = 1, self%ny_spec
+          do i = 1, self%nx_spec
+            ix = i + self%x_sp_st; iy = j + self%y_sp_st; iz = k + self%z_sp_st
+            rlexs = real(exs(ix), kind=dp)*geo%d(1)
+            rleys = real(eys(iy), kind=dp)*geo%d(2)
+            rlezs = real(ezs(iz), kind=dp)*geo%d(3)
 
-          xtt = 2*(xdirps%interpl_v2p%a*cos(rlexs*0.5_dp) &
-                   + xdirps%interpl_v2p%b*cos(rlexs*1.5_dp) &
-                   + xdirps%interpl_v2p%c*cos(rlexs*2.5_dp) &
-                   + xdirps%interpl_v2p%d*cos(rlexs*3.5_dp))
-          ytt = 2*(ydirps%interpl_v2p%a*cos(rleys*0.5_dp) &
-                   + ydirps%interpl_v2p%b*cos(rleys*1.5_dp) &
-                   + ydirps%interpl_v2p%c*cos(rleys*2.5_dp) &
-                   + ydirps%interpl_v2p%d*cos(rleys*3.5_dp))
-          ztt = 2*(zdirps%interpl_v2p%a*cos(rlezs*0.5_dp) &
-                   + zdirps%interpl_v2p%b*cos(rlezs*1.5_dp) &
-                   + zdirps%interpl_v2p%c*cos(rlezs*2.5_dp) &
-                   + zdirps%interpl_v2p%d*cos(rlezs*3.5_dp))
+            xtt = 2*(xdirps%interpl_v2p%a*cos(rlexs*0.5_dp) &
+                     + xdirps%interpl_v2p%b*cos(rlexs*1.5_dp) &
+                     + xdirps%interpl_v2p%c*cos(rlexs*2.5_dp) &
+                     + xdirps%interpl_v2p%d*cos(rlexs*3.5_dp))
+            ytt = 2*(ydirps%interpl_v2p%a*cos(rleys*0.5_dp) &
+                     + ydirps%interpl_v2p%b*cos(rleys*1.5_dp) &
+                     + ydirps%interpl_v2p%c*cos(rleys*2.5_dp) &
+                     + ydirps%interpl_v2p%d*cos(rleys*3.5_dp))
+            ztt = 2*(zdirps%interpl_v2p%a*cos(rlezs*0.5_dp) &
+                     + zdirps%interpl_v2p%b*cos(rlezs*1.5_dp) &
+                     + zdirps%interpl_v2p%c*cos(rlezs*2.5_dp) &
+                     + zdirps%interpl_v2p%d*cos(rlezs*3.5_dp))
 
-          xt1 = 1._dp + 2*xdirps%interpl_v2p%alpha*cos(rlexs)
-          yt1 = 1._dp + 2*ydirps%interpl_v2p%alpha*cos(rleys)
-          zt1 = 1._dp + 2*zdirps%interpl_v2p%alpha*cos(rlezs)
+            xt1 = 1._dp + 2*xdirps%interpl_v2p%alpha*cos(rlexs)
+            yt1 = 1._dp + 2*ydirps%interpl_v2p%alpha*cos(rleys)
+            zt1 = 1._dp + 2*zdirps%interpl_v2p%alpha*cos(rlezs)
 
-          xt2 = xk2(ix)*(((ytt/yt1)*(ztt/zt1))**2)
-          yt2 = yk2(iy)*(((xtt/xt1)*(ztt/zt1))**2)
-          zt2 = zk2(iz)*(((xtt/xt1)*(ytt/yt1))**2)
+            xt2 = xk2(ix)*(((ytt/yt1)*(ztt/zt1))**2)
+            yt2 = yk2(iy)*(((xtt/xt1)*(ztt/zt1))**2)
+            zt2 = zk2(iz)*(((xtt/xt1)*(ytt/yt1))**2)
 
-          xyzk = xt2 + yt2 + zt2
-          self%waves(i, j, k) = xyzk
+            xyzk = xt2 + yt2 + zt2
+            self%waves(i, j, k) = xyzk
+          end do
         end do
       end do
-    end do
+    else if (.not. (self%periodic_x .and. self%periodic_y .and. &
+                    self%periodic_z)) then
+      ! poisson 111
+      error stop 'No support for all non-periodic BCs yet!'
+    else
+      ! poisson 001, 011, 101
+      error stop 'FFT Poisson solver does not support specified BCs!'
+    end if
 
   end subroutine waves_set
 

--- a/src/poisson_fft.f90
+++ b/src/poisson_fft.f90
@@ -22,6 +22,8 @@ module m_poisson_fft
     complex(dp), allocatable, dimension(:, :, :) :: waves
     !> Wave numbers in x, y, and z
     real(dp), allocatable, dimension(:) :: ax, bx, ay, by, az, bz
+    !> Periodicity in x, y, and z
+    logical :: periodic_x, periodic_y, periodic_z
   contains
     procedure(fft_forward), deferred :: fft_forward
     procedure(fft_backward), deferred :: fft_backward
@@ -82,6 +84,10 @@ contains
     self%ny_spec = n_spec(2)
     self%nz_spec = n_spec(3)
 
+    self%periodic_x = mesh%grid%periodic_BC(1)
+    self%periodic_y = mesh%grid%periodic_BC(2)
+    self%periodic_z = mesh%grid%periodic_BC(3)
+
     self%x_sp_st = n_sp_st(1)
     self%y_sp_st = n_sp_st(2)
     self%z_sp_st = n_sp_st(3)
@@ -111,28 +117,15 @@ contains
                                               exs, eys, ezs
 
     integer :: nx, ny, nz, ix, iy, iz
-    real(dp) :: w, wp, rlexs, rleys, rlezs, xtt, ytt, ztt, xt1, yt1, zt1
+    real(dp) :: rlexs, rleys, rlezs, xtt, ytt, ztt, xt1, yt1, zt1
     complex(dp) :: xt2, yt2, zt2, xyzk
-    real(dp) :: d, L
+    real(dp) :: L_x, L_y, L_z, d_x, d_y, d_z
 
     integer :: i, j, k
 
     nx = self%nx_glob; ny = self%ny_glob; nz = self%nz_glob
-
-    do i = 1, nx
-      self%ax(i) = sin((i - 1)*pi/nx)
-      self%bx(i) = cos((i - 1)*pi/nx)
-    end do
-
-    do i = 1, ny
-      self%ay(i) = sin((i - 1)*pi/ny)
-      self%by(i) = cos((i - 1)*pi/ny)
-    end do
-
-    do i = 1, nz
-      self%az(i) = sin((i - 1)*pi/nz)
-      self%bz(i) = cos((i - 1)*pi/nz)
-    end do
+    L_x = geo%L(1); L_y = geo%L(2); L_z = geo%L(3)
+    d_x = geo%d(1); d_y = geo%d(2); d_z = geo%d(3)
 
     ! Now kxyz
     allocate (xkx(nx), xk2(nx), exs(nx))
@@ -140,62 +133,20 @@ contains
     allocate (zkz(nz), zk2(nz), ezs(nz))
     xkx(:) = 0; xk2(:) = 0; yky(:) = 0; yk2(:) = 0; zkz(:) = 0; zk2(:) = 0
 
-    ! periodic-x
-    d = geo%d(1)
-    L = geo%L(1)
-    do i = 1, nx/2 + 1
-      w = 2*pi*(i - 1)/nx
-      wp = xdirps%stagder_v2p%a*2*d*sin(0.5_dp*w) &
-           + xdirps%stagder_v2p%b*2*d*sin(1.5_dp*w)
-      wp = wp/(1._dp + 2*xdirps%stagder_v2p%alpha*cos(w))
+    call wave_numbers( &
+      self%ax, self%bx, xkx, exs, xk2, nx, L_x, d_x, self%periodic_x, &
+      xdirps%stagder_v2p%a, xdirps%stagder_v2p%b, xdirps%stagder_v2p%alpha &
+      )
 
-      xkx(i) = cmplx(1._dp, 1._dp, kind=dp)*(nx*wp/L)
-      exs(i) = cmplx(1._dp, 1._dp, kind=dp)*(nx*w/L)
-      xk2(i) = cmplx(1._dp, 1._dp, kind=dp)*(nx*wp/L)**2
-    end do
-    do i = nx/2 + 2, nx
-      xkx(i) = xkx(nx - i + 2)
-      exs(i) = exs(nx - i + 2)
-      xk2(i) = xk2(nx - i + 2)
-    end do
+    call wave_numbers( &
+      self%ay, self%by, yky, eys, yk2, ny, L_y, d_y, self%periodic_y, &
+      ydirps%stagder_v2p%a, ydirps%stagder_v2p%b, ydirps%stagder_v2p%alpha &
+      )
 
-    ! periodic-y
-    d = geo%d(2)
-    L = geo%L(2)
-    do i = 1, ny/2 + 1
-      w = 2*pi*(i - 1)/ny
-      wp = ydirps%stagder_v2p%a*2*d*sin(0.5_dp*w) &
-           + ydirps%stagder_v2p%b*2*d*sin(1.5_dp*w)
-      wp = wp/(1._dp + 2*ydirps%stagder_v2p%alpha*cos(w))
-
-      yky(i) = cmplx(1._dp, 1._dp, kind=dp)*(ny*wp/L)
-      eys(i) = cmplx(1._dp, 1._dp, kind=dp)*(ny*w/L)
-      yk2(i) = cmplx(1._dp, 1._dp, kind=dp)*(ny*wp/L)**2
-    end do
-    do i = ny/2 + 2, ny
-      yky(i) = yky(ny - i + 2)
-      eys(i) = eys(ny - i + 2)
-      yk2(i) = yk2(ny - i + 2)
-    end do
-
-    ! periodic-z
-    d = geo%d(3)
-    L = geo%L(3)
-    do i = 1, nz/2 + 1
-      w = 2*pi*(i - 1)/nz
-      wp = zdirps%stagder_v2p%a*2*d*sin(0.5_dp*w) &
-           + zdirps%stagder_v2p%b*2*d*sin(1.5_dp*w)
-      wp = wp/(1._dp + 2*zdirps%stagder_v2p%alpha*cos(w))
-
-      zkz(i) = cmplx(1._dp, 1._dp, kind=dp)*(nz*wp/L)
-      ezs(i) = cmplx(1._dp, 1._dp, kind=dp)*(nz*w/L)
-      zk2(i) = cmplx(1._dp, 1._dp, kind=dp)*(nz*wp/L)**2
-    end do
-    do i = nz/2 + 2, nz
-      zkz(i) = zkz(nz - i + 2)
-      ezs(i) = ezs(nz - i + 2)
-      zk2(i) = zk2(nz - i + 2)
-    end do
+    call wave_numbers( &
+      self%az, self%bz, zkz, ezs, zk2, nz, L_z, d_z, self%periodic_z, &
+      zdirps%stagder_v2p%a, zdirps%stagder_v2p%b, zdirps%stagder_v2p%alpha &
+      )
 
     do k = 1, self%nz_spec
       do j = 1, self%ny_spec
@@ -233,5 +184,56 @@ contains
     end do
 
   end subroutine waves_set
+
+  subroutine wave_numbers(a, b, k, e, k2, n, L, d, periodic, c_a, c_b, c_alpha)
+    implicit none
+
+    real(dp), dimension(:), intent(out) :: a, b
+    complex(dp), dimension(:), intent(out) :: k, e, k2
+    integer, intent(in) :: n
+    real(dp), intent(in) :: c_a, c_b, c_alpha, L, d
+    logical, intent(in) :: periodic
+
+    real(dp) :: w, wp
+    integer :: i
+
+    do i = 1, n
+      if (periodic) then
+        a(i) = sin((i - 1)*pi/n)
+        b(i) = cos((i - 1)*pi/n)
+      else
+        a(i) = sin((i - 1)*pi/2/n)
+        b(i) = cos((i - 1)*pi/2/n)
+      end if
+    end do
+
+    if (periodic) then
+      do i = 1, n/2 + 1
+        w = 2*pi*(i - 1)/n
+        wp = c_a*2*d*sin(0.5_dp*w) + c_b*2*d*sin(1.5_dp*w)
+        wp = wp/(1._dp + 2*c_alpha*cos(w))
+
+        k(i) = cmplx(1._dp, 1._dp, kind=dp)*(n*wp/L)
+        e(i) = cmplx(1._dp, 1._dp, kind=dp)*(n*w/L)
+        k2(i) = cmplx(1._dp, 1._dp, kind=dp)*(n*wp/L)**2
+      end do
+      do i = n/2 + 2, n
+        k(i) = k(n - i + 2)
+        e(i) = e(n - i + 2)
+        k2(i) = k2(n - i + 2)
+      end do
+    else
+      do i = 1, n
+        w = pi*(i - 1)/n
+        wp = c_a*2*d*sin(0.5_dp*w) + c_b*2*d*sin(1.5_dp*w)
+        wp = wp/(1._dp + 2*c_alpha*cos(w))
+
+        k(i) = cmplx(1._dp, 1._dp, kind=dp)*(n*wp/L)
+        e(i) = cmplx(1._dp, 1._dp, kind=dp)*(n*w/L)
+        k2(i) = cmplx(1._dp, 1._dp, kind=dp)*(n*wp/L)**2
+      end do
+    end if
+
+  end subroutine wave_numbers
 
 end module m_poisson_fft

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -343,15 +343,8 @@ contains
     p_temp => self%backend%allocator%get_block(DIR_C, CELL)
     call self%backend%reorder(p_temp, div_u, RDR_Z2C)
 
-    ! call forward FFT
-    ! output array in spectral space is stored at poisson_fft class
-    call self%backend%poisson_fft%fft_forward(p_temp)
-
-    ! postprocess
-    call self%backend%poisson_fft%fft_postprocess
-
-    ! call backward FFT
-    call self%backend%poisson_fft%fft_backward(p_temp)
+    ! solve poisson equation with FFT based approach
+    call self%backend%poisson_fft%solve_poisson(p_temp)
 
     ! reorder back to our specialist data structure from 3D Cartesian
     call self%backend%reorder(pressure, p_temp, RDR_C2Z)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -337,14 +337,18 @@ contains
     class(field_t), intent(inout) :: pressure
     class(field_t), intent(in) :: div_u
 
-    class(field_t), pointer :: p_temp
+    class(field_t), pointer :: p_temp, temp
 
     ! reorder into 3D Cartesian data structure
-    p_temp => self%backend%allocator%get_block(DIR_C, CELL)
+    p_temp => self%backend%allocator%get_block(DIR_C)
     call self%backend%reorder(p_temp, div_u, RDR_Z2C)
 
+    temp => self%backend%allocator%get_block(DIR_C)
+
     ! solve poisson equation with FFT based approach
-    call self%backend%poisson_fft%solve_poisson(p_temp)
+    call self%backend%poisson_fft%solve_poisson(p_temp, temp)
+
+    call self%backend%allocator%release_block(temp)
 
     ! reorder back to our specialist data structure from 3D Cartesian
     call self%backend%reorder(pressure, p_temp, RDR_C2Z)

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -7,6 +7,7 @@ program xcompact
   use m_common, only: pi, get_argument
   use m_config, only: domain_config_t, solver_config_t
   use m_mesh
+  use m_case_channel, only: case_channel_t
   use m_case_generic, only: case_generic_t
   use m_case_tgv, only: case_tgv_t
 
@@ -103,6 +104,9 @@ program xcompact
   if (nrank == 0) print *, 'Flow case: ', domain_cfg%flow_case_name
 
   select case (trim(domain_cfg%flow_case_name))
+  case ('channel')
+    allocate (case_channel_t :: flow_case)
+    flow_case = case_channel_t(backend, mesh, host_allocator)
   case ('generic')
     allocate (case_generic_t :: flow_case)
     flow_case = case_generic_t(backend, mesh, host_allocator)


### PR DESCRIPTION
Adds 010 BC support to FFT based Poisson solver to enable a channel case configuration.

The input file for the channel case in examples/channel runs a Re=4200 simulation on a uniform 62x361x32 grid so that y+ is 1 at the first grid point. Results look reasonable and an initial noise combined with rotation triggers turbulence in few thousand time steps. Limitation for the time being is that it only works on a single rank. This is due to some custom processing across y-direction in the FFT based Poisson solver.