### PR TITLE
ADIOS2 XML snapshots for ParaView for uniform grids

### DIFF
--- a/src/io/adios2_io.f90
+++ b/src/io/adios2_io.f90
@@ -65,7 +65,7 @@ module m_adios2_io
       write_array_1d_int, &
       write_array_4d_real
     generic, public :: write_attribute => write_attribute_string, &
-                                          write_attribute_array_1d_real
+      write_attribute_array_1d_real
 
     procedure, private :: write_scalar_int
     procedure, private :: write_scalar_real
@@ -163,8 +163,9 @@ contains
     ! remove all old variables from the IO object
     if (mode == adios2_mode_write) then
       call adios2_remove_all_variables(self%io, ierr)
-      call self%handle_error(ierr, "Failed to remove old ADIOS2 variables before open")
-    endif
+      call self%handle_error(ierr, "Failed to remove old ADIOS2 variables &
+                             & before open")
+    end if
 
     use_comm = self%comm
     if (present(comm)) use_comm = comm
@@ -461,9 +462,10 @@ contains
     integer :: num_elements
 
     num_elements = size(data)
-  
+
     call adios2_define_attribute(attr, self%io, name, data, num_elements, ierr)
-    call self%handle_error(ierr, "Error defining ADIOS2 1D real array attribute")
+    call self%handle_error(ierr, &
+                           "Error defining ADIOS2 1D real array attribute")
   end subroutine write_attribute_array_1d_real
 
   !> Begin a step for ADIOS2 reader type

--- a/src/io/adios2_io.f90
+++ b/src/io/adios2_io.f90
@@ -249,9 +249,14 @@ contains
     type(adios2_variable) :: var
     integer :: ierr
 
-    call adios2_define_variable(var, self%io, name, adios2_type_integer4, ierr)
-    call self%handle_error(ierr, &
-                           "Error defining ADIOS2 scalar integer variable")
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      call adios2_define_variable(var, self%io, name, adios2_type_integer4, &
+                                  ierr)
+      call self%handle_error(ierr, &
+                             "Error defining ADIOS2 scalar integer variable")
+    end if
 
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 scalar integer data")
@@ -267,10 +272,14 @@ contains
     type(adios2_variable) :: var
     integer :: ierr
 
-    call adios2_define_variable(var, self%io, name, &
-                                adios2_type_dp, ierr)
-    call self%handle_error(ierr, "Error defining ADIOS2 scalar &
-                                 & double precision real variable")
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      call adios2_define_variable(var, self%io, name, &
+                                  adios2_type_dp, ierr)
+      call self%handle_error(ierr, "Error defining ADIOS2 scalar &
+                                   & double precision real variable")
+    end if
 
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 scalar &
@@ -310,12 +319,17 @@ contains
       local_count = int(size(data), i8)
     end if
 
-    ! define adios2 variable to be written in given file format
-    call adios2_define_variable(var, self%io, name, adios2_type_integer4, &
-                                1, local_shape, local_start, &
-                                local_count, adios2_constant_dims, ierr)
-    call self%handle_error(ierr, &
-                           "Error defining ADIOS2 1D array integer variable")
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      ! define adios2 variable to be written in given file format
+      call adios2_define_variable(var, self%io, name, adios2_type_integer4, &
+                                  1, local_shape, local_start, &
+                                  local_count, adios2_constant_dims, ierr)
+      call self%handle_error(ierr, &
+                             "Error defining ADIOS2 1D array integer variable")
+    end if
+
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 1D array integer data")
   end subroutine write_array_1d_int
@@ -353,11 +367,16 @@ contains
       local_count = int(size(data), i8)
     end if
 
-    call adios2_define_variable(var, self%io, name, adios2_type_dp, &
-                                1, local_shape, local_start, &
-                                local_count, adios2_constant_dims, ierr)
-    call self%handle_error(ierr, "Error defining ADIOS2 1D array &
-                                 & double precision real variable")
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      call adios2_define_variable(var, self%io, name, adios2_type_dp, &
+                                  1, local_shape, local_start, &
+                                  local_count, adios2_constant_dims, ierr)
+      call self%handle_error(ierr, "Error defining ADIOS2 1D array &
+                                   & double precision real variable")
+    end if
+
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 1D array &
                                 & double precision real data")
@@ -377,11 +396,15 @@ contains
     type(adios2_variable) :: var
     integer :: ierr
 
-    call adios2_define_variable(var, self%io, name, adios2_type_dp, &
-                                2, shape_dims, start_dims, &
-                                count_dims, adios2_constant_dims, ierr)
-    call self%handle_error(ierr, "Error defining ADIOS2 2D array &
-                                 & double precision real variable")
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      call adios2_define_variable(var, self%io, name, adios2_type_dp, &
+                                  2, shape_dims, start_dims, &
+                                  count_dims, adios2_constant_dims, ierr)
+      call self%handle_error(ierr, "Error defining ADIOS2 2D array &
+                                   & double precision real variable")
+    end if
 
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 2D array &
@@ -402,11 +425,15 @@ contains
     type(adios2_variable) :: var
     integer :: ierr
 
-    call adios2_define_variable(var, self%io, name, adios2_type_dp, &
-                                3, shape_dims, start_dims, &
-                                count_dims, adios2_constant_dims, ierr)
-    call self%handle_error(ierr, "Error defining ADIOS2 3D array &
-                                 & double precision real variable")
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      call adios2_define_variable(var, self%io, name, adios2_type_dp, &
+                                  3, shape_dims, start_dims, &
+                                  count_dims, adios2_constant_dims, ierr)
+      call self%handle_error(ierr, "Error defining ADIOS2 3D array &
+                                   & double precision real variable")
+    end if
 
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 3D array &
@@ -426,11 +453,16 @@ contains
                                              count_dims
     type(adios2_variable) :: var
     integer :: ierr
-    call adios2_define_variable(var, self%io, name, adios2_type_dp, &
-                                4, shape_dims, start_dims, &
-                                count_dims, adios2_constant_dims, ierr)
-    call self%handle_error(ierr, "Error defining ADIOS2 4D array &
-                                 & double precision real variable")
+
+    call adios2_inquire_variable(var, self%io, name, ierr)
+
+    if (ierr /= adios2_found) then
+      call adios2_define_variable(var, self%io, name, adios2_type_dp, &
+                                  4, shape_dims, start_dims, &
+                                  count_dims, adios2_constant_dims, ierr)
+      call self%handle_error(ierr, "Error defining ADIOS2 4D array &
+                                   & double precision real variable")
+    end if
 
     call adios2_put(file%engine, var, data, adios2_mode_deferred, ierr)
     call self%handle_error(ierr, "Error writing ADIOS2 4D array &

--- a/src/io/checkpoint_io.f90
+++ b/src/io/checkpoint_io.f90
@@ -343,7 +343,7 @@ contains
 
     call self%generate_vtk_xml( &
       strided_shape_dims, field_names, origin, strided_spacing &
-    )
+      )
 
     if (myrank == 0) then
       call self%adios2_writer%write_attribute("vtk.xml", self%vtk_xml, file)

--- a/src/io/checkpoint_io.f90
+++ b/src/io/checkpoint_io.f90
@@ -342,7 +342,7 @@ contains
     call self%adios2_writer%begin_step(file)
 
     call self%generate_vtk_xml( &
-      strided_shape_dims, field_names, origin, strided_spacing
+      strided_shape_dims, field_names, origin, strided_spacing &
     )
 
     if (myrank == 0) then

--- a/src/io/checkpoint_io.f90
+++ b/src/io/checkpoint_io.f90
@@ -321,16 +321,7 @@ contains
     global_dims = solver%mesh%get_global_dims(VERT)
     origin = solver%mesh%get_coordinates(1, 1, 1)
     coords_max = solver%mesh%geo%L
-
-    do i = 1, 3
-      if (global_dims(i) > 1) then
-        original_spacing(i) = (coords_max(i) - origin(i))/ &
-                              real(global_dims(i) - 1, dp)
-      else
-        original_spacing(i) = 1.0_dp
-      end if
-    end do
-
+    original_spacing = solver%mesh%geo%d
     strided_spacing = original_spacing*real(self%output_stride, dp)
 
     do i = 1, 3


### PR DESCRIPTION

Writing snaphots have been modified to output using [VTK XML data model](https://adios2.readthedocs.io/en/latest/ecosystem/visualization.html). The resulting .bp files can be opened in ParaView.

It currently uses the VTK image data XML descriptor. This output will only work for uniform grids and it uses the grid origin and spacing. The origin is the coordinates of vertex (1,1,1) (in `mesh_content.f90` origin is defined but it's never set).

Some other changes were made to ADIOS2:

1. removed all variables when writing a new dataset (previously the variables were removed when closing, but I think removing them during writing is the proper way to do it)
2. Added a subroutine to define attributes using 1d arrays
3. Fixed a bug in `checkpoint_io.f90` where `release_block` was used outside the loop which would have caused memory leaks

The image below shows the paraview visualisation, three snapshots (for differen simulation times)

<img width="1912" height="870" alt="paraview_tgv" src="https://github.com/user-attachments/assets/12dac5b6-c490-4523-8e24-3ead1c180190" />

Closes #175 