### PR TITLE
Preliminary support for single precision

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,10 @@ else()
   list(APPEND SRC ${DUMMYADIOS2SRC})
 endif()
 
+if(SINGLE_PREC)
+  add_definitions("-DSINGLE_PREC")
+endif()
+
 add_library(x3d2 STATIC ${SRC})
 target_include_directories(x3d2 INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -5,7 +5,7 @@ module m_cuda_backend
 
   use m_allocator, only: allocator_t
   use m_base_backend, only: base_backend_t
-  use m_common, only: dp, move_data_loc, &
+  use m_common, only: dp, MPI_X3D2_DP, move_data_loc, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
                       RDR_C2X, RDR_C2Y, RDR_C2Z, RDR_X2C, RDR_Y2C, RDR_Z2C, &
                       DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, NULL_LOC, &
@@ -36,7 +36,6 @@ module m_cuda_backend
 
   type, extends(base_backend_t) :: cuda_backend_t
     !character(len=*), parameter :: name = 'cuda'
-    integer :: MPI_FP_PREC = dp
     real(dp), device, allocatable, dimension(:, :, :) :: &
       u_recv_s_dev, u_recv_e_dev, u_send_s_dev, u_send_e_dev, &
       v_recv_s_dev, v_recv_e_dev, v_send_s_dev, v_send_e_dev, &
@@ -786,7 +785,7 @@ contains
 
     s = sum_d
 
-    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_X3D2_DP, MPI_SUM, &
                        MPI_COMM_WORLD, ierr)
 
   end function scalar_product_cuda
@@ -864,9 +863,9 @@ contains
     mean_val = mean_val/product(self%mesh%get_global_dims(data_loc))
 
     ! make sure all ranks have final values
-    call MPI_Allreduce(MPI_IN_PLACE, max_val, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, max_val, 1, MPI_X3D2_DP, &
                        MPI_MAX, MPI_COMM_WORLD, ierr)
-    call MPI_Allreduce(MPI_IN_PLACE, mean_val, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, mean_val, 1, MPI_X3D2_DP, &
                        MPI_SUM, MPI_COMM_WORLD, ierr)
 
   end subroutine field_max_mean_cuda
@@ -986,7 +985,7 @@ contains
 
     s = integral_d
 
-    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_X3D2_DP, MPI_SUM, &
                        MPI_COMM_WORLD, ierr)
 
   end function field_volume_integral_cuda

--- a/src/backend/cuda/poisson_fft.f90
+++ b/src/backend/cuda/poisson_fft.f90
@@ -143,8 +143,13 @@ contains
     ierr = cufftCreate(poisson_fft%plan3D_fw)
     ierr = cufftMpAttachComm(poisson_fft%plan3D_fw, CUFFT_COMM_MPI, &
                              MPI_COMM_WORLD)
+#ifdef SINGLE_PREC
+    ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_R2C, &
+                           worksize)
+#else
     ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
                            worksize)
+#endif
     if (ierr /= 0) then
       write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Forward 3D FFT plan generation failed'
@@ -153,8 +158,13 @@ contains
     ierr = cufftCreate(poisson_fft%plan3D_bw)
     ierr = cufftMpAttachComm(poisson_fft%plan3D_bw, CUFFT_COMM_MPI, &
                              MPI_COMM_WORLD)
+#ifdef SINGLE_PREC
+    ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_C2R, &
+                           worksize)
+#else
     ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
                            worksize)
+#endif
     if (ierr /= 0) then
       write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Backward 3D FFT plan generation failed'

--- a/src/backend/cuda/sendrecv.f90
+++ b/src/backend/cuda/sendrecv.f90
@@ -2,7 +2,7 @@ module m_cuda_sendrecv
   use cudafor
   use mpi
 
-  use m_common, only: dp
+  use m_common, only: dp, MPI_X3D2_DP
 
   implicit none
 
@@ -22,13 +22,13 @@ contains
       f_recv_s = f_send_e
       f_recv_e = f_send_s
     else
