### PR TITLE
Add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,3 +1,0 @@
-sphinx
-ford
-ghp-import

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,8 @@
+sphinx>=3.2
+nbconvert>=5.6
+nbsphinx>=0.7
+sphinx-rtd-theme>=0.5
+sphinx-copybutton>=0.3
+pygments>=2.6
+sphinx-autobuild
+ford


### PR DESCRIPTION
Adding ReadTheDocs configuration for x3d2. This is currently done for xcompact3d as well. Reason for this change is that ReadTheDocs is more feature rich compared to Github pages.