### PR TITLE
Add a low-memory transeq algorithm.

### DIFF
--- a/src/config.f90
+++ b/src/config.f90
@@ -29,6 +29,7 @@ module m_config
     real(dp) :: Re, dt
     real(dp), dimension(:), allocatable :: pr_species
     integer :: n_iters, n_output, n_species
+    logical :: lowmem
     character(3) :: poisson_solver_type, time_intg
     character(30) :: der1st_scheme, der2nd_scheme, &
                      interpl_scheme, stagder_scheme
@@ -132,13 +133,14 @@ contains
     real(dp) :: Re, dt
     real(dp), dimension(n_species_max) :: pr_species = 1._dp
     integer :: n_iters, n_output, n_species = 0
+    logical :: lowmem = .false.
     character(3) :: time_intg
     character(3) :: poisson_solver_type = 'FFT'
     character(30) :: der1st_scheme = 'compact6', der2nd_scheme = 'compact6', &
                      interpl_scheme = 'classic', stagder_scheme = 'compact6'
 
     namelist /solver_params/ Re, dt, n_iters, n_output, poisson_solver_type, &
-      n_species, pr_species, &
+      n_species, pr_species, lowmem, &
       time_intg, der1st_scheme, der2nd_scheme, interpl_scheme, stagder_scheme
 
     if (present(nml_file) .and. present(nml_string)) then
@@ -161,6 +163,7 @@ contains
     self%n_output = n_output
     self%n_species = n_species
     if (n_species > 0) self%pr_species = pr_species(1:n_species)
+    self%lowmem = lowmem
     self%poisson_solver_type = poisson_solver_type
     self%time_intg = time_intg
     self%der1st_scheme = der1st_scheme

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -63,8 +63,8 @@ module m_solver
     type(dirps_t), pointer :: xdirps, ydirps, zdirps
     type(vector_calculus_t) :: vector_calculus
     procedure(poisson_solver), pointer :: poisson => null()
+    procedure(transport_equation), pointer :: transeq => null()
   contains
-    procedure :: transeq
     procedure :: transeq_species
     procedure :: pressure_correction
     procedure :: divergence_v2p
@@ -82,6 +82,15 @@ module m_solver
       class(field_t), intent(inout) :: pressure
       class(field_t), intent(in) :: div_u
     end subroutine poisson_solver
+
+    subroutine transport_equation(self, rhs, variables)
+      import :: solver_t
+      import :: flist_t
+      implicit none
+
+      class(solver_t) :: self
+      type(flist_t), intent(inout) :: rhs(:), variables(:)
+    end subroutine transport_equation
   end interface
 
   interface solver_t
@@ -179,6 +188,11 @@ contains
       error stop 'poisson_solver_type is not valid. Use "FFT" or "CG".'
     end select
 
