### PR TITLE
Fix data_loc constants

### DIFF
--- a/src/common.f90
+++ b/src/common.f90
@@ -12,12 +12,12 @@ module m_common
   integer, parameter :: POISSON_SOLVER_FFT = 0, POISSON_SOLVER_CG = 1
   integer, parameter :: VERT = 0000, & ! Vertex centered data
                         CELL = 1110, & ! Cell centered data
-                        X_FACE = 0110, &  ! Data on faces normal to X
-                        Y_FACE = 1010, &  ! Data on faces normal to Y
-                        Z_FACE = 1100, &  ! Data on faces normal to Z
-                        X_EDGE = 1000, & ! Data on edges along X
+                        X_FACE = 1100, & ! Data on faces normal to X
+                        Y_FACE = 1010, & ! Data on faces normal to Y
+                        Z_FACE = 0110, & ! Data on faces normal to Z
+                        X_EDGE = 0010, & ! Data on edges along X
                         Y_EDGE = 0100, & ! Data on edges along Y
-                        Z_EDGE = 0010, & ! Data on edges along Z
+                        Z_EDGE = 1000, & ! Data on edges along Z
                         NULL_LOC = -0001 ! The location of data isn't specified
   integer, parameter :: BC_PERIODIC = 0, BC_NEUMANN = 1, BC_DIRICHLET = 2, &
                         BC_HALO = -1


### PR DESCRIPTION
Fixes a minor mismatch between the `data_loc` movement rule defined in `move_data_loc` function and `DATA_LOC` constants.

Basically this was causing data_loc to be Z_FACE instead of X_FACE and etc. Main locations VERT and CELL was not affected, and also this doesn't make any difference for an all-periodic BC simulation.

Tested the behavior by printing the data_loc in various locations inside `divergence` and `gradient` subroutines and confirm that its all correct now.