### PR TITLE
Single precision snapshot writing

### DIFF
--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -15,10 +15,11 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
      keep_checkpoint = .false.
      checkpoint_prefix = "checkpoint"
      snapshot_prefix = "snapshot"
+     snapshot_sp = .false.
      output_stride = 2, 2, 2
      restart_from_checkpoint = .false.
      restart_file = ""
-   /
+   /End
 
 ``checkpoint_freq``: Frequency (in timesteps) at which to save checkpoint files for simulation restart. Set to ``0`` to disable checkpointing.
   **Default:** ``0``
@@ -34,6 +35,9 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
 
 ``snapshot_prefix``: String prefix for visualisation snapshot filenames. Each snapshot will be named as ``<snapshot_prefix>_XXXXXX.bp``.
   **Default:** ``"snapshot"``
+
+``snapshot_sp``: Boolean flag to save visualisation snapshots in single precision (float) instead of double precision (double). This reduces file size but may lose some precision.
+**Default:** ``false`` (double precision)
 
 ``output_stride``: Three-element array specifying the spatial stride (subsampling) in ``X``, ``Y``, and ``Z`` directions for visualisation snapshots. Using values greater than ``1`` reduces file size and increases I/O performance, but decreases visualisation resolution.
   **Default:** ``[1, 1, 1]``

--- a/src/backend/cuda/poisson_fft.f90
+++ b/src/backend/cuda/poisson_fft.f90
@@ -144,11 +144,11 @@ contains
     ierr = cufftMpAttachComm(poisson_fft%plan3D_fw, CUFFT_COMM_MPI, &
                              MPI_COMM_WORLD)
     if (is_sp) then
-        ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_R2C, &
-                               worksize)
+      ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_R2C, &
+                             worksize)
     else
-        ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
-                               worksize)
+      ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
+                             worksize)
     end if
     if (ierr /= 0) then
       write (stderr, *), 'cuFFT Error Code: ', ierr
@@ -159,11 +159,11 @@ contains
     ierr = cufftMpAttachComm(poisson_fft%plan3D_bw, CUFFT_COMM_MPI, &
                              MPI_COMM_WORLD)
     if (is_sp) then
-        ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_C2R, &
-                               worksize)
+      ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_C2R, &
+                             worksize)
     else
-        ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
-                               worksize)
+      ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
+                             worksize)
     end if
     if (ierr /= 0) then
       write (stderr, *), 'cuFFT Error Code: ', ierr

--- a/src/backend/cuda/poisson_fft.f90
+++ b/src/backend/cuda/poisson_fft.f90
@@ -6,7 +6,7 @@ module m_cuda_poisson_fft
   use cufft
   use mpi
 
-  use m_common, only: dp, CELL
+  use m_common, only: dp, CELL, is_sp
   use m_field, only: field_t
   use m_mesh, only: mesh_t
   use m_poisson_fft, only: poisson_fft_t
@@ -143,13 +143,13 @@ contains
     ierr = cufftCreate(poisson_fft%plan3D_fw)
     ierr = cufftMpAttachComm(poisson_fft%plan3D_fw, CUFFT_COMM_MPI, &
                              MPI_COMM_WORLD)
-#ifdef SINGLE_PREC
-    ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_R2C, &
-                           worksize)
-#else
-    ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
-                           worksize)
-#endif
+    if (is_sp) then
+        ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_R2C, &
+                               worksize)
+    else
+        ierr = cufftMakePlan3D(poisson_fft%plan3D_fw, nz, ny, nx, CUFFT_D2Z, &
+                               worksize)
+    end if
     if (ierr /= 0) then
       write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Forward 3D FFT plan generation failed'
@@ -158,13 +158,13 @@ contains
     ierr = cufftCreate(poisson_fft%plan3D_bw)
     ierr = cufftMpAttachComm(poisson_fft%plan3D_bw, CUFFT_COMM_MPI, &
                              MPI_COMM_WORLD)