+    if (solver_cfg%lowmem) then
+      solver%transeq => transeq_lowmem
+    else
+      solver%transeq => transeq_default
+    end if
   end function init
 
   subroutine allocate_tdsops(dirps, backend, mesh, der1st_scheme, &
@@ -237,7 +251,7 @@ contains
 
   end subroutine
 
-  subroutine transeq(self, rhs, variables)
+  subroutine transeq_default(self, rhs, variables)
     !! Skew-symmetric form of convection-diffusion terms in the
     !! incompressible Navier-Stokes momemtum equations, excluding
     !! pressure terms.
@@ -246,7 +260,7 @@ contains
 
     class(solver_t) :: self
     type(flist_t), intent(inout) :: rhs(:)
-    type(flist_t), intent(in) :: variables(:)
+    type(flist_t), intent(inout) :: variables(:)
 
     class(field_t), pointer :: u_y, v_y, w_y, u_z, v_z, w_z, &
       du_y, dv_y, dw_y, du_z, dv_z, dw_z, &
@@ -335,7 +349,123 @@ contains
       call self%transeq_species(rhs(4:), variables)
     end if
 
-  end subroutine transeq
+  end subroutine transeq_default
+
+  subroutine transeq_lowmem(self, rhs, variables)
+    !! low memory version of the transport equation
+    implicit none
+
+    class(solver_t) :: self
+    type(flist_t), intent(inout) :: rhs(:)
+    type(flist_t), intent(inout) :: variables(:)
+
+    class(field_t), pointer :: u_y, v_y, w_y, u_z, v_z, w_z, &
+      du_y, dv_y, dw_y, du_z, dv_z, dw_z, du, dv, dw, u, v, w
+
+    du => rhs(1)%ptr
+    dv => rhs(2)%ptr
+    dw => rhs(3)%ptr
+    u => variables(1)%ptr
+    v => variables(2)%ptr
+    w => variables(3)%ptr
+
+    ! -1/2(nabla u curl u + u nabla u) + nu nablasq u
+
+    ! call derivatives in x direction. Based on the run time arguments this
+    ! executes a distributed algorithm or the Thomas algorithm.
+    call self%backend%transeq_x(du, dv, dw, u, v, w, self%nu, self%xdirps)
+
+    ! request fields from the allocator
+    u_y => self%backend%allocator%get_block(DIR_Y)
+    v_y => self%backend%allocator%get_block(DIR_Y)
+    w_y => self%backend%allocator%get_block(DIR_Y)
+
+    ! reorder data from x orientation to y orientation
+    call self%backend%reorder(u_y, u, RDR_X2Y)
+    call self%backend%reorder(v_y, v, RDR_X2Y)
+    call self%backend%reorder(w_y, w, RDR_X2Y)
+
+    ! now release the x-directional fields for saving memory
+    call self%backend%allocator%release_block(u)
+    call self%backend%allocator%release_block(v)
+    call self%backend%allocator%release_block(w)
+
+    du_y => self%backend%allocator%get_block(DIR_Y)
+    dv_y => self%backend%allocator%get_block(DIR_Y)
+    dw_y => self%backend%allocator%get_block(DIR_Y)
+
+    ! similar to the x direction, obtain derivatives in y.
+    call self%backend%transeq_y(du_y, dv_y, dw_y, u_y, v_y, w_y, &
+                                self%nu, self%ydirps)
+
+    call self%backend%sum_yintox(du, du_y)
+    call self%backend%sum_yintox(dv, dv_y)
+    call self%backend%sum_yintox(dw, dw_y)
+
+    call self%backend%allocator%release_block(du_y)
+    call self%backend%allocator%release_block(dv_y)
+    call self%backend%allocator%release_block(dw_y)
+
+    ! just like in y direction, get some fields for the z derivatives.
+    u_z => self%backend%allocator%get_block(DIR_Z)
+    v_z => self%backend%allocator%get_block(DIR_Z)
+    w_z => self%backend%allocator%get_block(DIR_Z)
+
+    ! reorder from y to z
+    call self%backend%reorder(u_z, u_y, RDR_Y2Z)
+    call self%backend%reorder(v_z, v_y, RDR_Y2Z)
+    call self%backend%reorder(w_z, w_y, RDR_Y2Z)
+
+    ! we don't need the velocities in y orientation any more, so release
+    call self%backend%allocator%release_block(u_y)
+    call self%backend%allocator%release_block(v_y)
+    call self%backend%allocator%release_block(w_y)
+
+    du_z => self%backend%allocator%get_block(DIR_Z)
+    dv_z => self%backend%allocator%get_block(DIR_Z)
+    dw_z => self%backend%allocator%get_block(DIR_Z)
+
+    ! get the derivatives in z
+    call self%backend%transeq_z(du_z, dv_z, dw_z, u_z, v_z, w_z, &
+                                self%nu, self%zdirps)
+
+    ! gather all the contributions into the x result array
+    call self%backend%sum_zintox(du, du_z)
+    call self%backend%sum_zintox(dv, dv_z)
+    call self%backend%sum_zintox(dw, dw_z)
+
+    ! release all the unnecessary blocks.
+    call self%backend%allocator%release_block(du_z)
+    call self%backend%allocator%release_block(dv_z)
+    call self%backend%allocator%release_block(dw_z)
+
+    u => self%backend%allocator%get_block(DIR_X)
+    v => self%backend%allocator%get_block(DIR_X)
+    w => self%backend%allocator%get_block(DIR_X)
+
+    ! reorder from z to x
+    call self%backend%reorder(u, u_z, RDR_Z2X)
+    call self%backend%reorder(v, v_z, RDR_Z2X)
+    call self%backend%reorder(w, w_z, RDR_Z2X)
+
+    ! there is no need to keep velocities in z orientation around, so release
+    call self%backend%allocator%release_block(u_z)
+    call self%backend%allocator%release_block(v_z)
+    call self%backend%allocator%release_block(w_z)
+
+    variables(1)%ptr => u
+    variables(2)%ptr => v
+    variables(3)%ptr => w
+    self%u => u
+    self%v => v
+    self%w => w
+
+    ! Convection-diffusion for species
+    if (self%nspecies > 0) then
+      call self%transeq_species(rhs(4:), variables)
+    end if
+
+  end subroutine transeq_lowmem
 
   subroutine transeq_species(self, rhs, variables)
     !! Skew-symmetric form of convection-diffusion terms in the

--- a/src/vector_calculus.f90
+++ b/src/vector_calculus.f90
@@ -294,32 +294,28 @@ contains
     call self%backend%allocator%release_block(p_sxy_z)
     call self%backend%allocator%release_block(dpdz_sxy_z)
 
+    ! derivatives in y, with careful memory management
     p_sx_y => self%backend%allocator%get_block(DIR_Y)
     dpdy_sx_y => self%backend%allocator%get_block(DIR_Y)
-    dpdz_sx_y => self%backend%allocator%get_block(DIR_Y)
-
-    ! similar to the z direction, obtain derivatives in y.
     call self%backend%tds_solve(p_sx_y, p_sxy_y, y_interpl_c2v)
     call self%backend%tds_solve(dpdy_sx_y, p_sxy_y, y_stagder_c2v)
-    call self%backend%tds_solve(dpdz_sx_y, dpdz_sxy_y, y_interpl_c2v)
-
-    ! release memory
     call self%backend%allocator%release_block(p_sxy_y)
+
+    dpdz_sx_y => self%backend%allocator%get_block(DIR_Y)
+    call self%backend%tds_solve(dpdz_sx_y, dpdz_sxy_y, y_interpl_c2v)
     call self%backend%allocator%release_block(dpdz_sxy_y)
 
-    ! just like in y direction, get some fields for the x derivatives.
+    ! reorder from y to x, and release memory one by one
     p_sx_x => self%backend%allocator%get_block(DIR_X)
-    dpdy_sx_x => self%backend%allocator%get_block(DIR_X)
-    dpdz_sx_x => self%backend%allocator%get_block(DIR_X)
-
-    ! reorder from y to x
     call self%backend%reorder(p_sx_x, p_sx_y, RDR_Y2X)
-    call self%backend%reorder(dpdy_sx_x, dpdy_sx_y, RDR_Y2X)
-    call self%backend%reorder(dpdz_sx_x, dpdz_sx_y, RDR_Y2X)
-
-    ! release all the y directional fields.
     call self%backend%allocator%release_block(p_sx_y)
+
+    dpdy_sx_x => self%backend%allocator%get_block(DIR_X)
+    call self%backend%reorder(dpdy_sx_x, dpdy_sx_y, RDR_Y2X)
     call self%backend%allocator%release_block(dpdy_sx_y)
+
+    dpdz_sx_x => self%backend%allocator%get_block(DIR_X)
+    call self%backend%reorder(dpdz_sx_x, dpdz_sx_y, RDR_Y2X)
     call self%backend%allocator%release_block(dpdz_sx_y)
 
     ! get the derivatives in x


### PR DESCRIPTION
We can trigger a low-mem transeq from the input file, `lowmem = T|F`. When lowmem is activated, the solver requires 3 less fields, reducing the memory consumption from 14 fields down to 11 fields. Now a 512^3 TGV with euler time stepping requires around 16GiB memory. (was ~19).

closing #41 