### PR TITLE
 Stretching support for tridiagonal solvers

### DIFF
--- a/src/backend.f90
+++ b/src/backend.f90
@@ -243,8 +243,8 @@ module m_base_backend
 
   abstract interface
     subroutine alloc_tdsops( &
-      self, tdsops, n_tds, delta, operation, scheme, &
-      bc_start, bc_end, n_halo, from_to, sym, c_nu, nu0_nu &
+      self, tdsops, n_tds, delta, operation, scheme, bc_start, bc_end, &
+      stretch, stretch_correct, n_halo, from_to, sym, c_nu, nu0_nu &
       )
       import :: base_backend_t
       import :: dp
@@ -257,6 +257,7 @@ module m_base_backend
       real(dp), intent(in) :: delta
       character(*), intent(in) :: operation, scheme
       integer, intent(in) :: bc_start, bc_end
+      real(dp), optional, intent(in) :: stretch(:), stretch_correct(:)
       integer, optional, intent(in) :: n_halo
       character(*), optional, intent(in) :: from_to
       logical, optional, intent(in) :: sym

--- a/src/config.f90
+++ b/src/config.f90
@@ -17,6 +17,8 @@ module m_config
     real(dp) :: L_global(3)
     integer :: dims_global(3), nproc_dir(3)
     character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
+    character(len=20) :: stretching(3)
+    real(dp) :: beta(3)
   contains
     procedure :: read => read_domain_nml
   end type domain_config_t
@@ -70,9 +72,11 @@ contains
     integer, dimension(3) :: dims_global
     integer, dimension(3) :: nproc_dir
     character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
+    character(len=20) :: stretching(3) = ['uniform', 'uniform', 'uniform']
+    real(dp), dimension(3) :: beta
 
     namelist /domain_settings/ flow_case_name, L_global, dims_global, &
-      nproc_dir, BC_x, BC_y, BC_z
+      nproc_dir, BC_x, BC_y, BC_z, stretching, beta
 
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading domain config failed! &
@@ -95,6 +99,8 @@ contains
     self%BC_x = BC_x
     self%BC_y = BC_y
     self%BC_z = BC_z
+    self%stretching = stretching
+    self%beta = beta
 
   end subroutine read_domain_nml
 

--- a/src/cuda/backend.f90
+++ b/src/cuda/backend.f90
@@ -137,7 +137,7 @@ contains
 
   subroutine alloc_cuda_tdsops( &
     self, tdsops, n_tds, delta, operation, scheme, bc_start, bc_end, &
-    n_halo, from_to, sym, c_nu, nu0_nu &
+    stretch, stretch_correct, n_halo, from_to, sym, c_nu, nu0_nu &
     )
     implicit none
 
@@ -147,6 +147,7 @@ contains
     real(dp), intent(in) :: delta
     character(*), intent(in) :: operation, scheme
     integer, intent(in) :: bc_start, bc_end
+    real(dp), optional, intent(in) :: stretch(:), stretch_correct(:)
     integer, optional, intent(in) :: n_halo
     character(*), optional, intent(in) :: from_to
     logical, optional, intent(in) :: sym
@@ -157,7 +158,8 @@ contains
     select type (tdsops)
     type is (cuda_tdsops_t)
       tdsops = cuda_tdsops_t(n_tds, delta, operation, scheme, bc_start, &
-                             bc_end, n_halo, from_to, sym, c_nu, nu0_nu)
+                             bc_end, stretch, stretch_correct, n_halo, &
+                             from_to, sym, c_nu, nu0_nu)
     end select
 
   end subroutine alloc_cuda_tdsops

--- a/src/cuda/exec_dist.f90
+++ b/src/cuda/exec_dist.f90
@@ -49,8 +49,8 @@ contains
                          n_data, nproc, pprev, pnext)
 
     call der_univ_subs<<<blocks, threads>>>( & !&
-      du, du_recv_s, du_recv_e, &
-      tdsops%n_tds, tdsops%dist_sa_dev, tdsops%dist_sc_dev &
+      du, du_recv_s, du_recv_e, tdsops%n_tds, &
+      tdsops%dist_sa_dev, tdsops%dist_sc_dev, tdsops%stretch_dev &
       )
 
   end subroutine exec_dist_tds_compact
@@ -115,8 +115,10 @@ contains
     call transeq_3fused_subs<<<blocks, threads>>>( & !&
       r_du, v, dud, d2u, &
       du_recv_s, du_recv_e, dud_recv_s, dud_recv_e, d2u_recv_s, d2u_recv_e, &
-      der1st%n_tds, nu, der1st%dist_sa_dev, der1st%dist_sc_dev, &
-      der2nd%dist_sa_dev, der2nd%dist_sc_dev &
+      der1st%n_tds, nu, &
+      der1st%dist_sa_dev, der1st%dist_sc_dev, der1st%stretch_dev, &
+      der2nd%dist_sa_dev, der2nd%dist_sc_dev, der2nd%stretch_dev, &
+      der2nd%stretch_correct_dev &
       )
 
   end subroutine exec_dist_transeq_3fused

