### PR TITLE
Enable backend selection independently of compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,6 @@ set(WITH_2DECOMPFFT ON CACHE BOOL
 
 add_subdirectory(src)
 add_subdirectory(tests)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(SelectBackend)

--- a/cmake/SelectBackend.cmake
+++ b/cmake/SelectBackend.cmake
@@ -4,12 +4,22 @@
 # - GPU/CUDAFortran (nvfort only)
 # - CPU/OMP (all)
 
+set(X3D2_BACKEND_OPTIONS "OMP/CPU")
+if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
+    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")
+  set(X3D2_BACKEND_DEFAULT "CUDA/GPU")
+  list(APPEND X3D2_BACKEND_OPTIONS ${X3D2_BACKEND_DEFAULT})
+else()
+  set(X3D2_BACKEND_DEFAULT "OMP/CPU")
+endif()
+
 set(X3D2_BACKEND
-  "OMP/CPU"
+  ${X3D2_BACKEND_DEFAULT}
   CACHE
   STRING
-  "Select the backend. Current options are 'OMP/CPU' and 'CUDA/GPU'")
+  "Select the backend. Current options are ${X3D2_BACKEND_OPTIONS}")
 set_property(CACHE
   X3D2_BACKEND
   PROPERTY STRINGS
-  "OMP/CPU" "CUDA/GPU")
+  ${X3D2_BACKEND_OPTIONS})
+message(STATUS "Using ${X3D2_BACKEND} backend")

--- a/cmake/SelectBackend.cmake
+++ b/cmake/SelectBackend.cmake
@@ -1,0 +1,15 @@
+# Defines the backend selection for x3d2.
+#
+# Currently available backends
+# - GPU/CUDAFortran (nvfort only)
+# - CPU/OMP (all)
+
+set(X3D2_BACKEND
+  "OMP/CPU"
+  CACHE
+  STRING
+  "Select the backend. Current options are 'OMP/CPU' and 'CUDA/GPU'")
+set_property(CACHE
+  X3D2_BACKEND
+  PROPERTY STRINGS
+  "OMP/CPU" "CUDA/GPU")


### PR DESCRIPTION
Closes #178 

Currently the backend is fixed based on the compiler. As we add backends the user should be able to select between them, for example currently we could have

NVHPC: CUDA/GPU or OMP/CPU
Other: OMP/CPU