### PR TITLE
Add veccopy backend

### DIFF
--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -124,15 +124,15 @@ module m_base_backend
   end interface
 
   abstract interface
-    subroutine veccopy(self, x, y)
+    subroutine veccopy(self, dst, src)
          !! copy vectors: y = x
       import :: base_backend_t
       import :: field_t
       implicit none
 
       class(base_backend_t) :: self
-      class(field_t), intent(in) :: x
-      class(field_t), intent(inout) :: y
+      class(field_t), intent(inout) :: dst
+      class(field_t), intent(in) :: src
     end subroutine veccopy
   end interface
 

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -602,24 +602,24 @@ contains
 
   end subroutine sum_zintox_cuda
 
-  subroutine veccopy_cuda(self, x, y)
+  subroutine veccopy_cuda(self, dst, src)
     implicit none
 
     class(cuda_backend_t) :: self
-    class(field_t), intent(in) :: x
-    class(field_t), intent(inout) :: y
+    class(field_t), intent(inout) :: dst
+    class(field_t), intent(in) :: src
 
-    real(dp), device, pointer, dimension(:, :, :) :: x_d, y_d
+    real(dp), device, pointer, dimension(:, :, :) :: dst_d, src_d
     type(dim3) :: blocks, threads
-    integer :: nx
+    integer :: n
 
-    call resolve_field_t(x_d, x)
-    call resolve_field_t(y_d, y)
+    call resolve_field_t(dst_d, dst)
+    call resolve_field_t(src_d, src)
 
-    nx = size(x_d, dim=2)
-    blocks = dim3(size(x_d, dim=3), 1, 1)
+    n = size(src_d, dim=2)
+    blocks = dim3(size(src_d, dim=3), 1, 1)
     threads = dim3(SZ, 1, 1)
-    call copy<<<blocks, threads>>>(nx, x_d, y_d) !&
+    call copy<<<blocks, threads>>>(n, dst_d, src_d) !&
 
   end subroutine veccopy_cuda
 

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -6,12 +6,12 @@ module m_cuda_kernels_fieldops
 
 contains
 
-  attributes(global) subroutine copy(n, x, y)
+  attributes(global) subroutine copy(n, dst, src)
     implicit none
 
     integer, value, intent(in) :: n
-    real(dp), device, intent(in), dimension(:, :, :) :: x
-    real(dp), device, intent(out), dimension(:, :, :) :: y
+    real(dp), device, intent(out), dimension(:, :, :) :: dst
+    real(dp), device, intent(in), dimension(:, :, :) :: src
 
     integer :: i, j, b
 
@@ -19,7 +19,7 @@ contains
     b = blockIdx%x
 
     do j = 1, n
-      y(i, j, b) = x(i, j, b)
+      dst(i, j, b) = src(i, j, b)
     end do
 
   end subroutine copy

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -419,22 +419,22 @@ contains
 
   end subroutine sum_intox_omp
 
-  subroutine veccopy_omp(self, x, y)
+  subroutine veccopy_omp(self, dst, src)
     implicit none
 
     class(omp_backend_t) :: self
-    class(field_t), intent(in) :: x
-    class(field_t), intent(inout) :: y
+    class(field_t), intent(inout) :: dst
+    class(field_t), intent(in) :: src
     integer, dimension(3) :: dims
     integer :: i, j, k, ii
 
     integer :: nvec, remstart
 
-    if (x%dir /= y%dir) then
+    if (src%dir /= dst%dir) then
       error stop "Called vector add with incompatible fields"
     end if
 
-    dims = self%mesh%get_padded_dims(x)
+    dims = self%mesh%get_padded_dims(src)
     nvec = dims(1)/SZ
     remstart = nvec*SZ + 1
 
@@ -445,15 +445,15 @@ contains
         do ii = 1, nvec
           !$omp simd
           do i = 1, SZ
-            y%data(i + (ii - 1)*SZ, j, k) = &
-              x%data(i + (ii - 1)*SZ, j, k)
+            dst%data(i + (ii - 1)*SZ, j, k) = &
+              src%data(i + (ii - 1)*SZ, j, k)
           end do
           !$omp end simd
         end do
 
         ! Remainder loop
         do i = remstart, dims(1)
-          y%data(i, j, k) = x%data(i, j, k)
+          dst%data(i, j, k) = src%data(i, j, k)
         end do
       end do
     end do

--- a/src/time_integrator.f90
+++ b/src/time_integrator.f90
@@ -203,7 +203,7 @@ contains
       do i = 1, self%nvars
         ! update step solution from stage derivative
         if (self%nstage > 1) then
-          call self%backend%veccopy(self%olds(i, 1)%ptr, self%curr(i)%ptr)
+          call self%backend%veccopy(self%curr(i)%ptr, self%olds(i, 1)%ptr)
         end if
 
         do j = 1, self%nstage - 1
@@ -223,16 +223,15 @@ contains
       do i = 1, self%nvars
         ! save step initial condition
         if (self%istage == 1) then
-          call self%backend%veccopy(self%curr(i)%ptr, self%olds(i, 1)%ptr)
+          call self%backend%veccopy(self%olds(i, 1)%ptr, self%curr(i)%ptr)
         end if
 
         ! save stage derivative
-        call self%backend%veccopy(self%deriv(i)%ptr, &
-                                  self%olds(i, self%istage + 1)%ptr)
+call self%backend%veccopy(self%olds(i, self%istage + 1)%ptr, self%deriv(i)%ptr)
 
         ! update stage solution
         if (self%istage > 1) then
-          call self%backend%veccopy(self%olds(i, 1)%ptr, self%curr(i)%ptr)
+          call self%backend%veccopy(self%curr(i)%ptr, self%olds(i, 1)%ptr)
         end if
         do j = 1, self%istage
           call self%backend%vecadd(self%rk_a(j, self%istage, self%nstage)*dt, &
@@ -283,7 +282,7 @@ contains
 
       ! update olds(1) with new derivative
       if (self%nstep > 1) then
-        call self%backend%veccopy(self%deriv(i)%ptr, self%olds(i, 1)%ptr)
+        call self%backend%veccopy(self%olds(i, 1)%ptr, self%deriv(i)%ptr)
       end if
     end do
 


### PR DESCRIPTION
Multi step/stage time-integration methods often required deep copy of solution vectors at previous step/stage. Currently this is emulated by using vecadd by setting the coefficients to 1.0 and 0.0. A more effective way is to provide a veccopy backend.