### PR TITLE
Add convection-diffusion for passive species

### DIFF
--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -25,7 +25,6 @@ module m_base_backend
       !! define the specifics of these operations based on the target
       !! architecture.
 
-    real(dp) :: nu
     type(mesh_t), pointer :: mesh
     class(allocator_t), pointer :: allocator
     class(poisson_fft_t), pointer :: poisson_fft
@@ -55,7 +54,7 @@ module m_base_backend
   end type base_backend_t
 
   abstract interface
-    subroutine transeq_ders(self, du, dv, dw, u, v, w, dirps)
+    subroutine transeq_ders(self, du, dv, dw, u, v, w, nu, dirps)
          !! transeq equation obtains the derivatives direction by
          !! direction, and the exact algorithm used to obtain these
          !! derivatives are decided at runtime. Backend implementations
@@ -64,11 +63,13 @@ module m_base_backend
       import :: base_backend_t
       import :: field_t
       import :: dirps_t
+      import :: dp
       implicit none
 
       class(base_backend_t) :: self
       class(field_t), intent(inout) :: du, dv, dw
       class(field_t), intent(in) :: u, v, w
+      real(dp), intent(in) :: nu
       type(dirps_t), intent(in) :: dirps
     end subroutine transeq_ders
   end interface

--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -32,6 +32,7 @@ module m_base_backend
     procedure(transeq_ders), deferred :: transeq_x
     procedure(transeq_ders), deferred :: transeq_y
     procedure(transeq_ders), deferred :: transeq_z
+    procedure(transeq_ders_spec), deferred :: transeq_species
     procedure(tds_solve), deferred :: tds_solve
     procedure(reorder), deferred :: reorder
     procedure(sum_intox), deferred :: sum_yintox
@@ -72,6 +73,28 @@ module m_base_backend
       real(dp), intent(in) :: nu
       type(dirps_t), intent(in) :: dirps
     end subroutine transeq_ders
+  end interface
+
+  abstract interface
+    subroutine transeq_ders_spec(self, dspec, u, v, w, spec, nu, dirps, sync)
+         !! transeq equation obtains the derivatives direction by
+         !! direction, and the exact algorithm used to obtain these
+         !! derivatives are decided at runtime. Backend implementations
+         !! are responsible from directing calls to transeq_ders into
+         !! the correct algorithm.
+      import :: base_backend_t
+      import :: field_t
+      import :: dirps_t
+      import :: dp
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(inout) :: dspec
+      class(field_t), intent(in) :: u, v, w, spec
+      real(dp), intent(in) :: nu
+      type(dirps_t), intent(in) :: dirps
+      logical, intent(in) :: sync
+    end subroutine transeq_ders_spec
   end interface
 
   abstract interface

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -266,11 +266,11 @@ contains
                            spec_dev, self%mesh%get_n(dirps%dir, VERT))
 
     ! halo exchange
-    call sendrecv_fields(self%spec_recv_s_dev, self%spec_recv_e_dev, &                            
-                         self%spec_send_s_dev, self%spec_send_e_dev, &                            
+    call sendrecv_fields(self%spec_recv_s_dev, self%spec_recv_e_dev, &
+                         self%spec_send_s_dev, self%spec_send_e_dev, &
                          SZ*n_halo*n_groups, &
-                         self%mesh%par%nproc_dir(dirps%dir), &                                    
-                         self%mesh%par%pprev(dirps%dir), &                                        
+                         self%mesh%par%nproc_dir(dirps%dir), &
+                         self%mesh%par%pprev(dirps%dir), &
                          self%mesh%par%pnext(dirps%dir))
 
     if (dirps%dir == DIR_X) then
@@ -280,16 +280,16 @@ contains
                                   der1st, der1st_sym, der2nd, dirps%dir, &
                                   self%xblocks, self%xthreads)
     else if (dirps%dir == DIR_Y) then
