### PR TITLE
Refactor mesh and allocator

### DIFF
--- a/src/backend/cuda/allocator.f90
+++ b/src/backend/cuda/allocator.f90
@@ -71,12 +71,11 @@ contains
 
   end subroutine set_shape_cuda
 
-  function cuda_allocator_init(mesh, sz) result(allocator)
-    type(mesh_t), intent(inout) :: mesh
-    integer, intent(in) :: sz
+  function cuda_allocator_init(nx, ny, nz, sz) result(allocator)
+    integer, intent(in) :: nx, ny, nz, sz
     type(cuda_allocator_t) :: allocator
 
-    allocator%allocator_t = allocator_t(mesh, sz)
+    allocator%allocator_t = allocator_t(nx, ny, nz, sz)
   end function cuda_allocator_init
 
   function create_cuda_block(self, next) result(ptr)

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -399,7 +399,7 @@ contains
     integer :: out_i, out_j, out_k
     integer :: dir_from, dir_to
 
-    dims = self%mesh%get_padded_dims(u)
+    dims = u%get_shape()
     cart_padded = self%mesh%get_padded_dims(DIR_C)
     call get_dirs_from_rdr(dir_from, dir_to, direction)
 
@@ -456,7 +456,7 @@ contains
 
     dir_from = DIR_X
 
-    dims = self%mesh%get_padded_dims(u)
+    dims = u%get_shape()
     cart_padded = self%mesh%get_padded_dims(DIR_C)
 
     !$omp parallel do private(i, ii, jj, kk) collapse(2)
@@ -488,7 +488,7 @@ contains
       error stop "Called vector add with incompatible fields"
     end if
 
-    dims = self%mesh%get_padded_dims(src)
+    dims = src%get_shape()
     nvec = dims(1)/SZ
     remstart = nvec*SZ + 1
 
@@ -532,7 +532,7 @@ contains
       error stop "Called vector add with incompatible fields"
     end if
 
-    dims = self%mesh%get_padded_dims(x)
+    dims = x%get_shape()
     nvec = dims(1)/SZ
     remstart = nvec*SZ + 1
 

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -394,20 +394,21 @@ contains
     class(field_t), intent(inout) :: u_
     class(field_t), intent(in) :: u
     integer, intent(in) :: direction
-    integer, dimension(3) :: dims
+    integer, dimension(3) :: dims, cart_padded
     integer :: i, j, k
     integer :: out_i, out_j, out_k
     integer :: dir_from, dir_to
 
     dims = self%mesh%get_padded_dims(u)
+    cart_padded = self%mesh%get_padded_dims(DIR_C)
     call get_dirs_from_rdr(dir_from, dir_to, direction)
 
     !$omp parallel do private(out_i, out_j, out_k) collapse(2)
     do k = 1, dims(3)
       do j = 1, dims(2)
         do i = 1, dims(1)
-          call get_index_reordering( &
-            out_i, out_j, out_k, i, j, k, dir_from, dir_to, self%mesh)
+          call get_index_reordering(out_i, out_j, out_k, i, j, k, &
+                                    dir_from, dir_to, SZ, cart_padded)
           u_%data(out_i, out_j, out_k) = u%data(i, j, k)
         end do
       end do
@@ -449,19 +450,21 @@ contains
     integer, intent(in) :: dir_to
 
     integer :: dir_from
-    integer, dimension(3) :: dims
+    integer, dimension(3) :: dims, cart_padded
     integer :: i, j, k    ! Working indices
     integer :: ii, jj, kk ! Transpose indices
 
     dir_from = DIR_X
 
     dims = self%mesh%get_padded_dims(u)
+    cart_padded = self%mesh%get_padded_dims(DIR_C)
+
     !$omp parallel do private(i, ii, jj, kk) collapse(2)
     do k = 1, dims(3)
       do j = 1, dims(2)
         do i = 1, dims(1)
           call get_index_reordering(ii, jj, kk, i, j, k, &
-                                    dir_from, dir_to, self%mesh)
+                                    dir_from, dir_to, SZ, cart_padded)
           u%data(i, j, k) = u%data(i, j, k) + u_%data(ii, jj, kk)
         end do
       end do

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -608,7 +608,7 @@ contains
     y_ => self%allocator%get_block(DIR_C, y%data_loc)
     call self%get_field_data(y_%data, y)
 
