### PR TITLE
Simplify vecadd and veccopy by disabling DIR_C support

### DIFF
--- a/tests/test_time_integrator.f90
+++ b/tests/test_time_integrator.f90
@@ -13,8 +13,10 @@ program test_omp_adamsbashforth
 
   use m_cuda_allocator, only: cuda_allocator_t, cuda_field_t
   use m_cuda_backend, only: cuda_backend_t
+  use m_cuda_common, only: SZ
 #else
   use m_omp_backend, only: omp_backend_t
+  use m_omp_common, only: SZ
 #endif
 
   implicit none
@@ -75,7 +77,7 @@ program test_omp_adamsbashforth
 
   ! allocate object
 #ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), 1)
+  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
   allocator => cuda_allocator
   if (nrank == 0) print *, 'CUDA allocator instantiated'
 
@@ -83,7 +85,7 @@ program test_omp_adamsbashforth
   backend => cuda_backend
   if (nrank == 0) print *, 'CUDA backend instantiated'
 #else
-  omp_allocator = allocator_t(mesh%get_dims(VERT), 1)
+  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
   allocator => omp_allocator
   if (nrank == 0) print *, 'OpenMP allocator instantiated'
 

--- a/tests/test_vecadd.f90
+++ b/tests/test_vecadd.f90
@@ -21,9 +21,9 @@ program test_vecadd
 
   implicit none
 
-  integer, dimension(4), parameter :: dirs = [DIR_X, DIR_Y, DIR_Z, DIR_C]
-  character(len=5), dimension(4), parameter :: dirnames = &
-                         ["DIR_X", "DIR_Y", "DIR_Z", "DIR_C"]
+  integer, dimension(3), parameter :: dirs = [DIR_X, DIR_Y, DIR_Z]
+  character(len=5), dimension(3), parameter :: dirnames = &
+                         ["DIR_X", "DIR_Y", "DIR_Z"]
 
   class(mesh_t), allocatable :: mesh
   class(allocator_t), pointer :: allocator => null()


### PR DESCRIPTION
@pbartholomew08, are you using `vecadd` or `veccopy` with DIR_C arrays at all? @CFD-Xing had a bug in #189 related to vecadd with a specific domain size, I didn't get to the bottom of the issue but it looks like its related to the current implementation that supports DIR_C as well as DIR_X/Y/Z. If we can drop DIR_C support the implementation is a lot more straightforward and also potentially faster. I added the necessary sanity-checks so program terminates if someone attempts to use them with DIR_C fields.

Also, I think we already diverged from the suggestion in #38, so it is better closing it based on the discussions here.