### PR TITLE
Stretching support for tridiagonal solvers

### DIFF
--- a/src/config.f90
+++ b/src/config.f90
@@ -17,6 +17,8 @@ module m_config
     real(dp) :: L_global(3)
     integer :: dims_global(3), nproc_dir(3)
     character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
+    character(len=20) :: stretching(3)
+    real(dp) :: beta(3)
   contains
     procedure :: read => read_domain_nml
   end type domain_config_t
@@ -62,9 +64,11 @@ contains
     integer, dimension(3) :: dims_global
     integer, dimension(3) :: nproc_dir
     character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
+    character(len=20) :: stretching(3)
+    real(dp), dimension(3) :: beta
 
     namelist /domain_settings/ flow_case_name, L_global, dims_global, &
-      nproc_dir, BC_x, BC_y, BC_z
+      nproc_dir, BC_x, BC_y, BC_z, stretching, beta
 
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading domain config failed! &
@@ -87,6 +91,8 @@ contains
     self%BC_x = BC_x
     self%BC_y = BC_y
     self%BC_z = BC_z
+    self%stretching = stretching
+    self%beta = beta
 
   end subroutine read_domain_nml
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -55,7 +55,7 @@ module m_mesh
 contains
 
   function mesh_init(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z, &
-                     use_2decomp) result(mesh)
+                     stretching, beta, use_2decomp) result(mesh)
     use m_decomp, only: is_avail_2decomp, decomposition_2decomp
     !! Completely initialise the mesh object.
     !! Upon initialisation the mesh object can be read-only and shouldn't be edited
@@ -63,9 +63,11 @@ contains
     integer, dimension(3), intent(in) :: dims_global
     integer, dimension(3), intent(in) :: nproc_dir ! Number of proc in each direction
     real(dp), dimension(3), intent(in) :: L_global
+    character(len=*), dimension(2), intent(in) :: BC_x, BC_y, BC_z
+    character(len=*), dimension(3), optional, intent(in) :: stretching
+    real(dp), dimension(3), optional, intent(in) :: beta
     logical, optional, intent(in) :: use_2decomp
     class(mesh_t), allocatable :: mesh
-    character(len=*), dimension(2), intent(in) :: BC_x, BC_y, BC_z
 
     character(len=20), dimension(3, 2) :: BC_all
     logical :: is_first_domain, is_last_domain
@@ -117,10 +119,6 @@ contains
       end if
     end do
 
-    ! Geometry
-    mesh%geo%L = L_global
-    mesh%geo%d = mesh%geo%L/mesh%grid%global_cell_dims
-
     ! Parallel domain decomposition
     mesh%par%nproc_dir(:) = nproc_dir
     mesh%par%nproc = product(nproc_dir(:))
@@ -156,6 +154,24 @@ contains
         mesh%grid%BCs(dir, :) = BC_HALO
       end if
     end do
+
+    ! Geometry
+    mesh%geo%L = L_global
+    mesh%geo%d = mesh%geo%L/mesh%grid%global_cell_dims
+
+    if (present(stretching)) then
+      mesh%geo%stretching = stretching
+    else
+      mesh%geo%stretching(:) = 'uniform'
+    end if
+
+    if (present(beta)) then
+      mesh%geo%beta = beta
+    else
+      mesh%geo%beta(:) = 1
+    end if
+
+    call mesh%geo%obtain_coordinates(mesh%grid%vert_dims, mesh%grid%cell_dims)
 
     ! Define default values
     mesh%grid%vert_dims_padded = mesh%grid%vert_dims

--- a/src/mesh_content.f90
+++ b/src/mesh_content.f90
@@ -1,12 +1,32 @@
 module m_mesh_content
 
-  use m_common, only: dp
+  use m_common, only: dp, pi
   implicit none
 
   type :: geo_t
     !! Stores geometry information