-      call transeq_dist_component(self, dspev_dev, spec_dev, v_dev, nu, &                
-                                  self%spec_recv_s_dev, self%spec_recv_e_dev, &          
-                                  self%v_recv_s_dev, self%v_recv_e_dev, &                 
-                                  der1st, der1st_sym, der2nd, dirps%dir, &               
+      call transeq_dist_component(self, dspev_dev, spec_dev, v_dev, nu, &
+                                  self%spec_recv_s_dev, self%spec_recv_e_dev, &
+                                  self%v_recv_s_dev, self%v_recv_e_dev, &
+                                  der1st, der1st_sym, der2nd, dirps%dir, &
                                   self%yblocks, self%ythreads)
     else
-      call transeq_dist_component(self, dspev_dev, spec_dev, w_dev, nu, &               
-                                  self%spec_recv_s_dev, self%spec_recv_e_dev, &         
-                                  self%w_recv_s_dev, self%w_recv_e_dev, &               
-                                  der1st, der1st_sym, der2nd, dirps%dir, &              
+      call transeq_dist_component(self, dspev_dev, spec_dev, w_dev, nu, &
+                                  self%spec_recv_s_dev, self%spec_recv_e_dev, &
+                                  self%w_recv_s_dev, self%w_recv_e_dev, &
+                                  der1st, der1st_sym, der2nd, dirps%dir, &
                                   self%zblocks, self%zthreads)
     end if
 

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -166,54 +166,58 @@ contains
 
   end subroutine alloc_cuda_tdsops
 
-  subroutine transeq_x_cuda(self, du, dv, dw, u, v, w, dirps)
+  subroutine transeq_x_cuda(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
 
     class(cuda_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
-    call self%transeq_cuda_dist(du, dv, dw, u, v, w, dirps, &
+    call self%transeq_cuda_dist(du, dv, dw, u, v, w, nu, dirps, &
                                 self%xblocks, self%xthreads)
 
   end subroutine transeq_x_cuda
 
-  subroutine transeq_y_cuda(self, du, dv, dw, u, v, w, dirps)
+  subroutine transeq_y_cuda(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
 
     class(cuda_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
     ! u, v, w is reordered so that we pass v, u, w
-    call self%transeq_cuda_dist(dv, du, dw, v, u, w, dirps, &
+    call self%transeq_cuda_dist(dv, du, dw, v, u, w, nu, dirps, &
                                 self%yblocks, self%ythreads)
 
   end subroutine transeq_y_cuda
 
-  subroutine transeq_z_cuda(self, du, dv, dw, u, v, w, dirps)
+  subroutine transeq_z_cuda(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
 
     class(cuda_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
     ! u, v, w is reordered so that we pass w, u, v
-    call self%transeq_cuda_dist(dw, du, dv, w, u, v, dirps, &
+    call self%transeq_cuda_dist(dw, du, dv, w, u, v, nu, dirps, &
                                 self%zblocks, self%zthreads)
 
   end subroutine transeq_z_cuda
 
-  subroutine transeq_cuda_dist(self, du, dv, dw, u, v, w, dirps, &
+  subroutine transeq_cuda_dist(self, du, dv, dw, u, v, w, nu, dirps, &
                                blocks, threads)
     implicit none
 
     class(cuda_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
     type(dim3), intent(in) :: blocks, threads
 
@@ -245,17 +249,17 @@ contains
 
     call transeq_halo_exchange(self, u_dev, v_dev, w_dev, dirps%dir)
 
-    call transeq_dist_component(self, du_dev, u_dev, u_dev, self%nu, &
+    call transeq_dist_component(self, du_dev, u_dev, u_dev, nu, &
                                 self%u_recv_s_dev, self%u_recv_e_dev, &
                                 self%u_recv_s_dev, self%u_recv_e_dev, &
                                 der1st, der1st_sym, der2nd, dirps%dir, &
                                 blocks, threads)
-    call transeq_dist_component(self, dv_dev, v_dev, u_dev, self%nu, &
+    call transeq_dist_component(self, dv_dev, v_dev, u_dev, nu, &
                                 self%v_recv_s_dev, self%v_recv_e_dev, &
                                 self%u_recv_s_dev, self%u_recv_e_dev, &
                                 der1st_sym, der1st, der2nd_sym, dirps%dir, &
                                 blocks, threads)
-    call transeq_dist_component(self, dw_dev, w_dev, u_dev, self%nu, &
+    call transeq_dist_component(self, dw_dev, w_dev, u_dev, nu, &
                                 self%w_recv_s_dev, self%w_recv_e_dev, &
                                 self%u_recv_s_dev, self%u_recv_e_dev, &
                                 der1st_sym, der1st, der2nd_sym, dirps%dir, &

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -139,41 +139,44 @@ contains
 
   end subroutine alloc_omp_tdsops
 
-  subroutine transeq_x_omp(self, du, dv, dw, u, v, w, dirps)
+  subroutine transeq_x_omp(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
 
     class(omp_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
-    call self%transeq_omp_dist(du, dv, dw, u, v, w, dirps)
+    call self%transeq_omp_dist(du, dv, dw, u, v, w, nu, dirps)
 
   end subroutine transeq_x_omp
 
-  subroutine transeq_y_omp(self, du, dv, dw, u, v, w, dirps)
+  subroutine transeq_y_omp(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
 
     class(omp_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
     ! u, v, w is reordered so that we pass v, u, w
-    call self%transeq_omp_dist(dv, du, dw, v, u, w, dirps)
+    call self%transeq_omp_dist(dv, du, dw, v, u, w, nu, dirps)
 
   end subroutine transeq_y_omp
 
-  subroutine transeq_z_omp(self, du, dv, dw, u, v, w, dirps)
+  subroutine transeq_z_omp(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
 
     class(omp_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
     ! u, v, w is reordered so that we pass w, u, v
-    call self%transeq_omp_dist(dw, du, dv, w, u, v, dirps)
+    call self%transeq_omp_dist(dw, du, dv, w, u, v, nu, dirps)
 
   end subroutine transeq_z_omp
 
@@ -183,21 +186,22 @@ contains
     class(omp_backend_t) :: self
     class(field_t), intent(inout) :: du, dv, dw
     class(field_t), intent(in) :: u, v, w
+    real(dp), intent(in) :: nu
     type(dirps_t), intent(in) :: dirps
 
     call transeq_halo_exchange(self, u, v, w, dirps%dir)
 
-    call transeq_dist_component(self, du, u, u, self%nu, &
+    call transeq_dist_component(self, du, u, u, nu, &
                                 self%u_recv_s, self%u_recv_e, &
                                 self%u_recv_s, self%u_recv_e, &
                                 dirps%der1st, dirps%der1st_sym, &
                                 dirps%der2nd, dirps%dir)
-    call transeq_dist_component(self, dv, v, u, self%nu, &
+    call transeq_dist_component(self, dv, v, u, nu, &
                                 self%v_recv_s, self%v_recv_e, &
                                 self%u_recv_s, self%u_recv_e, &
                                 dirps%der1st_sym, dirps%der1st, &
                                 dirps%der2nd_sym, dirps%dir)
-    call transeq_dist_component(self, dw, w, u, self%nu, &
+    call transeq_dist_component(self, dw, w, u, nu, &
                                 self%w_recv_s, self%w_recv_e, &
                                 self%u_recv_s, self%u_recv_e, &
                                 dirps%der1st_sym, dirps%der1st, &

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -228,15 +228,15 @@ contains
                                   dirps%der2nd, dirps%dir)
     else if (dirps%dir == DIR_Y) then
       call transeq_dist_component(self, dspec, spec, v, nu, &
-                                  self%spec_recv_s, self%spec_recv_e, &                    
-                                  self%v_recv_s, self%v_recv_e, &                    
-                                  dirps%der1st, dirps%der1st_sym, &                        
+                                  self%spec_recv_s, self%spec_recv_e, &
+                                  self%v_recv_s, self%v_recv_e, &
+                                  dirps%der1st, dirps%der1st_sym, &
                                   dirps%der2nd, dirps%dir)
     else
       call transeq_dist_component(self, dspec, spec, w, nu, &
-                                  self%spec_recv_s, self%spec_recv_e, &                    
-                                  self%w_recv_s, self%w_recv_e, &                    
-                                  dirps%der1st, dirps%der1st_sym, &                        
+                                  self%spec_recv_s, self%spec_recv_e, &
+                                  self%w_recv_s, self%w_recv_e, &
+                                  dirps%der1st, dirps%der1st_sym, &
                                   dirps%der2nd, dirps%dir)
     end if
 

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -247,8 +247,7 @@ contains
         deriv(2)%ptr => self%solver%backend%allocator%get_block(DIR_X)
         deriv(3)%ptr => self%solver%backend%allocator%get_block(DIR_X)
 
-        call self%solver%transeq(deriv(1)%ptr, deriv(2)%ptr, deriv(3)%ptr, &
-                                 self%solver%u, self%solver%v, self%solver%w)
+        call self%solver%transeq(deriv, curr)
 
         ! models that introduce source terms handled here
         call self%forcings(deriv(1)%ptr, deriv(2)%ptr, deriv(3)%ptr, iter)

--- a/src/config.f90
+++ b/src/config.f90
@@ -6,6 +6,8 @@ module m_config
 
   implicit none
 
+  integer, parameter :: n_species_max = 99
+
   type, abstract :: base_config_t
     !! All config types have a method read to initialise their data
   contains
@@ -25,7 +27,8 @@ module m_config
 
   type, extends(base_config_t) :: solver_config_t
     real(dp) :: Re, dt
-    integer :: n_iters, n_output
+    real(dp), dimension(:), allocatable :: pr_species
+    integer :: n_iters, n_output, n_species
     character(3) :: poisson_solver_type, time_intg
     character(30) :: der1st_scheme, der2nd_scheme, &
                      interpl_scheme, stagder_scheme
@@ -127,13 +130,15 @@ contains
     integer :: unit
 
     real(dp) :: Re, dt
-    integer :: n_iters, n_output
+    real(dp), dimension(n_species_max) :: pr_species = 1._dp
+    integer :: n_iters, n_output, n_species = 0
     character(3) :: time_intg
     character(3) :: poisson_solver_type = 'FFT'
     character(30) :: der1st_scheme = 'compact6', der2nd_scheme = 'compact6', &
                      interpl_scheme = 'classic', stagder_scheme = 'compact6'
 
     namelist /solver_params/ Re, dt, n_iters, n_output, poisson_solver_type, &
+      n_species, pr_species, &
       time_intg, der1st_scheme, der2nd_scheme, interpl_scheme, stagder_scheme
 
     if (present(nml_file) .and. present(nml_string)) then
@@ -154,6 +159,8 @@ contains
     self%dt = dt
     self%n_iters = n_iters
     self%n_output = n_output
+    self%n_species = n_species
+    if (n_species > 0) self%pr_species = pr_species(1:n_species)
     self%poisson_solver_type = poisson_solver_type
     self%time_intg = time_intg
     self%der1st_scheme = der1st_scheme

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -121,7 +121,7 @@ contains
     end if
 
     solver%dt = solver_cfg%dt
-    solver%backend%nu = 1._dp/solver_cfg%Re
+    solver%nu = 1._dp/solver_cfg%Re
     solver%n_iters = solver_cfg%n_iters
     solver%n_output = solver_cfg%n_output
     solver%ngrid = product(solver%mesh%get_global_dims(VERT))
@@ -241,7 +241,7 @@ contains
 
     ! call derivatives in x direction. Based on the run time arguments this
     ! executes a distributed algorithm or the Thomas algorithm.
-    call self%backend%transeq_x(du, dv, dw, u, v, w, self%xdirps)
+    call self%backend%transeq_x(du, dv, dw, u, v, w, self%nu, self%xdirps)
 
     ! request fields from the allocator
     u_y => self%backend%allocator%get_block(DIR_Y)
@@ -257,7 +257,7 @@ contains
     call self%backend%reorder(w_y, w, RDR_X2Y)
 
     ! similar to the x direction, obtain derivatives in y.
-    call self%backend%transeq_y(du_y, dv_y, dw_y, u_y, v_y, w_y, self%ydirps)
+    call self%backend%transeq_y(du_y, dv_y, dw_y, u_y, v_y, w_y, self%nu, self%ydirps)
 
     ! we don't need the velocities in y orientation any more, so release
     ! them to open up space.
@@ -289,7 +289,7 @@ contains
     call self%backend%reorder(w_z, w, RDR_X2Z)
 
     ! get the derivatives in z
-    call self%backend%transeq_z(du_z, dv_z, dw_z, u_z, v_z, w_z, self%zdirps)
+    call self%backend%transeq_z(du_z, dv_z, dw_z, u_z, v_z, w_z, self%nu, self%zdirps)
 
     ! there is no need to keep velocities in z orientation around, so release
     call self%backend%allocator%release_block(u_z)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -9,7 +9,7 @@ module m_solver
                       RDR_Z2C, RDR_C2Z, &
                       DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, CELL
   use m_config, only: solver_config_t
-  use m_field, only: field_t
+  use m_field, only: field_t, flist_t
   use m_mesh, only: mesh_t
   use m_tdsops, only: dirps_t
   use m_time_integrator, only: time_intg_t
@@ -215,7 +215,7 @@ contains
 
   end subroutine
 
-  subroutine transeq(self, du, dv, dw, u, v, w)
+  subroutine transeq(self, rhs, variables)
     !! Skew-symmetric form of convection-diffusion terms in the
     !! incompressible Navier-Stokes momemtum equations, excluding
     !! pressure terms.
@@ -223,11 +223,19 @@ contains
     implicit none
 
     class(solver_t) :: self
-    class(field_t), intent(inout) :: du, dv, dw
-    class(field_t), intent(in) :: u, v, w
+    type(flist_t), intent(inout) :: rhs(:)
+    type(flist_t), intent(in) :: variables(:)
 
     class(field_t), pointer :: u_y, v_y, w_y, u_z, v_z, w_z, &
-      du_y, dv_y, dw_y, du_z, dv_z, dw_z
+      du_y, dv_y, dw_y, du_z, dv_z, dw_z, &
+      du, dv, dw, u, v, w
+
+    du => rhs(1)%ptr
+    dv => rhs(2)%ptr
+    dw => rhs(3)%ptr
+    u => variables(1)%ptr
+    v => variables(2)%ptr
+    w => variables(3)%ptr
 
     ! -1/2(nabla u curl u + u nabla u) + nu nablasq u
 

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -71,7 +71,6 @@ program test_omp_transeq
   n_groups = mesh%get_n_groups(DIR_X)
 
   nu = 1._dp
-  omp_backend%nu = nu
 
   u => allocator%get_block(DIR_X, VERT)
   v => allocator%get_block(DIR_X, VERT)
@@ -97,7 +96,7 @@ program test_omp_transeq
                        'compact6', 'compact6', 'classic', 'compact6')
 
   call cpu_time(tstart)
-  call transeq_x_omp(omp_backend, du, dv, dw, u, v, w, xdirps)
+  call transeq_x_omp(omp_backend, du, dv, dw, u, v, w, nu, xdirps)
   call cpu_time(tend)
 
   if (nrank == 0) print *, 'Total time', tend - tstart


### PR DESCRIPTION
The present PR add convection-diffusion for passive species.

The viscous coefficient `nu` is removed from the backend and only present at the solver level.

The solver namelist should contain `n_species > 0` to activate the species. The Prandt numbers for the species can be given in the solver namelist using the array `pr_species`. The diffusion coefficient will be 1 / (Re * Pr). Currently, the number of species is limited to 99, see `n_species_max` in config.f90.