-    dims = self%mesh%get_field_dims(x_)
+    dims = self%mesh%get_dims(x_%data_loc)
 
     nvec = dims(1)/SZ
     remstart = nvec*SZ + 1

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -28,12 +28,6 @@ module m_mesh
     procedure :: get_n_groups_phi
     generic :: get_n_groups => get_n_groups_dir, get_n_groups_phi
 
-    procedure :: get_field_dims_dir
-    procedure :: get_field_dims_phi
-    procedure :: get_field_dims_phi_dataloc
-    generic :: get_field_dims => get_field_dims_dir, get_field_dims_phi, &
-      get_field_dims_phi_dataloc
-
     procedure :: get_n_dir
     procedure :: get_n_phi
     generic :: get_n => get_n_dir, get_n_phi
@@ -342,46 +336,6 @@ contains
     integer :: n_groups
 
     n_groups = self%get_n_groups(phi%dir)
-
-  end function
-
-  pure function get_field_dims_phi(self, phi) result(dims)
-  !! Getter for the dimensions of field phi
-    class(mesh_t), intent(in) :: self
-    class(field_t), intent(in) :: phi
-    integer, dimension(3) :: dims
-
-    dims = self%get_field_dims(phi%dir, phi%data_loc)
-
-  end function
-
-  pure function get_field_dims_phi_dataloc(self, phi, data_loc) result(dims)
-  !! Getter for the dimensions of field phi where data is located on `data_loc`
-    class(mesh_t), intent(in) :: self
-    class(field_t), intent(in) :: phi
-    integer, intent(in) :: data_loc
-    integer, dimension(3) :: dims
-
-    dims = self%get_field_dims(phi%dir, data_loc)
-
-  end function
-
-  pure function get_field_dims_dir(self, dir, data_loc) result(dims)
-  !! Getter for the dimensions of an array directed along `dir` where data would be located on `data_loc`
-    class(mesh_t), intent(in) :: self
-    integer, intent(in) :: dir
-    integer, intent(in) :: data_loc
-    integer, dimension(3) :: dims
-
-    if (dir == DIR_C) then
-      dims(1) = self%get_n(DIR_X, data_loc)
-      dims(2) = self%get_n(DIR_Y, data_loc)
-      dims(3) = self%get_n(DIR_Z, data_loc)
-    else
-      dims(1) = self%sz
-      dims(2) = self%get_n(dir, data_loc)
-      dims(3) = self%get_n_groups(dir)
-    end if
 
   end function
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -14,32 +14,18 @@ module m_mesh
   ! The mesh class stores all the information about the global and local (due to domain decomposition) mesh
   ! It also includes getter functions to access some of its parameters
   type :: mesh_t
-    integer, private :: sz
     type(geo_t), allocatable :: geo ! object containing geometry information
     class(grid_t), allocatable :: grid ! object containing grid information
     class(par_t), allocatable :: par ! object containing parallel domain decomposition information
   contains
-    procedure :: get_SZ
-
     procedure :: get_dims
     procedure :: get_global_dims
-
-    procedure :: get_n_groups_dir
-    procedure :: get_n_groups_phi
-    generic :: get_n_groups => get_n_groups_dir, get_n_groups_phi
 
     procedure :: get_n_dir
     procedure :: get_n_phi
     generic :: get_n => get_n_dir, get_n_phi
 
-    procedure :: get_padded_dims_phi
-    procedure :: get_padded_dims_dir
-    generic :: get_padded_dims => get_padded_dims_dir, get_padded_dims_phi
-
     procedure :: get_coordinates
-
-    procedure :: set_sz
-    procedure :: set_padded_dims
   end type mesh_t
 
   interface mesh_t
@@ -169,10 +155,6 @@ contains
       mesh%grid%vert_dims, mesh%grid%cell_dims, mesh%par%n_offset &
       )
 
-    ! Define default values
-    mesh%grid%vert_dims_padded = mesh%grid%vert_dims
-    mesh%sz = 1
-
   end function mesh_init
 
   subroutine decomposition_generic(grid, par)
@@ -210,31 +192,6 @@ contains
     par%n_offset(:) = grid%vert_dims(:)*par%nrank_dir(:)
 
   end subroutine
