### PR TITLE
Adds compatibility with the (AMD) Flang compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 a.out
 *.mod
 build/
+build.*
 *.o
 
 # Emacs
 .dir-locals.el
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,8 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
 
   target_compile_options(xcompact PRIVATE "-DCUDA")
 
-elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
+elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" OR
+		${CMAKE_Fortran_COMPILER_ID} STREQUAL "LLVMFlang")
   set(CMAKE_Fortran_FLAGS "-cpp -std=f2018")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g -Og -Wall -Wpedantic -Werror -Wimplicit-interface -Wimplicit-procedure -Wno-unused-dummy-argument")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ffast-math")

--- a/src/mesh_content.f90
+++ b/src/mesh_content.f90
@@ -163,14 +163,14 @@ contains
     do dir = 1, 3
       if (trim(self%stretching(dir)) == 'uniform') then
         self%stretched(dir) = .false.
-        self%vert_coords(:, dir) = [((n_offset(dir) + i - 1)*self%d(dir), &
-                                     i=1, vert_dims(dir))]
+        self%vert_coords(1:vert_dims(dir), dir) = [((n_offset(dir) + i - 1)*self%d(dir), &
+                                                    i=1, vert_dims(dir))]
         self%vert_ds(:, dir) = 1._dp
         self%vert_ds2(:, dir) = 1._dp
         self%vert_d2s(:, dir) = 0._dp
-        self%midp_coords(:, dir) = [((n_offset(dir) + i &
-                                      - 0.5_dp)*self%d(dir), &
-                                     i=1, cell_dims(dir))]
+        self%midp_coords(1:cell_dims(dir), dir) = [((n_offset(dir) + i &
+                                                     - 0.5_dp)*self%d(dir), &
+                                                    i=1, cell_dims(dir))]
         self%midp_ds(:, dir) = 1._dp
         self%midp_ds2(:, dir) = 1._dp
         self%midp_d2s(:, dir) = 0._dp

--- a/tests/omp/test_omp_tridiag.f90
+++ b/tests/omp/test_omp_tridiag.f90
@@ -94,7 +94,8 @@ program test_omp_tridiag
 
   ! =========================================================================
   ! second derivative with periodic BC