-    real(dp), dimension(3) :: d ! size of a cell in each direction (=edge length, distance between centers, distance between vertices)
-    real(dp), dimension(3) :: L ! Global dimensions of the domain in each direction
+    !> Origin: coordinates of vertex (1, 1, 1)
+    real(dp) :: origin(3)
+    !> size of a cell in each direction for a uniform mesh
+    real(dp) :: d(3)
+    !> Global dimensions of the domain in each direction
+    real(dp) :: L(3)
+    !> Global coordinates at vertices
+    real(dp), allocatable, dimension(:, :) :: vert_coords
+    !> Global coordinates at midpoints
+    real(dp), allocatable, dimension(:, :) :: midp_coords
+    !> Stretching type
+    character(len=20), dimension(3) :: stretching
+    !> Stretching
+    logical :: stretched(3)
+    !> Stretching parameter
+    real(dp) :: beta(3)
+    !> Stretching factors at vertices
+    real(dp), allocatable, dimension(:, :) :: vert_ds, vert_ds2, vert_d2s
+    !> Stretching factors at midpoints
+    real(dp), allocatable, dimension(:, :) :: midp_ds, midp_ds2, midp_d2s
+  contains
+    procedure :: obtain_coordinates
   end type
 
   type :: grid_t
@@ -119,5 +139,100 @@ contains
     end do
 
   end subroutine