-#ifdef SINGLE_PREC
-    ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_C2R, &
-                           worksize)
-#else
-    ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
-                           worksize)
-#endif
+    if (is_sp) then
+        ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_C2R, &
+                               worksize)
+    else
+        ierr = cufftMakePlan3D(poisson_fft%plan3D_bw, nz, ny, nx, CUFFT_Z2D, &
+                               worksize)
+    end if
     if (ierr /= 0) then
       write (stderr, *), 'cuFFT Error Code: ', ierr
       error stop 'Backward 3D FFT plan generation failed'

--- a/src/common.f90
+++ b/src/common.f90
@@ -7,12 +7,15 @@ module m_common
   integer, parameter :: dp = kind(0.0e0)
   integer, parameter :: nbytes = 4
   integer, parameter :: MPI_X3D2_DP = MPI_REAL
+  logical, parameter :: is_sp = .true.
 #else
   integer, parameter :: dp = kind(0.0d0)
   integer, parameter :: nbytes = 8
   integer, parameter :: MPI_X3D2_DP = MPI_DOUBLE_PRECISION
+  logical, parameter :: is_sp = .false.
 #endif
 
+  integer, parameter :: sp = kind(0.0e0)
   integer, parameter :: i8 = selected_int_kind(18)
 
   real(dp), parameter :: pi = 4*atan(1.0_dp)

--- a/src/config.f90
+++ b/src/config.f90
@@ -55,6 +55,7 @@ module m_config
     logical :: restart_from_checkpoint = .false.
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [2, 2, 2]     !! Spatial stride for snapshot output
+    logical :: snapshot_sp = .false.                       !! if true, snapshot in single precision
   contains
     procedure :: read => read_checkpoint_nml
   end type checkpoint_config_t
@@ -232,11 +233,11 @@ contains
     logical :: restart_from_checkpoint = .false.
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [1, 1, 1]
+    logical :: snapshot_sp = .false.
 
     namelist /checkpoint_params/ checkpoint_freq, snapshot_freq, &
       keep_checkpoint, checkpoint_prefix, snapshot_prefix, &
-      restart_from_checkpoint, restart_file, output_stride
-
+      restart_from_checkpoint, restart_file, output_stride, snapshot_sp
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading checkpoint config failed! &
                  &Provide only a file name or source, not both.'
@@ -265,6 +266,7 @@ contains
     self%restart_from_checkpoint = restart_from_checkpoint
     self%restart_file = restart_file
     self%output_stride = output_stride
+    self%snapshot_sp = snapshot_sp
   end subroutine read_checkpoint_nml
 
 end module m_config