-  tdsops = tdsops_init(n, dx_per, operation='second-deriv', scheme='compact6', &
+  tdsops = tdsops_init(n, dx_per, operation='second-deriv', &
+                       scheme='compact6', &
                        bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
 
   call set_u(u, sin_0_2pi_per, n, n_groups)
@@ -188,7 +189,8 @@ program test_omp_tridiag
   ! stag interpolate 'v2p' with neumann sym
   n_loc = n
   if (nrank == nproc - 1) n_loc = n - 1
-  tdsops = tdsops_init(n_loc, dx_pi, operation='interpolate', scheme='classic', &
+  tdsops = tdsops_init(n_loc, dx_pi, operation='interpolate', &
+                       scheme='classic', &
                        bc_start=bc_start, bc_end=bc_end, &
                        from_to='v2p')
 
@@ -201,7 +203,8 @@ program test_omp_tridiag
                   nproc, pprev, pnext &
                   )
 
-  call check_error_norm(du, cos_0_pi_stag, n_loc, n_glob, n_groups, -1, norm_du)
+  call check_error_norm(du, cos_0_pi_stag, n_loc, n_glob, n_groups, &
+                        -1, norm_du)
   if (nrank == 0) print *, 'error norm interpolate v2p', norm_du
 
   if (nrank == 0) then
@@ -246,7 +249,8 @@ program test_omp_tridiag
   ! stag derivative 'v2p' with neumann anti-sym
   n_loc = n
   if (nrank == nproc - 1) n_loc = n - 1
-  tdsops = tdsops_init(n_loc, dx_pi, operation='stag-deriv', scheme='compact6', &
+  tdsops = tdsops_init(n_loc, dx_pi, operation='stag-deriv', &
+                       scheme='compact6', &
                        bc_start=bc_start, bc_end=bc_end, &
                        from_to='v2p')
 
@@ -259,7 +263,8 @@ program test_omp_tridiag
                   nproc, pprev, pnext &
                   )
 
-  call check_error_norm(du, cos_0_pi_stag, n_loc, n_glob, n_groups, -1, norm_du)
+  call check_error_norm(du, cos_0_pi_stag, n_loc, n_glob, n_groups, &
+                        -1, norm_du)
   if (nrank == 0) print *, 'error norm stag derivative v2p', norm_du
 
   if (nrank == 0) then

--- a/tests/test_fft.f90
+++ b/tests/test_fft.f90
@@ -46,7 +46,7 @@ program test_fft
   real(dp) :: x, y, z
   real(dp) :: error_norm
   real(dp), dimension(3) :: xloc
-  real(dp), parameter :: tol=1e-10
+  real(dp), parameter :: tol = 1e-10
   logical :: use_2decomp
   real(dp), allocatable, dimension(:, :, :) :: input_data, output_data
 
@@ -124,7 +124,7 @@ program test_fft
   call output_field%fill(0._dp)
 
   dims = mesh%get_dims(CELL)
-  allocate(input_data(dims(1), dims(2), dims(3)))
+  allocate (input_data(dims(1), dims(2), dims(3)))
 
   ! Initialise field with some function
   do k = 1, dims(3)
@@ -147,15 +147,15 @@ program test_fft
   call backend%poisson_fft%fft_forward(input_field)
   call backend%poisson_fft%fft_backward(output_field)
 
-  allocate(output_data(dims(1), dims(2), dims(3)))
+  allocate (output_data(dims(1), dims(2), dims(3)))
   call backend%get_field_data(output_data, output_field, DIR_C)
-  ! The output scaled with number of cells in domain, hence the first '/product(dims_global)'. 
+  ! The output scaled with number of cells in domain, hence the first '/product(dims_global)'.
   ! RMS value is used for the norm, hence the second '/product(dims_global)'
   error_norm = norm2(input_data(:, :, :) - output_data(:, :, :)/product(dims_global) )**2/product(dims_global)
   call MPI_Allreduce(MPI_IN_PLACE, error_norm, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
   error_norm = sqrt(error_norm)
 
-  if (error_norm .gt. tol) then
+  if (error_norm > tol) then
     if (mesh%par%is_root()) then
       print *, "error in FFT result, error norm=", error_norm
     end if

--- a/tests/test_mesh.f90
+++ b/tests/test_mesh.f90
@@ -34,13 +34,13 @@ program test_mesh
   end if
 
   if (nrank == 0) then
-      print *, "Generic decomposition"
+    print *, "Generic decomposition"
   end if
   call run_test_mesh(.false., allpass)
 
 #ifdef WITH_2DECOMPFFT
   if (nrank == 0) then
-      print *, "2decomp decomposition"
+    print *, "2decomp decomposition"
   end if
   call run_test_mesh(.true., allpass)
 #endif
@@ -97,17 +97,18 @@ contains
 
     ! if last rank
     if (mesh%par%nrank == 3) then
-      if (.not. (n_cell == n_vert_z(mesh%par%nrank+1) -1 &
-          .and. n_vert ==  n_vert_z(mesh%par%nrank+1))) then
+      if (.not. (n_cell == n_vert_z(mesh%par%nrank + 1) - 1 &
+                 .and. n_vert == n_vert_z(mesh%par%nrank + 1))) then
         allpass = .false.
         print *, mesh%par%nrank, "error in get_n and last rank, n_cell=", &
           n_cell, "n_vert=", n_vert
       end if
     else
-      if (.not. (n_cell == n_vert_z(mesh%par%nrank+1) &
-          .and. n_vert ==  n_vert_z(mesh%par%nrank+1))) then
+      if (.not. (n_cell == n_vert_z(mesh%par%nrank + 1) &
+                 .and. n_vert == n_vert_z(mesh%par%nrank + 1))) then
         allpass = .false.
-        print *, mesh%par%nrank, "error in get_n, n_cell=", n_cell, "n_vert=", n_vert
+        print *, mesh%par%nrank, "error in get_n, n_cell=", &
+                 n_cell, "n_vert=", n_vert
       end if
     end if
 
@@ -118,7 +119,7 @@ contains
     end if
 
     dims = mesh%get_padded_dims(DIR_C)
-    dims_check = [8, 8, n_vert_z(mesh%par%nrank+1)] ! No padding in Z
+    dims_check = [8, 8, n_vert_z(mesh%par%nrank + 1)] ! No padding in Z
 
     if (.not. all(dims(:) == dims_check(:))) then
       allpass = .false.
@@ -137,6 +138,6 @@ contains
 
     call allocator%destroy()
 
-end subroutine
+  end subroutine
 
 end program test_mesh

--- a/tests/test_mesh.f90
+++ b/tests/test_mesh.f90
@@ -108,7 +108,7 @@ contains
                  .and. n_vert == n_vert_z(mesh%par%nrank + 1))) then
         allpass = .false.
         print *, mesh%par%nrank, "error in get_n, n_cell=", &
-                 n_cell, "n_vert=", n_vert
+          n_cell, "n_vert=", n_vert
       end if
     end if
 

--- a/tests/test_reorder_map.f90
+++ b/tests/test_reorder_map.f90
@@ -2,40 +2,40 @@ program test_reorder_map
   !! Check that reorder mappings return the expected values
 
   use m_common
-  
+
   implicit none
 
   logical :: test_pass
 
   test_pass = .true.
-  
+
   call test_get_dirs_from_rdr()
   call test_get_rdr_from_dirs()
 
   if (.not. test_pass) then
     error stop "FAIL"
   end if
-  
+
 contains
 
   subroutine test_get_dirs_from_rdr()
-    
+
     call test_one_get_dirs_from_rdr("RDR_X2Y", RDR_X2Y, DIR_X, DIR_Y)
     call test_one_get_dirs_from_rdr("RDR_X2Z", RDR_X2Z, DIR_X, DIR_Z)
     call test_one_get_dirs_from_rdr("RDR_X2C", RDR_X2C, DIR_X, DIR_C)
-    
+
     call test_one_get_dirs_from_rdr("RDR_Y2X", RDR_Y2X, DIR_Y, DIR_X)
     call test_one_get_dirs_from_rdr("RDR_Y2Z", RDR_Y2Z, DIR_Y, DIR_Z)
     call test_one_get_dirs_from_rdr("RDR_Y2C", RDR_Y2C, DIR_Y, DIR_C)
-    
+
     call test_one_get_dirs_from_rdr("RDR_Z2X", RDR_Z2X, DIR_Z, DIR_X)
     call test_one_get_dirs_from_rdr("RDR_Z2Y", RDR_Z2Y, DIR_Z, DIR_Y)
     call test_one_get_dirs_from_rdr("RDR_Z2C", RDR_Z2C, DIR_Z, DIR_C)
-    
+
     call test_one_get_dirs_from_rdr("RDR_C2X", RDR_C2X, DIR_C, DIR_X)
     call test_one_get_dirs_from_rdr("RDR_C2Y", RDR_C2Y, DIR_C, DIR_Y)
     call test_one_get_dirs_from_rdr("RDR_C2Z", RDR_C2Z, DIR_C, DIR_Z)
-    
+
   end subroutine test_get_dirs_from_rdr
 
   subroutine test_one_get_dirs_from_rdr(test, rdr, expect_from, expect_to)
@@ -71,7 +71,7 @@ contains
     call test_one_get_rdr_from_dirs("C->X", DIR_C, DIR_X, RDR_C2X)
     call test_one_get_rdr_from_dirs("C->Y", DIR_C, DIR_Y, RDR_C2Y)
     call test_one_get_rdr_from_dirs("C->Z", DIR_C, DIR_Z, RDR_C2Z)
-    
+
   end subroutine test_get_rdr_from_dirs
 
   subroutine test_one_get_rdr_from_dirs(test, from, to, expect_rdr)
@@ -89,5 +89,5 @@ contains
     end if
 
   end subroutine test_one_get_rdr_from_dirs
-  
+
 end program test_reorder_map

--- a/tests/test_scalar_product.f90
+++ b/tests/test_scalar_product.f90
@@ -32,7 +32,7 @@ program test_scalar_product
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
   character(len=5), dimension(4), parameter :: test = &
-    ["DIR_X", "DIR_Y", "DIR_Z", "DIR_C"]
+                                           ["DIR_X", "DIR_Y", "DIR_Z", "DIR_C"]
   integer, dimension(4), parameter :: dir = [DIR_X, DIR_Y, DIR_Z, DIR_C]
   integer :: i
 
@@ -92,7 +92,7 @@ contains
     if (nrank == 0) then
       print *, "Testing ", test
     end if
-    
+
     a => backend%allocator%get_block(dir, VERT)
     b => backend%allocator%get_block(dir, VERT)
 
@@ -108,8 +108,8 @@ contains
       check_pass = .true.
     end if
     call MPI_Allreduce(MPI_IN_PLACE, check_pass, 1, &
-      MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
-      ierr)
+                       MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
+                       ierr)
     if (nrank == 0) then
       print *, "- Got: ", s
       print *, "- Expected: ", 0
