### PR TITLE
Backend functionality for getting max and mean values of a field

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -38,6 +38,7 @@ module m_base_backend
     procedure(sum_intox), deferred :: sum_zintox
     procedure(vecadd), deferred :: vecadd
     procedure(scalar_product), deferred :: scalar_product
+    procedure(field_max_mean), deferred :: field_max_mean
     procedure(field_ops), deferred :: field_scale
     procedure(field_ops), deferred :: field_shift
     procedure(copy_data_to_f), deferred :: copy_data_to_f
@@ -159,6 +160,21 @@ module m_base_backend
       class(field_t), intent(in) :: f
       real(dp), intent(in) :: a
     end subroutine field_ops
+  end interface
+
+  abstract interface
+    subroutine field_max_mean(self, max_val, mean_val, f, enforced_data_loc)
+      !! Obtains maximum and mean values in a field
+      import :: base_backend_t
+      import :: dp
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      real(dp), intent(out) :: max_val, mean_val
+      class(field_t), intent(in) :: f
+      integer, optional, intent(in) :: enforced_data_loc
+    end subroutine field_max_mean
   end interface
 
   abstract interface

--- a/src/cuda/kernels/fieldops.f90
+++ b/src/cuda/kernels/fieldops.f90
@@ -79,23 +79,27 @@ contains
 
   end subroutine field_shift
 
-  attributes(global) subroutine scalar_product(s, x, y, n)
+  attributes(global) subroutine scalar_product(s, x, y, n, n_i_pad, n_j)
     implicit none
 
     real(dp), device, intent(inout) :: s
     real(dp), device, intent(in), dimension(:, :, :) :: x, y
-    integer, value, intent(in) :: n
+    integer, value, intent(in) :: n, n_i_pad, n_j
 
     real(dp) :: s_pncl !! pencil sum
-    integer :: i, j, b, ierr
+    integer :: i, j, b, b_i, b_j, ierr
 
     i = threadIdx%x
-    b = blockIdx%x
+    b_i = blockIdx%x
+    b_j = blockIdx%y
 
+    b = b_i + (b_j - 1)*n_i_pad
     s_pncl = 0._dp
-    do j = 1, n
-      s_pncl = s_pncl + x(i, j, b)*y(i, j, b)
-    end do
+    if (i + (b_j - 1)*blockDim%x <= n_j) then
+      do j = 1, n
+        s_pncl = s_pncl + x(i, j, b)*y(i, j, b)
+      end do
+    end if
     ierr = atomicadd(s, s_pncl)
 
   end subroutine scalar_product

--- a/src/cuda/kernels/fieldops.f90
+++ b/src/cuda/kernels/fieldops.f90
@@ -100,4 +100,33 @@ contains
 
   end subroutine scalar_product
 
+  attributes(global) subroutine field_max_sum(max_f, sum_f, f, n, n_i_pad, n_j)
+    implicit none
+
+    real(dp), device, intent(inout) :: max_f, sum_f
+    real(dp), device, intent(in), dimension(:, :, :) :: f
+    integer, value, intent(in) :: n, n_i_pad, n_j
+
+    real(dp) :: max_pncl, sum_pncl, val
+    integer :: i, j, b, b_i, b_j, ierr
+
+    i = threadIdx%x
+    b_i = blockIdx%x
+    b_j = blockIdx%y
+
+    b = b_i + (b_j - 1)*n_i_pad
+    max_pncl = 0._dp
+    sum_pncl = 0._dp
+    if (i + (b_j - 1)*blockDim%x <= n_j) then
+      do j = 1, n
+        val = abs(f(i, j, b))
+        sum_pncl = sum_pncl + val
+        max_pncl = max(max_pncl, val)
+      end do
+    end if
+    ierr = atomicadd(sum_f, sum_pncl)
+    ierr = atomicmax(max_f, max_pncl)
+
+  end subroutine field_max_sum
+
 end module m_cuda_kernels_fieldops

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -458,6 +458,7 @@ contains
   end subroutine vecadd_omp
 
   real(dp) function scalar_product_omp(self, x, y) result(s)
+    !! [[m_base_backend(module):scalar_product(function)]]
     implicit none
 
     class(omp_backend_t) :: self


### PR DESCRIPTION
Kind of continuation of #144. Back then relied on moving things back to CPU and doing some simple operations and now adding proper support in both backends.

Adds a new function `field_max_mean` to get maximum and mean values in field, takes care of the padding and considers only the actual region in a padded field. Also improved the existing CUDA scalar_product to support padded configurations.

@pbartholomew08, I noticed that the `scalar_product` in OpenMP backend supports `DIR_C` layout as well, do you ever call `scalar_product` on `DIR_C` arrays or just added this in case? On GPU supporting `DIR_C` would be a bit nasty, for now I just terminate the code if the field is `DIR_C` but if you need this for your stuff we need to find a solution later.

@ia267, added a FORD description to this new function `field_max_mean` I added in the `base_backend`, then simply referred to this description in the CUDA and OpenMP extensions. Otherwise it would be too much duplication, what do you think?

I tested these two functions by running a TGV case first with default input.x3d file to make sure divU (calls max_mean) and enstrophy (calls scalar_product) progresses correctly as before. Then I did another test this time with global dimensions that require padding in all directions. I can confirm that both div U and enstrophy looks correct both on OpenMP and CUDA backends.