--- a/src/io/adios2/io.f90
+++ b/src/io/adios2/io.f90
@@ -445,7 +445,7 @@ contains
   end subroutine write_data_integer_adios2
 
   subroutine write_data_real_adios2(self, variable_name, value, file_handle, &
-                                     use_sp)
+                                    use_sp)
     class(io_adios2_writer_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: value

--- a/src/io/dummy/io.f90
+++ b/src/io/dummy/io.f90
@@ -236,17 +236,19 @@ contains
     ! silently ignore write operations
   end subroutine write_data_integer_dummy
 
-  subroutine write_data_real_dummy(self, variable_name, value, file_handle)
+  subroutine write_data_real_dummy(self, variable_name, value, file_handle, &
+                                    use_sp)
     class(io_dummy_writer_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: value
     class(io_file_t), intent(inout) :: file_handle
+    logical, intent(in), optional :: use_sp
     ! silently ignore write operations
   end subroutine write_data_real_dummy
 
   subroutine write_data_array_3d_dummy( &
     self, variable_name, array, file_handle, &
-    shape_dims, start_dims, count_dims &
+    shape_dims, start_dims, count_dims, use_sp &
     )
     class(io_dummy_writer_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
@@ -255,6 +257,7 @@ contains
     integer(i8), intent(in) :: shape_dims(3)
     integer(i8), intent(in) :: start_dims(3)
     integer(i8), intent(in) :: count_dims(3)
+    logical, intent(in), optional :: use_sp
     ! silently ignore write operations
   end subroutine write_data_array_3d_dummy
 

--- a/src/io/dummy/io.f90
+++ b/src/io/dummy/io.f90
@@ -237,7 +237,7 @@ contains
   end subroutine write_data_integer_dummy
 
   subroutine write_data_real_dummy(self, variable_name, value, file_handle, &
-                                    use_sp)
+                                   use_sp)
     class(io_dummy_writer_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: value

--- a/src/io/io_base.f90
+++ b/src/io/io_base.f90
@@ -223,18 +223,19 @@ contains
       & use concrete implementation"
   end subroutine write_data_integer
 
-  subroutine write_data_real(self, variable_name, value, file_handle)
+  subroutine write_data_real(self, variable_name, value, file_handle, use_sp)
     class(io_writer_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: value
     class(io_file_t), intent(inout) :: file_handle
+    logical, intent(in), optional :: use_sp
     error stop "write_data_real should not be called - &
       & use concrete implementation"
   end subroutine write_data_real
 
   subroutine write_data_array_3d( &
     self, variable_name, array, file_handle, &
-    shape_dims, start_dims, count_dims &
+    shape_dims, start_dims, count_dims, use_sp &
     )
     class(io_writer_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
@@ -243,6 +244,7 @@ contains
     integer(i8), intent(in) :: shape_dims(3)
     integer(i8), intent(in) :: start_dims(3)
     integer(i8), intent(in) :: count_dims(3)
+    logical, intent(in), optional :: use_sp
     error stop "write_data_array_3d should not be called - &
       & use concrete implementation"
   end subroutine write_data_array_3d

--- a/src/io/io_session.f90
+++ b/src/io/io_session.f90
@@ -242,17 +242,18 @@ contains
     call self%writer%write_data(variable_name, value, self%file)
   end subroutine write_data_integer
 
-  subroutine write_data_real(self, variable_name, value)
+  subroutine write_data_real(self, variable_name, value, use_sp)
     class(writer_session_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: value
+    logical, intent(in), optional :: use_sp
 
     if (.not. self%is_open) error stop "IO session not open"
-    call self%writer%write_data(variable_name, value, self%file)
+    call self%writer%write_data(variable_name, value, self%file, use_sp)
   end subroutine write_data_real
 
   subroutine write_data_array_3d( &
-    self, variable_name, array, shape_dims, start_dims, count_dims &
+    self, variable_name, array, shape_dims, start_dims, count_dims, use_sp &
     )
     class(writer_session_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
@@ -260,11 +261,12 @@ contains
     integer(i8), intent(in) :: shape_dims(3)
     integer(i8), intent(in) :: start_dims(3)
     integer(i8), intent(in) :: count_dims(3)
+    logical, intent(in), optional :: use_sp
 
     if (.not. self%is_open) error stop "IO session not open"
     call self%writer%write_data( &
       variable_name, array, self%file, &
-      shape_dims, start_dims, count_dims &
+      shape_dims, start_dims, count_dims, use_sp &
       )
   end subroutine write_data_array_3d
 

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -79,7 +79,7 @@ contains
       print *, 'Snapshot prefix: ', trim(self%config%snapshot_prefix)
       print *, 'Output stride: ', self%output_stride
       print *, 'Snapshot precision: ', merge('Single', 'Double', &
-        self%config%snapshot_sp)
+                                             self%config%snapshot_sp)
     end if
   end subroutine configure_output
 


### PR DESCRIPTION
This PR implements single-precision ADIOS2 functionality.

The user can now set snapshots to be written in single precision, which will halve the snapshot file sizes. For a simulation running with single precision the snapshots will be written in single precision, but for a simulation with double precision, the user can set `snapshot_sp = .true.` to write in single precision.

SINGLE_PREC runs would not have worked with the previous code as it was always writing with double precision (`adios_type_dp`) - modified it now to write with single precision (`adios_type_real`) if it's a single precision run.

Added `is_sp` parameter to avoid writing compilation directives in `poisson_fft.f90` 

Closes #212 