### PR TITLE
Add support for cuFFTMp for running on arbitrary global grid dimensions

### DIFF
--- a/src/cuda/kernels/spectral_processing.f90
+++ b/src/cuda/kernels/spectral_processing.f90
@@ -7,6 +7,26 @@ module m_cuda_spectral
 
 contains
 
+  attributes(global) subroutine memcpy3D(dst, src, nx, ny, nz)
+    !! Copy data between x3d2 padded arrays and cuFFTMp descriptors
+    implicit none
+
+    real(dp), device, intent(inout), dimension(:, :, :) :: dst
+    real(dp), device, intent(in), dimension(:, :, :) :: src
+    integer, value, intent(in) :: nx, ny, nz
+
+    integer :: i, j, k
+
+    j = threadIdx%x + (blockIdx%x - 1)*blockDim%x !ny
+    k = blockIdx%y !nz
+
+    if (j <= ny) then
+      do i = 1, nx
+        dst(i, j, k) = src(i, j, k)
+      end do
+    end if
+  end subroutine memcpy3D
+
   attributes(global) subroutine process_spectral_div_u( &
     div_u, waves, nx_spec, ny_spec, y_sp_st, nx, ny, nz, &
     ax, bx, ay, by, az, bz &


### PR DESCRIPTION
`cudaMemcpy2D` function of CUDA we use in the FFT Poisson solver on CUDA backend prevents running some arbitrary grid dimensions. Using `cudaMemcpy3D` would be the best solution, but it's not really supported on CUDA Fortran. https://forums.developer.nvidia.com/t/how-to-use-cudamemcpy3d-and-cudamemcpy3dparms-in-cuda-fortran/232532

So I implemented a custom CUDA kernel to carry out copies between padded x3d2 arrays and cuFFTMp descriptors. Tested on parallel with a 250^3 grid, works fine and enstrophy is correct.

Had to carry out the `norm2` operation for enstrophy on the host as well because the `scalar_product` function in the CUDA backend doesn't work well with padded arrays for the time being. Its only for outputs and not called very often so doesn't cause a meaningful performance issue. Probably fix later on in any case.