@@ -120,7 +120,7 @@ contains
       end if
     end if
     test_pass = test_pass .and. check_pass
-      
+
     if (nrank == 0) then
       print *, "Check: dot(nrank, nrank) = sum^{nrank-1}_i=0 sum_n(i) i**2"
     end if
@@ -132,7 +132,7 @@ contains
     call c%set_data_loc(a%data_loc)
     n = product(mesh%get_field_dims(c))
     call backend%allocator%release_block(c)
-    
+
     expt = n*(nrank + 1)**2
     call MPI_Allreduce(MPI_IN_PLACE, expt, 1, &
                        MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD, &
@@ -143,8 +143,8 @@ contains
       check_pass = .true.
     end if
     call MPI_Allreduce(MPI_IN_PLACE, check_pass, 1, &
-      MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
-      ierr)
+                       MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
+                       ierr)
     if (nrank == 0) then
       print *, "- Got: ", s
       print *, "- Expected: ", expt

--- a/tests/test_scalar_product.f90
+++ b/tests/test_scalar_product.f90
@@ -32,8 +32,10 @@ program test_scalar_product
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
   character(len=5), dimension(4), parameter :: test = &
-                                           ["DIR_X", "DIR_Y", "DIR_Z", "DIR_C"]
-  integer, dimension(4), parameter :: dir = [DIR_X, DIR_Y, DIR_Z, DIR_C]
+                                               ["DIR_X", "DIR_Y", &
+                                                "DIR_Z", "DIR_C"]
+  integer, dimension(4), parameter :: dir = [DIR_X, DIR_Y, &
+                                             DIR_Z, DIR_C]
   integer :: i
 
   integer :: nrank, nproc