-      call MPI_Isend(f_send_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f_send_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(1), err(1))
-      call MPI_Irecv(f_recv_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f_recv_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(2), err(2))
-      call MPI_Isend(f_send_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f_send_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(3), err(3))
-      call MPI_Irecv(f_recv_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f_recv_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(4), err(4))
 
       call MPI_Waitall(4, req, MPI_STATUSES_IGNORE, ierr)
@@ -59,31 +59,31 @@ contains
       f3_recv_s = f3_send_e
       f3_recv_e = f3_send_s
     else
-      call MPI_Isend(f1_send_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f1_send_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(1), err(1))
-      call MPI_Irecv(f1_recv_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f1_recv_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(2), err(2))
-      call MPI_Isend(f1_send_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f1_send_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(3), err(3))
-      call MPI_Irecv(f1_recv_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f1_recv_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(4), err(4))
 
-      call MPI_Isend(f2_send_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f2_send_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(5), err(5))
-      call MPI_Irecv(f2_recv_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f2_recv_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(6), err(6))
-      call MPI_Isend(f2_send_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f2_send_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(7), err(7))
-      call MPI_Irecv(f2_recv_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f2_recv_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(8), err(8))
 
-      call MPI_Isend(f3_send_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f3_send_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(9), err(9))
-      call MPI_Irecv(f3_recv_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f3_recv_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(10), err(10))
-      call MPI_Isend(f3_send_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f3_send_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(11), err(11))
-      call MPI_Irecv(f3_recv_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f3_recv_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(12), err(12))
 
       call MPI_Waitall(12, req, MPI_STATUSES_IGNORE, ierr)

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -3,7 +3,7 @@ module m_omp_backend
 
   use m_allocator, only: allocator_t
   use m_base_backend, only: base_backend_t
-  use m_common, only: dp, get_dirs_from_rdr, move_data_loc, &
+  use m_common, only: dp, MPI_X3D2_DP, get_dirs_from_rdr, move_data_loc, &
                       DIR_X, DIR_Y, DIR_Z, DIR_C, NULL_LOC, &
                       X_FACE, Y_FACE, Z_FACE, VERT
   use m_field, only: field_t
@@ -21,7 +21,6 @@ module m_omp_backend
 
   type, extends(base_backend_t) :: omp_backend_t
     !character(len=*), parameter :: name = 'omp'
-    integer :: MPI_FP_PREC = dp
     real(dp), allocatable, dimension(:, :, :) :: &
       u_recv_s, u_recv_e, u_send_s, u_send_e, &
       v_recv_s, v_recv_e, v_send_s, v_send_e, &
@@ -617,7 +616,7 @@ contains
     call self%allocator%release_block(y_)
 
     ! Reduce the result
-    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_X3D2_DP, &
                        MPI_SUM, MPI_COMM_WORLD, &
                        ierr)
 
@@ -714,9 +713,9 @@ contains
     mean_val = sum_p/product(self%mesh%get_global_dims(data_loc))
 
     ! make sure all ranks have final values
-    call MPI_Allreduce(MPI_IN_PLACE, max_val, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, max_val, 1, MPI_X3D2_DP, &
                        MPI_MAX, MPI_COMM_WORLD, ierr)
-    call MPI_Allreduce(MPI_IN_PLACE, mean_val, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, mean_val, 1, MPI_X3D2_DP, &
                        MPI_SUM, MPI_COMM_WORLD, ierr)
 
   end subroutine field_max_mean_omp
@@ -824,7 +823,7 @@ contains
     ! rank-local values
     s = sum_p
 
-    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+    call MPI_Allreduce(MPI_IN_PLACE, s, 1, MPI_X3D2_DP, MPI_SUM, &
                        MPI_COMM_WORLD, ierr)
 
   end function field_volume_integral_omp

--- a/src/backend/omp/sendrecv.f90
+++ b/src/backend/omp/sendrecv.f90
@@ -1,7 +1,7 @@
 module m_omp_sendrecv
   use mpi
 