-
-  subroutine set_padded_dims(self, vert_dims)
-    class(mesh_t), intent(inout) :: self
-    integer, dimension(3), intent(in) :: vert_dims
-
-    self%grid%vert_dims_padded = vert_dims
-
-  end subroutine
-
-  subroutine set_sz(self, sz)
-    class(mesh_t), intent(inout) :: self
-    integer, intent(in) :: sz
-
-    self%sz = sz
-
-  end subroutine
-
-  pure function get_sz(self) result(sz)
-  !! Getter for parameter SZ
-    class(mesh_t), intent(in) :: self
-    integer :: sz
-
-    sz = self%sz
-
-  end function
 
   pure function get_dims(self, data_loc) result(dims)
   !! Getter for local domain dimensions
@@ -290,54 +247,6 @@ contains
       error stop "Unknown location in get_dims_dataloc"
     end select
   end function get_dims_dataloc
-
-  pure function get_padded_dims_dir(self, dir) result(dims_padded)
-  !! Getter for padded dimensions with structure in `dir` direction
-    class(mesh_t), intent(in) :: self
-    integer, intent(in) :: dir
-    integer, dimension(3) :: dims_padded
-
-    if (dir == DIR_C) then
-      dims_padded = self%grid%vert_dims_padded
-    else
-      dims_padded(1) = self%sz
-      dims_padded(2) = self%grid%vert_dims_padded(dir)
-      dims_padded(3) = self%get_n_groups(dir)
-    end if
-
-  end function
-
-  pure function get_padded_dims_phi(self, phi) result(dims_padded)
-  !! Getter for padded dimensions for field phi
-  !! Gets the field direction from the field itself
-    class(mesh_t), intent(in) :: self
-    class(field_t), intent(in) :: phi
-    integer, dimension(3) :: dims_padded
-
-    dims_padded = self%get_padded_dims(phi%dir)
-
-  end function
-
-  pure function get_n_groups_dir(self, dir) result(n_groups)
-  !! Getter for the number of groups for fields in direction `dir`
-    class(mesh_t), intent(in) :: self
-    integer, intent(in) :: dir
-    integer :: n_groups
-
-    n_groups = (product(self%grid%vert_dims_padded(:))/ &
-                self%grid%vert_dims_padded(dir))/self%sz
-
-  end function
-
-  pure function get_n_groups_phi(self, phi) result(n_groups)
-  !! Getter for the number of groups for fields phi
-    class(mesh_t), intent(in) :: self
-    class(field_t), intent(in) :: phi
-    integer :: n_groups
-
-    n_groups = self%get_n_groups(phi%dir)
-
-  end function
 
   pure function get_n_phi(self, phi) result(n)
   !! Getter for the main dimension of field phi

--- a/src/mesh_content.f90
+++ b/src/mesh_content.f90
@@ -34,7 +34,6 @@ module m_mesh_content
     integer, dimension(3) :: global_vert_dims ! global number of vertices in each direction without padding (cartesian structure)
     integer, dimension(3) :: global_cell_dims ! global number of cells in each direction without padding (cartesian structure)
 
-    integer, dimension(3) :: vert_dims_padded ! local domain size including padding (cartesian structure)
     integer, dimension(3) :: vert_dims ! local number of vertices in each direction without padding (cartesian structure)
     integer, dimension(3) :: cell_dims ! local number of cells in each direction without padding (cartesian structure)
     logical, dimension(3) :: periodic_BC ! Whether or not a direction has a periodic BC

--- a/src/ordering.f90
+++ b/src/ordering.f90
@@ -1,14 +1,8 @@
 module m_ordering
 
-  use m_common, only: dp, get_dirs_from_rdr, DIR_X, DIR_Y, DIR_Z, DIR_C, &
-                      RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y
-
-  use m_mesh, only: mesh_t
+  use m_common, only: dp, get_dirs_from_rdr, DIR_X, DIR_Y, DIR_Z, DIR_C
 
   implicit none
-  interface get_index_reordering
-    procedure get_index_reordering_rdr, get_index_reordering_dirs
-  end interface
 
 contains
    !!
@@ -74,38 +68,22 @@ contains
 
   end subroutine get_index_dir
 