--- a/src/cuda/exec_thom.f90
+++ b/src/cuda/exec_thom.f90
@@ -20,15 +20,16 @@ contains
     if (tdsops%periodic) then
       call der_univ_thom_per<<<blocks, threads>>>( & !&
         du, u, tdsops%n_tds, tdsops%coeffs_dev, tdsops%alpha, &
-        tdsops%thom_f_dev, tdsops%thom_s_dev, &
-        tdsops%thom_w_dev, tdsops%thom_p_dev &
+        tdsops%thom_f_dev, tdsops%thom_s_dev, tdsops%thom_w_dev, &
+        tdsops%thom_p_dev, tdsops%stretch_dev &
         )
     else
       call der_univ_thom<<<blocks, threads>>>( & !&
         du, u, &
         tdsops%n_tds, tdsops%n_rhs, &
         tdsops%coeffs_s_dev, tdsops%coeffs_e_dev, tdsops%coeffs_dev, &
-        tdsops%thom_f_dev, tdsops%thom_s_dev, tdsops%thom_w_dev &
+        tdsops%thom_f_dev, tdsops%thom_s_dev, tdsops%thom_w_dev, &
+        tdsops%stretch_dev &
         )
     end if
 

--- a/src/omp/backend.f90
+++ b/src/omp/backend.f90
@@ -110,7 +110,7 @@ contains
 
   subroutine alloc_omp_tdsops( &
     self, tdsops, n_tds, delta, operation, scheme, bc_start, bc_end, &
-    n_halo, from_to, sym, c_nu, nu0_nu &
+    stretch, stretch_correct, n_halo, from_to, sym, c_nu, nu0_nu &
     )
     implicit none
 
@@ -120,6 +120,7 @@ contains
     real(dp), intent(in) :: delta
     character(*), intent(in) :: operation, scheme
     integer, intent(in) :: bc_start, bc_end
+    real(dp), optional, intent(in) :: stretch(:), stretch_correct(:)
     integer, optional, intent(in) :: n_halo
     character(*), optional, intent(in) :: from_to
     logical, optional, intent(in) :: sym
@@ -129,8 +130,9 @@ contains
 
     select type (tdsops)
     type is (tdsops_t)
-      tdsops = tdsops_t(n_tds, delta, operation, scheme, bc_start, &
-                        bc_end, n_halo, from_to, sym, c_nu, nu0_nu)
+      tdsops = tdsops_t(n_tds, delta, operation, scheme, bc_start, bc_end, &
+                        stretch, stretch_correct, n_halo, from_to, sym, &
+                        c_nu, nu0_nu)
     end select
 
   end subroutine alloc_omp_tdsops

--- a/src/omp/exec_dist.f90
+++ b/src/omp/exec_dist.f90
@@ -54,9 +54,10 @@ contains
 
     !$omp parallel do
     do k = 1, n_groups
-      call der_univ_subs(du(:, :, k), &
-                         du_recv_s(:, :, k), du_recv_e(:, :, k), &
-                         tdsops%n_tds, tdsops%dist_sa, tdsops%dist_sc)
+      call der_univ_subs( &
+        du(:, :, k), du_recv_s(:, :, k), du_recv_e(:, :, k), &
+        tdsops%n_tds, tdsops%dist_sa, tdsops%dist_sc, tdsops%stretch &
+        )
     end do
     !$omp end parallel do
 
@@ -171,9 +172,11 @@ contains
         du_recv_s(:, :, k), du_recv_e(:, :, k), &
         dud_recv_s(:, :, k), dud_recv_e(:, :, k), &
         d2u_recv_s(:, :, k), d2u_recv_e(:, :, k), &
-        nu, tdsops_du%n_tds, tdsops_du%dist_sa, tdsops_du%dist_sc, &
-        tdsops_dud%dist_sa, tdsops_dud%dist_sc, &
-        tdsops_d2u%dist_sa, tdsops_d2u%dist_sc &
+        nu, tdsops_du%n_tds, &
+        tdsops_du%dist_sa, tdsops_du%dist_sc, tdsops_du%stretch, &
+        tdsops_dud%dist_sa, tdsops_dud%dist_sc, tdsops_dud%stretch, &
+        tdsops_d2u%dist_sa, tdsops_d2u%dist_sc, tdsops_d2u%stretch, &
+        tdsops_d2u%stretch_correct &
         )
     end do
     !$omp end parallel do

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -165,7 +165,7 @@ contains
     character(*), intent(in) :: der1st_scheme, der2nd_scheme, &
                                 interpl_scheme, stagder_scheme
 
-    integer :: dir, bc_start, bc_end, n_vert, n_cell
+    integer :: dir, bc_start, bc_end, n_vert, n_cell, i
     real(dp) :: d
 
     dir = dirps%dir
@@ -176,22 +176,40 @@ contains
     n_vert = mesh%get_n(dir, VERT)
     n_cell = mesh%get_n(dir, CELL)
 
