### PR TITLE
Change ep1 to be polymorphic to fix memcpy error

### DIFF
--- a/src/module/ibm.f90
+++ b/src/module/ibm.f90
@@ -29,7 +29,7 @@ module m_ibm
     class(mesh_t), pointer :: mesh => null()
     type(allocator_t), pointer :: host_allocator => null()
     integer :: iibm = 0
-    type(field_t), pointer :: ep1 => null()
+    class(field_t), pointer :: ep1 => null()
   contains
     procedure :: body
   end type ibm_t


### PR DESCRIPTION
Closes #218 

This PR fixes an illegal memory access error for IBM cases that occurs when a pointer to an extended data type is copied to device.

This is because pointer `ep1` is declared as `type(field_t)`. which prevents it from correctly handling objects of types that extend `field_t`. The `memcpy` operation consequently uses the wrong object size, leading to a buffer overrun.

This change modifies the declaration from `type(field_t)` to `class(field_t)`, making the pointer polymorphic. This allows it to correctly handle any object in the `field_t` inheritance hierarchy, ensuring that memory operations use the correct dynamic type and size.

### Summary of Changes

* Changed the declaration of the `ep1` pointer in `[filename.f90]` from `type(field_t)` to `class(field_t)`.

### Testing

* before fix, running in debug build gives: `0: copyin Memcpy (dev=0x72d55c000000, host=0x72d59bfffa70, size=134217728) FAILED: 700(an illegal memory access was encountered)`
* after fix code runs in debug build for IBM cases