-  use m_common, only: dp
+  use m_common, only: dp, MPI_X3D2_DP
 
   implicit none
 
@@ -21,13 +21,13 @@ contains
       f_recv_s = f_send_e
       f_recv_e = f_send_s
     else
-      call MPI_Isend(f_send_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f_send_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(1), err(1))
-      call MPI_Irecv(f_recv_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f_recv_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(2), err(2))
-      call MPI_Isend(f_send_e, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Isend(f_send_e, n_data, MPI_X3D2_DP, &
                      next, tag, MPI_COMM_WORLD, req(3), err(3))
-      call MPI_Irecv(f_recv_s, n_data, MPI_DOUBLE_PRECISION, &
+      call MPI_Irecv(f_recv_s, n_data, MPI_X3D2_DP, &
                      prev, tag, MPI_COMM_WORLD, req(4), err(4))
 
       call MPI_Waitall(4, req, MPI_STATUSES_IGNORE, ierr)

--- a/src/case/channel.f90
+++ b/src/case/channel.f90
@@ -5,7 +5,7 @@ module m_case_channel
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
   use m_base_case, only: base_case_t
-  use m_common, only: dp, get_argument, DIR_C, VERT, CELL, Y_FACE
+  use m_common, only: dp, MPI_X3D2_DP, get_argument, DIR_C, VERT, CELL, Y_FACE
   use m_config, only: channel_config_t
   use m_mesh, only: mesh_t
   use m_solver, only: init
@@ -53,7 +53,7 @@ contains
     ub = self%solver%backend%field_volume_integral(self%solver%u)
 
     ub = ub/(product(self%solver%mesh%get_global_dims(CELL)))
-    call MPI_Allreduce(MPI_IN_PLACE, ub, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, ub, 1, MPI_X3D2_DP, &
                        MPI_SUM, MPI_COMM_WORLD, ierr)
 
     can = 2._dp/3._dp - ub

--- a/src/common.f90
+++ b/src/common.f90
@@ -1,8 +1,18 @@
 module m_common
+  use mpi
+
   implicit none
 
+#ifdef SINGLE_PREC
+  integer, parameter :: dp = kind(0.0e0)
+  integer, parameter :: MPI_X3D2_DP = MPI_REAL
+#else
   integer, parameter :: dp = kind(0.0d0)
+  integer, parameter :: MPI_X3D2_DP = MPI_DOUBLE_PRECISION
+#endif
+
   integer, parameter :: i8 = selected_int_kind(18)
+
   real(dp), parameter :: pi = 4*atan(1.0_dp)
 
   integer, parameter :: RDR_X2Y = 12, RDR_X2Z = 13, RDR_Y2X = 21, &

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -50,7 +50,10 @@ program xcompact
   call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
   call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
 
-  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
+  if (nrank == 0) then
+    print *, 'Parallel run with', nproc, 'ranks'
+    print *, 'Data precision is', dp
+  end if
 
 #ifdef CUDA
   ierr = cudaGetDeviceCount(ndevs)

--- a/tests/cuda/test_cuda_transeq.f90
+++ b/tests/cuda/test_cuda_transeq.f90
@@ -3,7 +3,8 @@ program test_cuda_tridiag
   use cudafor
   use mpi
 
-  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
+  use m_common, only: dp, pi, MPI_X3D2_DP, &
+                      BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields, sendrecv_3fields
@@ -148,9 +149,9 @@ program test_cuda_tridiag
   ! BW utilisation and performance checks
   ! 11 in the first phase, 5 in the second phase, 16 in total
   achievedBW = 16._dp*n_iters*n*n_block*SZ*dp/(tend - tstart)
-  call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_X3D2_DP, &
                      MPI_MAX, MPI_COMM_WORLD, ierr)
-  call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_X3D2_DP, &
                      MPI_MIN, MPI_COMM_WORLD, ierr)
 
   if (nrank == 0) then
