### PR TITLE
Issue error for formatting issues

### DIFF
--- a/.github/workflows/check_policies.yml
+++ b/.github/workflows/check_policies.yml
@@ -11,7 +11,20 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install fprettify
-      - run: fprettify --config .fprettify.ini --diff --recursive src
-      - run: if [[ ! -z "$($FPRETTIFY_COMMAND)" ]]; then echo "::warning::Code formatting issues detected. See log for details."; fi
-        env:
-          FPRETTIFY_COMMAND: fprettify --config .fprettify.ini --diff --recursive src
+      - name: Run fprettify
+        id: fprettify-check
+        run: |
+          echo "Running fprettify..."
+          FPRETTIFY_OUTPUT=$(fprettify --config .fprettify.ini --diff --recursive src)
+          echo "$FPRETTIFY_OUTPUT"
+          {
+            echo "fprettify_output<<EOF"
+            echo "$FPRETTIFY_OUTPUT"
+            echo "EOF"
+          } >> $GITHUB_ENV
+      - name: Check fprettify result
+        if: env.fprettify_output != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('Code formatting issues found. Please run fprettify locally and commit the changes.')


### PR DESCRIPTION
This PR will recover the previous behaviour that will issue an error during a PR if there are Formatting issues from fprettify (instead of just issuing a warning).  A meaningful error message is issued.

before
![before](https://github.com/user-attachments/assets/4c5a221c-0221-4e93-8960-22d703b9a3cf)

after
![after](https://github.com/user-attachments/assets/b028cbfb-3348-411b-944b-95ae82f27247)