-    call backend%alloc_tdsops(dirps%der1st, n_vert, d, 'first-deriv', &
-                              der1st_scheme, bc_start, bc_end)
-    call backend%alloc_tdsops(dirps%der1st_sym, n_vert, d, 'first-deriv', &
-                              der1st_scheme, bc_start, bc_end)
-    call backend%alloc_tdsops(dirps%der2nd, n_vert, d, 'second-deriv', &
-                              der2nd_scheme, bc_start, bc_end)
-    call backend%alloc_tdsops(dirps%der2nd_sym, n_vert, d, 'second-deriv', &
-                              der2nd_scheme, bc_start, bc_end)
-    call backend%alloc_tdsops(dirps%interpl_v2p, n_cell, d, 'interpolate', &
-                              interpl_scheme, bc_start, bc_end, from_to='v2p')
-    call backend%alloc_tdsops(dirps%interpl_p2v, n_vert, d, 'interpolate', &
-                              interpl_scheme, bc_start, bc_end, from_to='p2v')
-    call backend%alloc_tdsops(dirps%stagder_v2p, n_cell, d, 'stag-deriv', &
-                              stagder_scheme, bc_start, bc_end, from_to='v2p')
-    call backend%alloc_tdsops(dirps%stagder_p2v, n_vert, d, 'stag-deriv', &
-                              stagder_scheme, bc_start, bc_end, from_to='p2v')
+    call backend%alloc_tdsops( &
+      dirps%der1st, n_vert, d, 'first-deriv', der1st_scheme, &
+      bc_start, bc_end, stretch=mesh%geo%vert_ds(1:n_vert, dir) &
+      )
+    call backend%alloc_tdsops( &
+      dirps%der1st_sym, n_vert, d, 'first-deriv', der1st_scheme, &
+      bc_start, bc_end, stretch=mesh%geo%vert_ds(1:n_vert, dir) &
+      )
+    call backend%alloc_tdsops( &
+      dirps%der2nd, n_vert, d, 'second-deriv', der2nd_scheme, &
+      bc_start, bc_end, stretch=mesh%geo%vert_ds2(1:n_vert, dir), &
+      stretch_correct=mesh%geo%vert_d2s(1:n_vert, dir) &
+      )
+    call backend%alloc_tdsops( &
+      dirps%der2nd_sym, n_vert, d, 'second-deriv', der2nd_scheme, &
+      bc_start, bc_end, stretch=mesh%geo%vert_ds2(1:n_vert, dir), &
+      stretch_correct=mesh%geo%vert_d2s(1:n_vert, dir) &
+      )
+    call backend%alloc_tdsops( &
+      dirps%stagder_v2p, n_cell, d, 'stag-deriv', stagder_scheme, bc_start, &
+      bc_end, from_to='v2p', stretch=mesh%geo%midp_ds(1:n_cell, dir) &
+      )
+    call backend%alloc_tdsops( &
+      dirps%stagder_p2v, n_vert, d, 'stag-deriv', stagder_scheme, bc_start, &
+      bc_end, from_to='p2v', stretch=mesh%geo%vert_ds(1:n_vert, dir) &
+      )
+    call backend%alloc_tdsops( &
+      dirps%interpl_v2p, n_cell, d, 'interpolate', interpl_scheme, &
+      bc_start, bc_end, from_to='v2p', stretch=[(1._dp, i=1, n_cell)] &
+      )
+    call backend%alloc_tdsops( &
+      dirps%interpl_p2v, n_vert, d, 'interpolate', interpl_scheme, &
+      bc_start, bc_end, from_to='p2v', stretch=[(1._dp, i=1, n_vert)] &
+      )
 
   end subroutine
 

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -77,7 +77,8 @@ program xcompact
 
   mesh = mesh_t(domain_cfg%dims_global, domain_cfg%nproc_dir, &
                 domain_cfg%L_global, domain_cfg%BC_x, domain_cfg%BC_y, &
-                domain_cfg%BC_z, use_2decomp=use_2decomp)
+                domain_cfg%BC_z, domain_cfg%stretching, domain_cfg%beta, &
+                use_2decomp=use_2decomp)
 
 #ifdef CUDA
   cuda_allocator = cuda_allocator_t(mesh, SZ)

--- a/tests/test_mesh.f90
+++ b/tests/test_mesh.f90
@@ -76,7 +76,8 @@ contains
     BC_y = [character(len=20) :: 'periodic', 'periodic']
     BC_z = [character(len=20) :: 'dirichlet', 'neumann']
 
-    mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z, use_2decomp)
+    mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z, &
+                  use_2decomp=use_2decomp)
 
     ! Expected decomposition by 2decomp and generic
     if (use_2decomp) then


### PR DESCRIPTION
closing #12 

- [x] Add stretching stuff in mesh%geo
- [x] Add stretching in `tdsops_t`
- [x] Update tridiagonal solvers with stretching support

@slaizet, I've checked that all stretching types, centred, both-ends, and bottom, are giving a reasonable point distribution. If you have any suggestions or want any changes in the implementation let me know. I followed Incompact3d stretching implementation and it looks a bit different than the formulation in the 2009 paper.

Best way to move forward is merging #136 first and then this one. Only then I can start working on stretching support for the FFT stuff.