### PR TITLE
Fix global coordinate assignment for multi-rank simulations.

### DIFF
--- a/src/mesh_content.f90
+++ b/src/mesh_content.f90
@@ -163,11 +163,13 @@ contains
     do dir = 1, 3
       if (trim(self%stretching(dir)) == 'uniform') then
         self%stretched(dir) = .false.
-        self%vert_coords(:, dir) = [((i - 1)*self%d(dir), i=1, vert_dims(dir))]
+        self%vert_coords(:, dir) = [((n_offset(dir) + i - 1)*self%d(dir), &
+                                     i=1, vert_dims(dir))]
         self%vert_ds(:, dir) = 1._dp
         self%vert_ds2(:, dir) = 1._dp
         self%vert_d2s(:, dir) = 0._dp
-        self%midp_coords(:, dir) = [((i - 0.5_dp)*self%d(dir), &
+        self%midp_coords(:, dir) = [((n_offset(dir) + i &
+                                      - 0.5_dp)*self%d(dir), &
                                      i=1, cell_dims(dir))]
         self%midp_ds(:, dir) = 1._dp
         self%midp_ds2(:, dir) = 1._dp


### PR DESCRIPTION
Minor fix for the 'uniform' stretching to make sure global offset is taken into account. Merging when the tests pass.