### PR TITLE
Add support in mesh%get_coordinates to return coords of any data_loc

### DIFF
--- a/src/io/checkpoint_io.f90
+++ b/src/io/checkpoint_io.f90
@@ -338,7 +338,7 @@ contains
     end if
 
     call self%generate_coordinates( &
-      solver, file, shape_dims, start_dims, count_dims &
+      solver, file, shape_dims, start_dims, count_dims, solver%u%data_loc &
       )
 
     allocate (field_ptrs(3))
@@ -356,12 +356,13 @@ contains
   end subroutine write_snapshot
 
   subroutine generate_coordinates( &
-    self, solver, file, shape_dims, start_dims, count_dims &
+    self, solver, file, shape_dims, start_dims, count_dims, data_loc &
     )
     class(checkpoint_manager_adios2_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
     type(adios2_file_t), intent(inout) :: file
     integer(i8), dimension(3), intent(in) :: shape_dims, start_dims, count_dims
+    integer, intent(in) :: data_loc
 
     integer :: i, nx, ny, nz
     real(dp), dimension(3) :: coords
@@ -390,17 +391,17 @@ contains
     end if
 
     do i = 1, nx
-      coords = solver%mesh%get_coordinates(i, 1, 1)
+      coords = solver%mesh%get_coordinates(i, 1, 1, data_loc)
       self%coords_x(i, 1, 1) = coords(1)
     end do
 
     do i = 1, ny
-      coords = solver%mesh%get_coordinates(1, i, 1)
+      coords = solver%mesh%get_coordinates(1, i, 1, data_loc)
       self%coords_y(1, i, 1) = coords(2)
     end do
 
     do i = 1, nz
-      coords = solver%mesh%get_coordinates(1, 1, i)
+      coords = solver%mesh%get_coordinates(1, 1, i, data_loc)
       self%coords_z(1, 1, i) = coords(3)
     end do
 

--- a/src/mesh.f90
+++ b/src/mesh.f90
@@ -305,15 +305,57 @@ contains
     end select
   end function get_n_dir
 
-  pure function get_coordinates(self, i, j, k) result(xloc)
-    !! Get the coordinates of a vertex with i, j, k local indices
+  pure function get_coordinates(self, i, j, k, data_loc_op) result(coords)
+    !! Get the coordinates of a vertex with i, j, k local cartesian indices
+    !! Avoid calling this in hot loops
     class(mesh_t), intent(in) :: self
     integer, intent(in) :: i, j, k
-    real(dp), dimension(3) :: xloc
+    integer, optional, intent(in) :: data_loc_op
+    integer :: data_loc
+    real(dp), dimension(3) :: coords
 
-    xloc(1) = self%geo%vert_coords(i, 1)
-    xloc(2) = self%geo%vert_coords(j, 2)
-    xloc(3) = self%geo%vert_coords(k, 3)
+    if (present(data_loc_op)) then
+      data_loc = data_loc_op
+    else
+      data_loc = VERT
+    end if
+
+    select case (data_loc)
+    case (VERT)
+      coords(1) = self%geo%vert_coords(i, 1)
+      coords(2) = self%geo%vert_coords(j, 2)
+      coords(3) = self%geo%vert_coords(k, 3)
+    case (CELL)
+      coords(1) = self%geo%midp_coords(i, 1)
+      coords(2) = self%geo%midp_coords(j, 2)
+      coords(3) = self%geo%midp_coords(k, 3)
+    case (X_FACE)
+      coords(1) = self%geo%vert_coords(i, 1)
+      coords(2) = self%geo%midp_coords(j, 2)
+      coords(3) = self%geo%midp_coords(k, 3)
+    case (Y_FACE)
+      coords(1) = self%geo%midp_coords(i, 1)
+      coords(2) = self%geo%vert_coords(j, 2)
+      coords(3) = self%geo%midp_coords(k, 3)
+    case (Z_FACE)
+      coords(1) = self%geo%midp_coords(i, 1)
+      coords(2) = self%geo%midp_coords(j, 2)
+      coords(3) = self%geo%vert_coords(k, 3)
+    case (X_EDGE)
+      coords(1) = self%geo%midp_coords(i, 1)
+      coords(2) = self%geo%vert_coords(j, 2)
+      coords(3) = self%geo%vert_coords(k, 3)
+    case (Y_EDGE)
+      coords(1) = self%geo%vert_coords(i, 1)
+      coords(2) = self%geo%midp_coords(j, 2)
+      coords(3) = self%geo%vert_coords(k, 3)
+    case (Z_EDGE)
+      coords(1) = self%geo%vert_coords(i, 1)
+      coords(2) = self%geo%vert_coords(j, 2)
+      coords(3) = self%geo%midp_coords(k, 3)
+    case default
+      error stop "Unknown data_loc in get_coordinates"
+    end select
   end function
 
 end module m_mesh


### PR DESCRIPTION
Closes #186 

`mesh%get_coordinates` returns VERT coordinates by default, but an arbitrary data_loc can be passed and then it returns the correct coordinates. I guess this can be useful in IO if we want to output a CELL field for example.