+
+  subroutine obtain_coordinates(self, vert_dims, cell_dims)
+    !! Obtains global coordinates for all the vertices and midpoints
+    implicit none
+    class(geo_t) :: self
+    integer, intent(in) :: vert_dims(3), cell_dims(3)
+
+    integer :: dir, i
+    real(dp) :: L_inf, alpha, beta, r, const, yeta_vt, yeta_mp, coord
+
+    allocate (self%vert_coords(maxval(vert_dims), 3))
+    allocate (self%vert_ds(maxval(vert_dims), 3))
+    allocate (self%vert_ds2(maxval(vert_dims), 3))
+    allocate (self%vert_d2s(maxval(vert_dims), 3))
+
+    allocate (self%midp_coords(maxval(cell_dims), 3))
+    allocate (self%midp_ds(maxval(cell_dims), 3))
+    allocate (self%midp_ds2(maxval(cell_dims), 3))
+    allocate (self%midp_d2s(maxval(cell_dims), 3))
+
+    ! vertex coordinates
+    do dir = 1, 3
+      if (trim(self%stretching(dir)) == 'uniform') then
+        self%stretched(dir) = .false.
+        self%vert_coords(:, dir) = [((i - 1)*self%d(dir), i=1, vert_dims(dir))]
+        self%vert_ds(:, dir) = 1
+        self%vert_ds2(:, dir) = 1
+        self%vert_d2s(:, dir) = 1
+        self%midp_coords(:, dir) = [((i - 0.5_dp)*self%d(dir), &
+                                     i=1, cell_dims(dir))]
+        self%midp_ds(:, dir) = 1
+        self%midp_ds2(:, dir) = 1
+        self%midp_d2s(:, dir) = 1
+        ! all sorted, move on to the next direction
+        cycle
+      else
+        self%stretched(dir) = .true.
+      end if
+
+      L_inf = self%L(dir)/2
+      beta = self%beta(dir)
+      alpha = abs((L_inf - sqrt((pi*beta)**2 + L_inf**2))/(2*beta*L_inf))
+      r = sqrt((alpha*beta + 1)/(alpha*beta))
+      const = sqrt(beta)/(2*sqrt(alpha)*sqrt(alpha*beta + 1))
+
+      do i = 1, vert_dims(dir)
+        select case (trim(self%stretching(dir)))
+        case ('centred')
+          yeta_vt = (i - 1)*self%d(dir)/self%L(dir)
+          yeta_mp = (i - 0.5_dp)*self%d(dir)/self%L(dir)
+        case ('both-ends')
+          yeta_vt = (i - 1)*self%d(dir)/self%L(dir) - 0.5_dp
+          yeta_mp = (i - 0.5_dp)*self%d(dir)/self%L(dir) - 0.5_dp
+        case ('bottom')
+          yeta_vt = (i - 1)*self%d(dir)/self%L(dir)/2 - 0.5_dp
+          yeta_mp = (i - 0.5_dp)*self%d(dir)/self%L(dir)/2 - 0.5_dp
+        case default
+          error stop 'Invalid stretching type'
+        end select
+
+        ! vertex coordinates
+        coord = const*atan2(r*sin(pi*yeta_vt), cos(pi*yeta_vt)) &
+                *(2*alpha*beta - cos(2*pi*yeta_vt) + 1) &
+                /(sin(pi*yeta_vt)**2 + alpha*beta)
+        self%vert_coords(i, dir) = coord + pi*const
+        self%vert_ds(i, dir) = self%L(dir)*(alpha/pi &
+                                            + sin(pi*yeta_vt)**2/(pi*beta))
+        self%vert_ds2(i, dir) = self%vert_ds(i, dir)**2
+        self%vert_d2s(i, dir) = -2*cos(pi*yeta_vt)*sin(pi*yeta_vt)/beta
+
+        ! midpoint coordinates
+        coord = const*atan2(r*sin(pi*yeta_mp), cos(pi*yeta_mp)) &
+                *(2*alpha*beta - cos(2*pi*yeta_mp) + 1) &
+                /(sin(pi*yeta_mp)**2 + alpha*beta)
+        self%midp_coords(i, dir) = coord + pi*const
+        self%midp_ds(i, dir) = self%L(dir)*(alpha/pi &
+                                            + sin(pi*yeta_mp)**2/(pi*beta))
+        self%midp_ds2(i, dir) = self%vert_ds(i, dir)**2
+        self%midp_d2s(i, dir) = -2*cos(pi*yeta_mp)*sin(pi*yeta_mp)/beta
+      end do
+
+      ! final shifts/corrections
+      select case (trim(self%stretching(dir)))
+      case ('centred')
+        self%vert_coords(:, dir) = self%vert_coords(:, dir) - L_inf
+        self%midp_coords(:, dir) = self%midp_coords(:, dir) - L_inf
+      case ('bottom')
+        self%vert_coords(:, dir) = 2*(self%vert_coords(:, dir))
+        self%vert_d2s(:, dir) = self%vert_d2s(:, dir)/2
+        self%midp_coords(:, dir) = 2*(self%midp_coords(:, dir))
+        self%midp_d2s(:, dir) = self%midp_d2s(:, dir)/2
+      end select
+    end do
+
+  end subroutine obtain_coordinates
 
 end module m_mesh_content

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -76,7 +76,8 @@ program xcompact
 
   mesh = mesh_t(domain_cfg%dims_global, domain_cfg%nproc_dir, &
                 domain_cfg%L_global, domain_cfg%BC_x, domain_cfg%BC_y, &
-                domain_cfg%BC_z, use_2decomp=use_2decomp)
+                domain_cfg%BC_z, domain_cfg%stretching, domain_cfg%beta, &
+                use_2decomp=use_2decomp)
 
 #ifdef CUDA
   cuda_allocator = cuda_allocator_t(mesh, SZ)

--- a/tests/test_mesh.f90
+++ b/tests/test_mesh.f90
@@ -76,7 +76,8 @@ contains
     BC_y = [character(len=20) :: 'periodic', 'periodic']
     BC_z = [character(len=20) :: 'dirichlet', 'neumann']
 
-    mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z, use_2decomp)
+    mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z, &
+                  use_2decomp=use_2decomp)
 
     ! Expected decomposition by 2decomp and generic
     if (use_2decomp) then


### PR DESCRIPTION
closing #12

- [x] Add stretching stuff in mesh%geo
- [ ] Update tridiagonal solvers with stretching support

@slaizet, I've checked that all stretching types, `centred`, `both-ends`, and `bottom`, is giving a reasonable point distribution. If you have any suggestions or want any changes in the implementation let me know.