@@ -174,7 +175,7 @@ program test_cuda_tridiag
   r_u = r_u - (-v*v + 0.5_dp*u*u - nu*u)
   norm_du = norm2(r_u)
   norm_du = norm_du*norm_du/n_glob/n_block/SZ
-  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_X3D2_DP, &
                      MPI_SUM, MPI_COMM_WORLD, ierr)
   norm_du = sqrt(norm_du)
 

--- a/tests/cuda/test_cuda_tridiag.f90
+++ b/tests/cuda/test_cuda_tridiag.f90
@@ -3,7 +3,8 @@ program test_cuda_tridiag
   use cudafor
   use mpi
 
-  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
+  use m_common, only: dp, pi, MPI_X3D2_DP, &
+                      BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
@@ -110,9 +111,9 @@ program test_cuda_tridiag
   ! BW utilisation and performance checks
   ! 4 in the first phase, 2 in the second phase, 6 in total
   achievedBW = 6._dp*n_iters*n*n_block*SZ*dp/(tend - tstart)
-  call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_X3D2_DP, &
                      MPI_MAX, MPI_COMM_WORLD, ierr)
-  call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_X3D2_DP, &
                      MPI_MIN, MPI_COMM_WORLD, ierr)
 
   if (nrank == 0) then

--- a/tests/omp/test_omp_dist_transeq.f90
+++ b/tests/omp/test_omp_dist_transeq.f90
@@ -2,7 +2,7 @@ program test_transeq
   use iso_fortran_env, only: stderr => error_unit
   use mpi
 
-  use m_common, only: dp, pi, BC_PERIODIC
+  use m_common, only: dp, pi, MPI_X3D2_DP, BC_PERIODIC
   use m_omp_common, only: SZ
   use m_omp_exec_dist, only: exec_dist_transeq_compact
   use m_omp_sendrecv, only: sendrecv_fields
@@ -120,7 +120,7 @@ program test_transeq
   r_u = r_u - (-v*v + 0.5_dp*u*u - nu*u)
   norm_du = norm2(r_u)
   norm_du = norm_du*norm_du/n_glob/n_block/SZ
-  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_X3D2_DP, &
                      MPI_SUM, MPI_COMM_WORLD, ierr)
   norm_du = sqrt(norm_du)
 

--- a/tests/omp/test_omp_transeq.f90
+++ b/tests/omp/test_omp_transeq.f90
@@ -3,7 +3,7 @@ program test_omp_transeq
   use mpi
 
   use m_allocator, only: allocator_t, field_t
-  use m_common, only: dp, pi, DIR_X, DIR_Y, DIR_Z, VERT
+  use m_common, only: dp, pi, MPI_X3D2_DP, DIR_X, DIR_Y, DIR_Z, VERT
   use m_omp_common, only: SZ
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_backend, only: omp_backend_t, transeq_x_omp, base_backend_t
@@ -111,7 +111,7 @@ program test_omp_transeq
   r_u = dv%data - (u%data*u%data - 0.5_dp*v%data*v%data - nu*v%data)
   norm_du = norm2(r_u)
   norm_du = norm_du*norm_du/dims_global(DIR_X)/n_groups/SZ
-  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_X3D2_DP, &
                      MPI_SUM, MPI_COMM_WORLD, ierr)
   norm_du = sqrt(norm_du)
 

--- a/tests/omp/test_omp_transeq_species.f90
+++ b/tests/omp/test_omp_transeq_species.f90
@@ -3,7 +3,7 @@ program test_omp_transeq_species
   use mpi
 
   use m_allocator, only: allocator_t, field_t
-  use m_common, only: dp, pi, DIR_X, DIR_Y, DIR_Z, VERT
+  use m_common, only: dp, pi, MPI_X3D2_DP, DIR_X, DIR_Y, DIR_Z, VERT
   use m_omp_common, only: SZ
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_backend, only: omp_backend_t, transeq_x_omp, base_backend_t
@@ -114,7 +114,7 @@ program test_omp_transeq_species
         - (u%data*u%data - 0.5_dp*spec%data*spec%data - nu*spec%data)
   norm_du = norm2(r_u)
   norm_du = norm_du*norm_du/dims_global(DIR_X)/n_groups/SZ