-  pure subroutine get_index_reordering_dirs( &
-    out_i, out_j, out_k, in_i, in_j, in_k, dir_from, dir_to, mesh &
+  pure subroutine get_index_reordering( &
+    out_i, out_j, out_k, in_i, in_j, in_k, dir_from, dir_to, sz, cart_padded &
     )
-      !! Converts a set of application storage directional index to an other direction.
-      !! The two directions are defined by the reorder_dir variable, RDR_X2Y will go from storage in X to Y etc.
-    integer, intent(out) :: out_i, out_j, out_k         ! new indices in the application storage
-    integer, intent(in) :: in_i, in_j, in_k             ! original indices
+    !! Converts indices in between any two DIR_?
+    integer, intent(out) :: out_i, out_j, out_k ! output indices
+    integer, intent(in) :: in_i, in_j, in_k ! input indices
     integer, intent(in) :: dir_from, dir_to
-    type(mesh_t), intent(in) :: mesh
+    integer, intent(in) :: sz
+    integer, intent(in) :: cart_padded(3) ! padded cartesian dimensions
     integer :: i, j, k        ! Intermediary cartesian indices
-    integer, dimension(3) :: dims_padded
 
-    dims_padded = mesh%get_padded_dims(DIR_C)
-    call get_index_ijk(i, j, k, in_i, in_j, in_k, dir_from, mesh%get_sz(), &
-                       dims_padded(1), dims_padded(2), dims_padded(3))
-    call get_index_dir(out_i, out_j, out_k, i, j, k, dir_to, mesh%get_sz(), &
-                       dims_padded(1), dims_padded(2), dims_padded(3))
+    call get_index_ijk(i, j, k, in_i, in_j, in_k, dir_from, sz, &
+                       cart_padded(1), cart_padded(2), cart_padded(3))
+    call get_index_dir(out_i, out_j, out_k, i, j, k, dir_to, sz, &
+                       cart_padded(1), cart_padded(2), cart_padded(3))
 
-  end subroutine get_index_reordering_dirs
-
-  pure subroutine get_index_reordering_rdr(out_i, out_j, out_k, &
-                                           in_i, in_j, in_k, reorder_dir, mesh)
-    integer, intent(out) :: out_i, out_j, out_k         ! new indices in the application storage
-    integer, intent(in) :: in_i, in_j, in_k             ! original indices
-    integer, intent(in) :: reorder_dir
-    type(mesh_t), intent(in) :: mesh
-    integer :: dir_from, dir_to
-
-    call get_dirs_from_rdr(dir_from, dir_to, reorder_dir)
-    call get_index_reordering(out_i, out_j, out_k, in_i, in_j, in_k, &
-                              dir_from, dir_to, mesh)
-
-  end subroutine get_index_reordering_rdr
+  end subroutine get_index_reordering
 
 end module m_ordering

--- a/tests/cuda/test_cuda_allocator.f90
+++ b/tests/cuda/test_cuda_allocator.f90
@@ -3,35 +3,20 @@ program test_allocator_cuda
 
   use m_allocator, only: allocator_t, field_t
   use m_common, only: dp, pi, DIR_X
-  use m_mesh, only: mesh_t
 
   use m_cuda_allocator, only: cuda_allocator_t
 
   implicit none
 
   logical :: allpass
-  integer, dimension(3) :: dims, nproc_dir
-  real(dp) :: L_global(3)
-  character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
   class(allocator_t), allocatable :: allocator
-  class(mesh_t), allocatable :: mesh
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
   integer :: ierr
 
   call MPI_Init(ierr)
 
-  dims = [8, 8, 8]
-  nproc_dir = [1, 1, 1]
-  L_global = [2*pi, 2*pi, 2*pi]
-
-  BC_x = ['periodic', 'periodic']
-  BC_y = ['periodic', 'periodic']
-  BC_z = ['periodic', 'periodic']
-
-  mesh = mesh_t(dims, nproc_dir, L_global, BC_x, BC_y, BC_z)
-
-  allocator = cuda_allocator_t(mesh, 8)
+  allocator = cuda_allocator_t(8, 8, 8, 8)
 
   allpass = .true.
 

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -18,7 +18,7 @@ program test_omp_transeq
   class(field_t), pointer :: du, dv, dw
   real(dp), dimension(:, :, :), allocatable :: r_u
   class(mesh_t), allocatable :: mesh
-  integer, dimension(3) :: dims_global, nproc_dir
+  integer, dimension(3) :: dims_global, dims, nproc_dir
   real(dp), dimension(3) :: L_global
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
@@ -55,9 +55,11 @@ program test_omp_transeq
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
 
+  dims = mesh%get_dims(VERT)
+
   xdirps%dir = DIR_X; ydirps%dir = DIR_Y; zdirps%dir = DIR_Z
 
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
   print *, 'OpenMP allocator instantiated'
 
@@ -68,7 +70,7 @@ program test_omp_transeq
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
 
   n = mesh%get_n(DIR_X, VERT)
-  n_groups = mesh%get_n_groups(DIR_X)
+  n_groups = allocator%get_n_groups(DIR_X)
 
   nu = 1._dp
 

--- a/tests/omp/test_omp_transeq_species.f90
+++ b/tests/omp/test_omp_transeq_species.f90
@@ -18,7 +18,7 @@ program test_omp_transeq_species
   class(field_t), pointer :: dspec
   real(dp), dimension(:, :, :), allocatable :: r_u
   class(mesh_t), allocatable :: mesh
-  integer, dimension(3) :: dims_global, nproc_dir
+  integer, dimension(3) :: dims_global, dims, nproc_dir
   real(dp), dimension(3) :: L_global
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
@@ -55,9 +55,11 @@ program test_omp_transeq_species
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
 
+  dims = mesh%get_dims(VERT)
+
   xdirps%dir = DIR_X; ydirps%dir = DIR_Y; zdirps%dir = DIR_Z
 
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
   print *, 'OpenMP allocator instantiated'
 
@@ -68,7 +70,7 @@ program test_omp_transeq_species
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
 
   n = mesh%get_n(DIR_X, VERT)
-  n_groups = mesh%get_n_groups(DIR_X)
+  n_groups = allocator%get_n_groups(DIR_X)
 
   nu = 1._dp
 

--- a/tests/test_allocator.f90
+++ b/tests/test_allocator.f90
@@ -4,7 +4,6 @@ program test_allocator
 
   use m_allocator, only: allocator_t
   use m_field, only: field_t
-  use m_mesh, only: mesh_t
   use m_common, only: DIR_X, pi, dp
 
   implicit none
@@ -14,28 +13,13 @@ program test_allocator
   real(dp), dimension(3) :: L_global
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
   class(allocator_t), allocatable :: allocator
-  class(mesh_t), allocatable :: mesh
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
   integer :: ierr
 
   call MPI_Init(ierr)
-  ! Global number of cells in each direction
-  dims_global = [8, 8, 8]
 
-  ! Global domain dimensions
-  L_global = [2*pi, 2*pi, 2*pi]
-
-  ! Domain decomposition in each direction
-  nproc_dir = [1, 1, 1]
-
-  BC_x = ['periodic', 'periodic']
-  BC_y = ['periodic', 'periodic']
-  BC_z = ['periodic', 'periodic']
-
-  mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
-
-  allocator = allocator_t(mesh, 8)
+  allocator = allocator_t(8, 8, 8, 8)
 
   allpass = .true.
 

--- a/tests/test_fft.f90
+++ b/tests/test_fft.f90
@@ -88,8 +88,9 @@ program test_fft
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z, use_2decomp=use_2decomp)
 