--- a/tests/test_setget_field.f90
+++ b/tests/test_setget_field.f90
@@ -1,6 +1,6 @@
 program test_setget_field
 
-  use mpi 
+  use mpi
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
@@ -14,9 +14,9 @@ program test_setget_field
   use m_omp_common, only: SZ
 #endif
   use m_mesh, only: mesh_t
-  
+
   implicit none
-  
+
   class(allocator_t), pointer :: allocator
   class(base_backend_t), pointer :: backend
 #ifdef CUDA
@@ -27,19 +27,19 @@ program test_setget_field
   type(omp_backend_t), target :: omp_backend
 #endif
   type(mesh_t) :: mesh
-  
+
   class(field_t), pointer :: fld, fld_c
   real(dp), dimension(:, :, :), allocatable :: arr
   integer, dimension(3) :: shape_c
 
   integer :: ierr
-  
+
   call MPI_Init(ierr)
 
-  mesh = mesh_t ([16, 32, 48], [1, 1, 1], [1.0_dp, 1.0_dp, 1.0_dp], &
-    ["periodic", "periodic"], &
-    ["periodic", "periodic"], &
-    ["periodic", "periodic"])
+  mesh = mesh_t([16, 32, 48], [1, 1, 1], [1.0_dp, 1.0_dp, 1.0_dp], &
+                ["periodic", "periodic"], &
+                ["periodic", "periodic"], &
+                ["periodic", "periodic"])
 
 #ifdef CUDA
   cuda_allocator = cuda_allocator_t(mesh, SZ)
@@ -51,22 +51,22 @@ program test_setget_field
   omp_backend = omp_backend_t(mesh, allocator)
   backend => omp_backend
 #endif
-  
+
   fld => backend%allocator%get_block(DIR_X, VERT)
   fld_c => backend%allocator%get_block(DIR_C, VERT)
   shape_c = fld_c%get_shape()
-  allocate(arr(shape_c(1), shape_c(2), shape_c(3)))
+  allocate (arr(shape_c(1), shape_c(2), shape_c(3)))
   arr = 1.0_dp
   call backend%set_field_data(fld, arr)
-  
+
   if (fld%data_loc /= VERT) then
     error stop "Field location was changed by set_field_data"
   end if
 
-  deallocate(arr)
+  deallocate (arr)
   call backend%allocator%release_block(fld)
   call backend%allocator%release_block(fld_c)
 
   call MPI_Finalize(ierr)
-  
+
 end program test_setget_field

--- a/tests/test_sum_intox.f90
+++ b/tests/test_sum_intox.f90
@@ -73,7 +73,7 @@ contains
 
     character(len=*), intent(in) :: test
     integer, intent(in) :: dir_from
-    
+
     class(field_t), pointer :: a, b
     integer :: ctr
     integer :: i, j, k
@@ -112,7 +112,7 @@ contains
     else
       call backend%sum_zintox(a, b)
     end if
-    
+
     check_pass = .not. ((minval(a%data) /= 0) .or. (maxval(a%data) /= 0))
     call MPI_Allreduce(MPI_IN_PLACE, check_pass, 1, &
                        MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &


### PR DESCRIPTION
This was tested using AMD Flang 5.3.0:
```
> flang --version
AMD AFAR drop #5.3 01/21/25 flang-new version 20.0.0git (https://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@github.com/AMD-Lightning-Internal/llvm-project  25033 72cae04fa87269ff93e10a79b4d1705a65b30a5b)
Target: x86_64-unknown-linux-gnu
Thread model: posix
Build config: +assertions
```