-  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(MPI_IN_PLACE, norm_du, 1, MPI_X3D2_DP, &
                      MPI_SUM, MPI_COMM_WORLD, ierr)
   norm_du = sqrt(norm_du)
 

--- a/tests/omp/test_omp_tridiag.f90
+++ b/tests/omp/test_omp_tridiag.f90
@@ -3,7 +3,8 @@ program test_omp_tridiag
   use mpi
   use omp_lib
 
-  use m_common, only: dp, pi, BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
+  use m_common, only: dp, pi, MPI_X3D2_DP, &
+                      BC_PERIODIC, BC_NEUMANN, BC_DIRICHLET, BC_HALO
   use m_omp_common, only: SZ
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_exec_dist, only: exec_dist_tds_compact
@@ -342,9 +343,9 @@ program test_omp_tridiag
   ! BW utilisation and performance checks
   ! 3 in the first phase, 2 in the second phase, so 5 in total
   achievedBW = 5._dp*n_iters*n*n_groups*SZ*dp/(tend - tstart)
-  call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(achievedBW, achievedBWmax, 1, MPI_X3D2_DP, &
                      MPI_MAX, MPI_COMM_WORLD, ierr)
-  call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_DOUBLE_PRECISION, &
+  call MPI_Allreduce(achievedBW, achievedBWmin, 1, MPI_X3D2_DP, &
                      MPI_MIN, MPI_COMM_WORLD, ierr)
   if (nrank == 0) then
     print'(a, f8.3, a)', 'Achieved BW min: ', achievedBWmin/2**30, ' GiB/s'
@@ -456,7 +457,7 @@ contains
 
     norm = norm2(du(:, 1:n, :))
     norm = norm*norm/n_glob/n_groups/SZ
-    call MPI_Allreduce(MPI_IN_PLACE, norm, 1, MPI_DOUBLE_PRECISION, &
+    call MPI_Allreduce(MPI_IN_PLACE, norm, 1, MPI_X3D2_DP, &
                        MPI_SUM, MPI_COMM_WORLD, ierr)
     norm = sqrt(norm)
 

--- a/tests/test_fft.f90
+++ b/tests/test_fft.f90
@@ -7,7 +7,7 @@ program test_fft
   use m_tdsops, only: dirps_t
   use m_solver, only: allocate_tdsops
 
-  use m_common, only: dp, pi, &
+  use m_common, only: dp, pi, MPI_X3D2_DP, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
                       DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, CELL
 
@@ -152,7 +152,7 @@ program test_fft
   ! The output scaled with number of cells in domain, hence the first '/product(dims_global)'.
   ! RMS value is used for the norm, hence the second '/product(dims_global)'
   error_norm = norm2(input_data(:, :, :) - output_data(:, :, :)/product(dims_global) )**2/product(dims_global)
-  call MPI_Allreduce(MPI_IN_PLACE, error_norm, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+  call MPI_Allreduce(MPI_IN_PLACE, error_norm, 1, MPI_X3D2_DP, MPI_SUM, MPI_COMM_WORLD, ierr)
   error_norm = sqrt(error_norm)
 
   if (error_norm > tol) then


### PR DESCRIPTION
Closes #70.

I tried running a TGV case with single precision. The first operation in a TGV case is calculating the enstrophy using the compact schemes, and based on the initial condition we get the expected value even at multiple ranks. However the simulation NaN's quickly. The fact that enstrophy calculation is correct showing us that there is nothing fundamentally wrong about the tridiagonal solvers, but still there is a but at some level. Some of the tests with tridiagonal solvers are also failing both on CUDA and OpenMP, while some of them are passing. Unfortunately I don't have enough time left to fix this bug, but this PR is at least adding a preliminary support and would be a good starting point for someone debugging the issue, so I think it can be merged into main, with a new issue detailing the bug with single precision. What do you think @slaizet @pbartholomew08 @ia267?