+  dims = mesh%get_dims(VERT)
 #ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh, SZ)
+  cuda_allocator = cuda_allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => cuda_allocator
   print *, 'CUDA allocator instantiated'
 
@@ -97,7 +98,7 @@ program test_fft
   backend => cuda_backend
   print *, 'CUDA backend instantiated'
 #else
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
 
   omp_backend = omp_backend_t(mesh, allocator)

--- a/tests/test_mesh.f90
+++ b/tests/test_mesh.f90
@@ -58,7 +58,7 @@ contains
   subroutine run_test_mesh(use_2decomp, allpass)
     logical, intent(in) :: use_2decomp
     logical, intent(inout) :: allpass
-    integer, dimension(3) :: nproc_dir, dims_global
+    integer, dimension(3) :: nproc_dir, dims_global, dims
     real(dp), dimension(3) :: L_global
     character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
     integer, dimension(4) :: n_vert_z
@@ -86,7 +86,8 @@ contains
       n_vert_z = [4, 4, 4, 4]
     end if
 
-    allocator = allocator_t(mesh, 8)
+    dims = mesh%get_dims(VERT)
+    allocator = allocator_t(dims(1), dims(2), dims(3), 8)
 
     ptr1 => allocator%get_block(DIR_Z, CELL)
     ptr2 => allocator%get_block(DIR_Z, VERT)
@@ -118,7 +119,7 @@ contains
       print *, "error in get_n for x_face, n_x_face=", n_x_face
     end if
 
-    dims = mesh%get_padded_dims(DIR_C)
+    dims = allocator%get_padded_dims(DIR_C)
     dims_check = [8, 8, n_vert_z(mesh%par%nrank + 1)] ! No padding in Z
 
     if (.not. all(dims(:) == dims_check(:))) then

--- a/tests/test_reordering.f90
+++ b/tests/test_reordering.f90
@@ -83,8 +83,9 @@ program test_reorder
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
 
+  dims = mesh%get_dims(VERT)
 #ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh, SZ)
+  cuda_allocator = cuda_allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => cuda_allocator
   print *, 'CUDA allocator instantiated'
 
@@ -92,7 +93,7 @@ program test_reorder
   backend => cuda_backend
   print *, 'CUDA backend instantiated'
 #else
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
   print *, 'OpenMP allocator instantiated'
 
@@ -106,20 +107,17 @@ program test_reorder
   pass_Y = .true.
   pass_Z = .true.
 
-  dims_padded = mesh%get_padded_dims(DIR_C)
+  dims_padded = allocator%get_padded_dims(DIR_C)
 
   ! Test indexing only
   do k = 1, mesh%get_n(DIR_Z, VERT)
     do j = 1, mesh%get_n(DIR_Y, VERT)
       do i = 1, mesh%get_n(DIR_X, VERT)
-        call test_index_reversing(pass_X, i, j, k, DIR_X, &
-                                  mesh%get_sz(), dims_padded(1), &
+        call test_index_reversing(pass_X, i, j, k, DIR_X, SZ, dims_padded(1), &
                                   dims_padded(2), dims_padded(3))
-        call test_index_reversing(pass_Y, i, j, k, DIR_Y, &
-                                  mesh%get_sz(), dims_padded(1), &
+        call test_index_reversing(pass_Y, i, j, k, DIR_Y, SZ, dims_padded(1), &
                                   dims_padded(2), dims_padded(3))
-        call test_index_reversing(pass_Z, i, j, k, DIR_Z, &
-                                  mesh%get_sz(), dims_padded(1), &
+        call test_index_reversing(pass_Z, i, j, k, DIR_Z, SZ, dims_padded(1), &
                                   dims_padded(2), dims_padded(3))
       end do
     end do
@@ -136,7 +134,7 @@ program test_reorder
   u_z => allocator%get_block(DIR_Z)
   u_x_original => allocator%get_block(DIR_X)
 
-  dims(:) = mesh%get_padded_dims(DIR_X)
+  dims(:) = allocator%get_padded_dims(DIR_X)
   allocate (u_array(dims(1), dims(2), dims(3)))
 
   call random_number(u_array)

--- a/tests/test_scalar_product.f90
+++ b/tests/test_scalar_product.f90
@@ -36,7 +36,7 @@ program test_scalar_product
                                                 "DIR_Z", "DIR_C"]
   integer, dimension(4), parameter :: dir = [DIR_X, DIR_Y, &
                                              DIR_Z, DIR_C]
-  integer :: i
+  integer :: i, dims(3)
 
   integer :: nrank, nproc
   integer :: ierr
@@ -56,9 +56,11 @@ program test_scalar_product
                 [lx, ly, lz], &
                 BC_x, BC_y, BC_z)
 
+  dims = mesh%get_dims(VERT)
+
 #ifdef CUDA
 #else
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
   omp_backend = omp_backend_t(mesh, allocator)
   backend => omp_backend

--- a/tests/test_scalar_product.f90
+++ b/tests/test_scalar_product.f90
@@ -132,7 +132,7 @@ contains
     ! Determine number of interior points, using a temporary DIR_C field
     c => backend%allocator%get_block(DIR_C)
     call c%set_data_loc(a%data_loc)
-    n = product(mesh%get_field_dims(c))
+    n = product(mesh%get_dims(c%data_loc))
     call backend%allocator%release_block(c)
 
     expt = n*(nrank + 1)**2

--- a/tests/test_setget_field.f90
+++ b/tests/test_setget_field.f90
@@ -30,7 +30,7 @@ program test_setget_field
 
   class(field_t), pointer :: fld, fld_c
   real(dp), dimension(:, :, :), allocatable :: arr
-  integer, dimension(3) :: shape_c
+  integer, dimension(3) :: shape_c, dims
 
   integer :: ierr
 
@@ -41,11 +41,13 @@ program test_setget_field
                 ["periodic", "periodic"], &
                 ["periodic", "periodic"])
 
+  dims = mesh%get_dims(VERT)
+
 #ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh, SZ)
+  cuda_allocator = cuda_allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => cuda_allocator
 #else
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
 
   omp_backend = omp_backend_t(mesh, allocator)

--- a/tests/test_sum_intox.f90
+++ b/tests/test_sum_intox.f90
@@ -29,7 +29,7 @@ program test_sum_intox
   type(mesh_t) :: mesh
 
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
-  integer :: nrank, nproc
+  integer :: nrank, nproc, dims(3)
   integer :: ierr
 
   logical :: test_pass = .true.
@@ -47,9 +47,11 @@ program test_sum_intox
                 [lx, ly, lz], &
                 BC_x, BC_y, BC_z)
 
+  dims = mesh%get_dims(VERT)
+
 #ifdef CUDA
 #else
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
   omp_backend = omp_backend_t(mesh, allocator)
   backend => omp_backend
@@ -90,7 +92,7 @@ contains
     a => backend%allocator%get_block(DIR_X)
     b => backend%allocator%get_block(dir_from)
 
-    dims = mesh%get_padded_dims(DIR_C)
+    dims = backend%allocator%get_padded_dims(DIR_C)
 
     ! Initialise fields so that b = -a
     ctr = 0

--- a/tests/test_time_integrator.f90
+++ b/tests/test_time_integrator.f90
@@ -2,7 +2,7 @@ program test_omp_adamsbashforth
   use iso_fortran_env, only: stderr => error_unit
   use mpi
 
-  use m_common, only: dp, DIR_X, pi
+  use m_common, only: dp, pi, DIR_X, VERT
   use m_mesh, only: mesh_t
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
@@ -73,9 +73,10 @@ program test_omp_adamsbashforth
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
 
+  dims = mesh%get_dims(VERT)
   ! allocate object
 #ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh, 1)
+  cuda_allocator = cuda_allocator_t(dims(1), dims(2), dims(3), 1)
   allocator => cuda_allocator
   if (nrank == 0) print *, 'CUDA allocator instantiated'
 
@@ -83,7 +84,7 @@ program test_omp_adamsbashforth
   backend => cuda_backend
   if (nrank == 0) print *, 'CUDA backend instantiated'
 #else
-  omp_allocator = allocator_t(mesh, 1)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), 1)
   allocator => omp_allocator
   if (nrank == 0) print *, 'OpenMP allocator instantiated'
 

--- a/tests/test_vecadd.f90
+++ b/tests/test_vecadd.f90
@@ -6,7 +6,7 @@ program test_vecadd
 
   use MPI
 
-  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
   use m_mesh, only: mesh_t
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
@@ -42,7 +42,7 @@ program test_vecadd
   class(field_t), pointer :: c => null()
   class(field_t), pointer :: z => null()
 
-  integer, dimension(3) :: dims_global
+  integer, dimension(3) :: dims_global, dims
   integer, dimension(3) :: nproc_dir
   real(dp), dimension(3) :: L_global
   character(len=8), dimension(2) :: BC_x, BC_y, BC_z
@@ -62,15 +62,16 @@ program test_vecadd
   BC_z = BC_x
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
+  dims = mesh%get_dims(VERT)
 #ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh, SZ)
+  cuda_allocator = cuda_allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => cuda_allocator
-  host_allocator = allocator_t(mesh, SZ)
+  host_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
 
   cuda_backend = cuda_backend_t(mesh, allocator)
   backend => cuda_backend
 #else
-  omp_allocator = allocator_t(mesh, SZ)
+  omp_allocator = allocator_t(dims(1), dims(2), dims(3), SZ)
   allocator => omp_allocator
   host_allocator => omp_allocator
 


### PR DESCRIPTION
closes #166

Ended up moving `get_padded_dims` and `get_n_groups` from mesh to allocator. Mesh is used for all the physical dimensions and allocator is used when padded dimensions are required. No more cyclic dependency between mesh and allocator (explained in detail in #166), and they can be instantiated independently.