### PR TITLE
Case statements switched to if/else for ordering.f90

### DIFF
--- a/src/ordering.f90
+++ b/src/ordering.f90
@@ -17,25 +17,42 @@ contains
     integer, intent(in) :: dir_i, dir_j, dir_k        ! application storage indices
     integer, intent(in) :: dir                        ! direction of the applicatino storage indices
     integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
+    !    select case (dir)
+!    case (DIR_X)
+!      i = dir_j
+!      j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
+!      k = 1 + (dir_k - 1)/(ny_padded/SZ)
+!    case (DIR_Y)
+!      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+!      j = dir_j
+!      k = 1 + (dir_k - 1)/(nx_padded/SZ)
+!    case (DIR_Z)
+!      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+!      j = 1 + (dir_k - 1)/(nx_padded/SZ)
+!      k = dir_j
+!    case (DIR_C)
+!      i = dir_i
+!      j = dir_j
+!      k = dir_k
+!    end select
+    if(dir == DIR_X) then
+        i = dir_j
+        j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
+        k = 1 + (dir_k - 1)/(ny_padded/SZ)
+    else if(dir == DIR_Y) then
+        i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+        j = dir_j
+        k = 1 + (dir_k - 1)/(nx_padded/SZ)
+    else if(dir== DIR_Z) then
+        i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+        j = 1 + (dir_k - 1)/(nx_padded/SZ)
+        k = dir_j
+    else 
+        i = dir_i
+        j = dir_j
+        k = dir_k
+    end if
 
-    select case (dir)
-    case (DIR_X)
-      i = dir_j
-      j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
-      k = 1 + (dir_k - 1)/(ny_padded/SZ)
-    case (DIR_Y)
-      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-      j = dir_j
-      k = 1 + (dir_k - 1)/(nx_padded/SZ)
-    case (DIR_Z)
-      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-      j = 1 + (dir_k - 1)/(nx_padded/SZ)
-      k = dir_j
-    case (DIR_C)
-      i = dir_i
-      j = dir_j
-      k = dir_k
-    end select
 
   end subroutine get_index_ijk
 
@@ -46,25 +63,43 @@ contains
     integer, intent(in) :: i, j, k                     ! cartesian indices
     integer, intent(in) :: dir                        ! direction of the application storage indices
     integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-
-    select case (dir)
-    case (DIR_X)
+!    select case (dir)
+!    case (DIR_X)
+!      dir_i = mod(j - 1, SZ) + 1
+!      dir_j = i
+!      dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
+!    case (DIR_Y)
+!      dir_i = mod(i - 1, SZ) + 1
+!      dir_j = j
+!      dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
+!    case (DIR_Z)
+!      dir_i = mod(i - 1, SZ) + 1
+!      dir_j = k
+!      dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
+!    case (DIR_C)
+!      dir_i = i
+!      dir_j = j
+!      dir_k = k
+!    end select
+    if(dir == DIR_X) then
       dir_i = mod(j - 1, SZ) + 1
       dir_j = i
       dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
-    case (DIR_Y)
+    else if(dir == DIR_Y) then
       dir_i = mod(i - 1, SZ) + 1
       dir_j = j
       dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
-    case (DIR_Z)
+    else if(dir== DIR_Z) then
       dir_i = mod(i - 1, SZ) + 1
       dir_j = k
       dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
-    case (DIR_C)
+    else 
       dir_i = i
       dir_j = j
       dir_k = k
-    end select
+    end if
+
+
 
   end subroutine get_index_dir
 

--- a/src/ordering.f90
+++ b/src/ordering.f90
@@ -1,8 +1,8 @@
 module m_ordering
 
-   use m_common, only: dp, get_dirs_from_rdr, DIR_X, DIR_Y, DIR_Z, DIR_C
+  use m_common, only: dp, get_dirs_from_rdr, DIR_X, DIR_Y, DIR_Z, DIR_C
 
-   implicit none
+  implicit none
 
 contains
    !!
@@ -10,76 +10,76 @@ contains
    !!  This set of functions converts indices from this application storage (_dir) to cartesian indices (_ijk)
    !!
 
-   pure subroutine get_index_ijk(i, j, k, dir_i, dir_j, dir_k, dir, &
-                                 SZ, nx_padded, ny_padded, nz_padded)
+  pure subroutine get_index_ijk(i, j, k, dir_i, dir_j, dir_k, dir, &
+                                SZ, nx_padded, ny_padded, nz_padded)
       !! Get cartesian index from application storage directional one
-      integer, intent(out) :: i, j, k                   ! cartesian indices
-      integer, intent(in) :: dir_i, dir_j, dir_k        ! application storage indices
-      integer, intent(in) :: dir                        ! direction of the applicatino storage indices
-      integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-      if (dir == DIR_X) then
-         i = dir_j
-         j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
-         k = 1 + (dir_k - 1)/(ny_padded/SZ)
-      else if (dir == DIR_Y) then
-         i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-         j = dir_j
-         k = 1 + (dir_k - 1)/(nx_padded/SZ)
-      else if (dir == DIR_Z) then
-         i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-         j = 1 + (dir_k - 1)/(nx_padded/SZ)
-         k = dir_j
-      else
-         i = dir_i
-         j = dir_j
-         k = dir_k
-      end if
+    integer, intent(out) :: i, j, k                   ! cartesian indices
+    integer, intent(in) :: dir_i, dir_j, dir_k        ! application storage indices
+    integer, intent(in) :: dir                        ! direction of the applicatino storage indices
+    integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
+    if (dir == DIR_X) then
+      i = dir_j
+      j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
+      k = 1 + (dir_k - 1)/(ny_padded/SZ)
+    else if (dir == DIR_Y) then
+      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+      j = dir_j
+      k = 1 + (dir_k - 1)/(nx_padded/SZ)
+    else if (dir == DIR_Z) then
+      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+      j = 1 + (dir_k - 1)/(nx_padded/SZ)
+      k = dir_j
+    else
+      i = dir_i
+      j = dir_j
+      k = dir_k
+    end if
 
-   end subroutine get_index_ijk
+  end subroutine get_index_ijk
 
-   pure subroutine get_index_dir(dir_i, dir_j, dir_k, i, j, k, dir, &
-                                 SZ, nx_padded, ny_padded, nz_padded)
+  pure subroutine get_index_dir(dir_i, dir_j, dir_k, i, j, k, dir, &
+                                SZ, nx_padded, ny_padded, nz_padded)
       !! Get application storage directional index from cartesian index
-      integer, intent(out) :: dir_i, dir_j, dir_k        ! application storage indices
-      integer, intent(in) :: i, j, k                     ! cartesian indices
-      integer, intent(in) :: dir                        ! direction of the application storage indices
-      integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-      if (dir == DIR_X) then
-         dir_i = mod(j - 1, SZ) + 1
-         dir_j = i
-         dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
-      else if (dir == DIR_Y) then
-         dir_i = mod(i - 1, SZ) + 1
-         dir_j = j
-         dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
-      else if (dir == DIR_Z) then
-         dir_i = mod(i - 1, SZ) + 1
-         dir_j = k
-         dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
-      else
-         dir_i = i
-         dir_j = j
-         dir_k = k
-      end if
+    integer, intent(out) :: dir_i, dir_j, dir_k        ! application storage indices
+    integer, intent(in) :: i, j, k                     ! cartesian indices
+    integer, intent(in) :: dir                        ! direction of the application storage indices
+    integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
+    if (dir == DIR_X) then
+      dir_i = mod(j - 1, SZ) + 1
+      dir_j = i
+      dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
+    else if (dir == DIR_Y) then
+      dir_i = mod(i - 1, SZ) + 1
+      dir_j = j
+      dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
+    else if (dir == DIR_Z) then
+      dir_i = mod(i - 1, SZ) + 1
+      dir_j = k
+      dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
+    else
+      dir_i = i
+      dir_j = j
+      dir_k = k
+    end if
 
-   end subroutine get_index_dir
+  end subroutine get_index_dir
 
-   pure subroutine get_index_reordering( &
-      out_i, out_j, out_k, in_i, in_j, in_k, dir_from, dir_to, sz, cart_padded &
-      )
+  pure subroutine get_index_reordering( &
+    out_i, out_j, out_k, in_i, in_j, in_k, dir_from, dir_to, sz, cart_padded &
+    )
     !! Converts indices in between any two DIR_?
-      integer, intent(out) :: out_i, out_j, out_k ! output indices
-      integer, intent(in) :: in_i, in_j, in_k ! input indices
-      integer, intent(in) :: dir_from, dir_to
-      integer, intent(in) :: sz
-      integer, intent(in) :: cart_padded(3) ! padded cartesian dimensions
-      integer :: i, j, k        ! Intermediary cartesian indices
+    integer, intent(out) :: out_i, out_j, out_k ! output indices
+    integer, intent(in) :: in_i, in_j, in_k ! input indices
+    integer, intent(in) :: dir_from, dir_to
+    integer, intent(in) :: sz
+    integer, intent(in) :: cart_padded(3) ! padded cartesian dimensions
+    integer :: i, j, k        ! Intermediary cartesian indices
 
-      call get_index_ijk(i, j, k, in_i, in_j, in_k, dir_from, sz, &
-                         cart_padded(1), cart_padded(2), cart_padded(3))
-      call get_index_dir(out_i, out_j, out_k, i, j, k, dir_to, sz, &
-                         cart_padded(1), cart_padded(2), cart_padded(3))
+    call get_index_ijk(i, j, k, in_i, in_j, in_k, dir_from, sz, &
+                       cart_padded(1), cart_padded(2), cart_padded(3))
+    call get_index_dir(out_i, out_j, out_k, i, j, k, dir_to, sz, &
+                       cart_padded(1), cart_padded(2), cart_padded(3))
 
-   end subroutine get_index_reordering
+  end subroutine get_index_reordering
 
 end module m_ordering

--- a/src/ordering.f90
+++ b/src/ordering.f90
@@ -17,24 +17,6 @@ contains
     integer, intent(in) :: dir_i, dir_j, dir_k        ! application storage indices
     integer, intent(in) :: dir                        ! direction of the applicatino storage indices
     integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-    !    select case (dir)
-!    case (DIR_X)
-!      i = dir_j
-!      j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
-!      k = 1 + (dir_k - 1)/(ny_padded/SZ)
-!    case (DIR_Y)
-!      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-!      j = dir_j
-!      k = 1 + (dir_k - 1)/(nx_padded/SZ)
-!    case (DIR_Z)
-!      i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-!      j = 1 + (dir_k - 1)/(nx_padded/SZ)
-!      k = dir_j
-!    case (DIR_C)
-!      i = dir_i
-!      j = dir_j
-!      k = dir_k
-!    end select
     if(dir == DIR_X) then
         i = dir_j
         j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
@@ -63,24 +45,6 @@ contains
     integer, intent(in) :: i, j, k                     ! cartesian indices
     integer, intent(in) :: dir                        ! direction of the application storage indices
     integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-!    select case (dir)
-!    case (DIR_X)
-!      dir_i = mod(j - 1, SZ) + 1
-!      dir_j = i
-!      dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
-!    case (DIR_Y)
-!      dir_i = mod(i - 1, SZ) + 1
-!      dir_j = j
-!      dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
-!    case (DIR_Z)
-!      dir_i = mod(i - 1, SZ) + 1
-!      dir_j = k
-!      dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
-!    case (DIR_C)
-!      dir_i = i
-!      dir_j = j
-!      dir_k = k
-!    end select
     if(dir == DIR_X) then
       dir_i = mod(j - 1, SZ) + 1
       dir_j = i

--- a/src/ordering.f90
+++ b/src/ordering.f90
@@ -1,8 +1,8 @@
 module m_ordering
 
-  use m_common, only: dp, get_dirs_from_rdr, DIR_X, DIR_Y, DIR_Z, DIR_C
+   use m_common, only: dp, get_dirs_from_rdr, DIR_X, DIR_Y, DIR_Z, DIR_C
 
-  implicit none
+   implicit none
 
 contains
    !!
@@ -10,79 +10,76 @@ contains
    !!  This set of functions converts indices from this application storage (_dir) to cartesian indices (_ijk)
    !!
 
-  pure subroutine get_index_ijk(i, j, k, dir_i, dir_j, dir_k, dir, &
-                                SZ, nx_padded, ny_padded, nz_padded)
+   pure subroutine get_index_ijk(i, j, k, dir_i, dir_j, dir_k, dir, &
+                                 SZ, nx_padded, ny_padded, nz_padded)
       !! Get cartesian index from application storage directional one
-    integer, intent(out) :: i, j, k                   ! cartesian indices
-    integer, intent(in) :: dir_i, dir_j, dir_k        ! application storage indices
-    integer, intent(in) :: dir                        ! direction of the applicatino storage indices
-    integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-    if(dir == DIR_X) then
-        i = dir_j
-        j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
-        k = 1 + (dir_k - 1)/(ny_padded/SZ)
-    else if(dir == DIR_Y) then
-        i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-        j = dir_j
-        k = 1 + (dir_k - 1)/(nx_padded/SZ)
-    else if(dir== DIR_Z) then
-        i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
-        j = 1 + (dir_k - 1)/(nx_padded/SZ)
-        k = dir_j
-    else 
-        i = dir_i
-        j = dir_j
-        k = dir_k
-    end if
+      integer, intent(out) :: i, j, k                   ! cartesian indices
+      integer, intent(in) :: dir_i, dir_j, dir_k        ! application storage indices
+      integer, intent(in) :: dir                        ! direction of the applicatino storage indices
+      integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
+      if (dir == DIR_X) then
+         i = dir_j
+         j = mod(dir_k - 1, ny_padded/SZ)*SZ + dir_i
+         k = 1 + (dir_k - 1)/(ny_padded/SZ)
+      else if (dir == DIR_Y) then
+         i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+         j = dir_j
+         k = 1 + (dir_k - 1)/(nx_padded/SZ)
+      else if (dir == DIR_Z) then
+         i = mod(dir_k - 1, nx_padded/SZ)*SZ + dir_i
+         j = 1 + (dir_k - 1)/(nx_padded/SZ)
+         k = dir_j
+      else
+         i = dir_i
+         j = dir_j
+         k = dir_k
+      end if
 
+   end subroutine get_index_ijk
 
-  end subroutine get_index_ijk
-
-  pure subroutine get_index_dir(dir_i, dir_j, dir_k, i, j, k, dir, &
-                                SZ, nx_padded, ny_padded, nz_padded)
+   pure subroutine get_index_dir(dir_i, dir_j, dir_k, i, j, k, dir, &
+                                 SZ, nx_padded, ny_padded, nz_padded)
       !! Get application storage directional index from cartesian index
-    integer, intent(out) :: dir_i, dir_j, dir_k        ! application storage indices
-    integer, intent(in) :: i, j, k                     ! cartesian indices
-    integer, intent(in) :: dir                        ! direction of the application storage indices
-    integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
-    if(dir == DIR_X) then
-      dir_i = mod(j - 1, SZ) + 1
-      dir_j = i
-      dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
-    else if(dir == DIR_Y) then
-      dir_i = mod(i - 1, SZ) + 1
-      dir_j = j
-      dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
-    else if(dir== DIR_Z) then
-      dir_i = mod(i - 1, SZ) + 1
-      dir_j = k
-      dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
-    else 
-      dir_i = i
-      dir_j = j
-      dir_k = k
-    end if
+      integer, intent(out) :: dir_i, dir_j, dir_k        ! application storage indices
+      integer, intent(in) :: i, j, k                     ! cartesian indices
+      integer, intent(in) :: dir                        ! direction of the application storage indices
+      integer, intent(in) :: SZ, nx_padded, ny_padded, nz_padded ! dimensions of the block
+      if (dir == DIR_X) then
+         dir_i = mod(j - 1, SZ) + 1
+         dir_j = i
+         dir_k = (ny_padded/SZ)*(k - 1) + 1 + (j - 1)/SZ
+      else if (dir == DIR_Y) then
+         dir_i = mod(i - 1, SZ) + 1
+         dir_j = j
+         dir_k = (nx_padded/SZ)*(k - 1) + 1 + (i - 1)/SZ
+      else if (dir == DIR_Z) then
+         dir_i = mod(i - 1, SZ) + 1
+         dir_j = k
+         dir_k = (nx_padded/SZ)*(j - 1) + 1 + (i - 1)/SZ
+      else
+         dir_i = i
+         dir_j = j
+         dir_k = k
+      end if
 
+   end subroutine get_index_dir
 
-
-  end subroutine get_index_dir
-
-  pure subroutine get_index_reordering( &
-    out_i, out_j, out_k, in_i, in_j, in_k, dir_from, dir_to, sz, cart_padded &
-    )
+   pure subroutine get_index_reordering( &
+      out_i, out_j, out_k, in_i, in_j, in_k, dir_from, dir_to, sz, cart_padded &
+      )
     !! Converts indices in between any two DIR_?
-    integer, intent(out) :: out_i, out_j, out_k ! output indices
-    integer, intent(in) :: in_i, in_j, in_k ! input indices
-    integer, intent(in) :: dir_from, dir_to
-    integer, intent(in) :: sz
-    integer, intent(in) :: cart_padded(3) ! padded cartesian dimensions
-    integer :: i, j, k        ! Intermediary cartesian indices
+      integer, intent(out) :: out_i, out_j, out_k ! output indices
+      integer, intent(in) :: in_i, in_j, in_k ! input indices
+      integer, intent(in) :: dir_from, dir_to
+      integer, intent(in) :: sz
+      integer, intent(in) :: cart_padded(3) ! padded cartesian dimensions
+      integer :: i, j, k        ! Intermediary cartesian indices
 
-    call get_index_ijk(i, j, k, in_i, in_j, in_k, dir_from, sz, &
-                       cart_padded(1), cart_padded(2), cart_padded(3))
-    call get_index_dir(out_i, out_j, out_k, i, j, k, dir_to, sz, &
-                       cart_padded(1), cart_padded(2), cart_padded(3))
+      call get_index_ijk(i, j, k, in_i, in_j, in_k, dir_from, sz, &
+                         cart_padded(1), cart_padded(2), cart_padded(3))
+      call get_index_dir(out_i, out_j, out_k, i, j, k, dir_to, sz, &
+                         cart_padded(1), cart_padded(2), cart_padded(3))
 
-  end subroutine get_index_reordering
+   end subroutine get_index_reordering
 
 end module m_ordering


### PR DESCRIPTION
During the TGV case run I tested for 1000 iterations and AMD uProfiler output showed 10 hottest functions and it turns out to be the `reorder_omp` is the second highest time consuming function which repeatedly calls the module `m_ordering`. Before diving deep with algorithmic optimisations I wanted to try something with slight modifications. I noticed that it uses `select case` for decisions instead of `if else`. This is not ideal for the compiler. So I modified them to be if/else statement. 

Disclaimer would be this change is not necessary for other modules because they are not the first or second hottest functions. 

The 1000 TGV run
----------------------

Before:
```
 solver instantiated
 initial conditions
 time =   0.0000000000000000      iteration =           0
 enstrophy:  0.37500056314210506     
 div u max mean:   7.4241182236900240E-014   4.6425442329974923E-015
 start run
 time =  0.10000000000000001      iteration =         100
 enstrophy:  0.37525051849886970     
 div u max mean:   1.2185232149686254E-007   3.5138289281208653E-009
 time =  0.20000000000000001      iteration =         200
 enstrophy:  0.37628353027785910     
 div u max mean:   1.2342342865789835E-007   3.5031468385433071E-009
 time =  0.29999999999999999      iteration =         300
 enstrophy:  0.37810777470606399     
 div u max mean:   1.2608932925539662E-007   3.4874846289820097E-009
 time =  0.40000000000000002      iteration =         400
 enstrophy:  0.38073816178863462     
 div u max mean:   1.2987100272976448E-007   3.4683619522790331E-009
 time =  0.50000000000000000      iteration =         500
 enstrophy:  0.38419607045527204     
 div u max mean:   1.3479555077688943E-007   3.4475698888332965E-009
 time =  0.59999999999999998      iteration =         600
 enstrophy:  0.38850900827352475     
 div u max mean:   1.4089259348093464E-007   3.4270327631455799E-009
 time =  0.70000000000000007      iteration =         700
 enstrophy:  0.39371024738962596     
 div u max mean:   1.4818927601689680E-007   3.4086645130049231E-009
 time =  0.80000000000000004      iteration =         800
 enstrophy:  0.39983846518902949     
 div u max mean:   1.5670384551080829E-007   3.3943682946129801E-009
 time =  0.90000000000000002      iteration =         900
 enstrophy:  0.40693741438884812     
 div u max mean:   1.6643768474544629E-007   3.3860065608543613E-009
 time =   1.0000000000000000      iteration =        1000
 enstrophy:  0.41505564012994600     
 div u max mean:   1.7736599844386802E-007   3.3851674985669417E-009
 run end
 Time:    575.58670499999994 
 ```
 After:
 ```
 solver instantiated
 initial conditions
 time =   0.0000000000000000      iteration =           0
 enstrophy:  0.37500056314210506     
 div u max mean:   7.4241182236900240E-014   4.6425442329974923E-015
 start run
 time =  0.10000000000000001      iteration =         100
 enstrophy:  0.37525051849886970     
 div u max mean:   1.2185232149686254E-007   3.5138289281208653E-009
 time =  0.20000000000000001      iteration =         200
 enstrophy:  0.37628353027785910     
 div u max mean:   1.2342342865789835E-007   3.5031468385433071E-009
 time =  0.29999999999999999      iteration =         300
 enstrophy:  0.37810777470606399     
 div u max mean:   1.2608932925539662E-007   3.4874846289820097E-009
 time =  0.40000000000000002      iteration =         400
 enstrophy:  0.38073816178863462     
 div u max mean:   1.2987100272976448E-007   3.4683619522790331E-009
 time =  0.50000000000000000      iteration =         500
 enstrophy:  0.38419607045527204     
 div u max mean:   1.3479555077688943E-007   3.4475698888332965E-009
 time =  0.59999999999999998      iteration =         600
 enstrophy:  0.38850900827352475     
 div u max mean:   1.4089259348093464E-007   3.4270327631455799E-009
 time =  0.70000000000000007      iteration =         700
 enstrophy:  0.39371024738962596     
 div u max mean:   1.4818927601689680E-007   3.4086645130049231E-009
 time =  0.80000000000000004      iteration =         800
 enstrophy:  0.39983846518902949     
 div u max mean:   1.5670384551080829E-007   3.3943682946129801E-009
 time =  0.90000000000000002      iteration =         900
 enstrophy:  0.40693741438884812     
 div u max mean:   1.6643768474544629E-007   3.3860065608543613E-009
 time =   1.0000000000000000      iteration =        1000
 enstrophy:  0.41505564012994600     
 div u max mean:   1.7736599844386802E-007   3.3851674985669417E-009
 run end
 Time:    564.87784799999997 
 ```
 
 Overall, for 20000 case I would expect at least ~3 minute improvement with execution time which is not massive but good small step forward
 ```
 Compiled with GNU 13.3.0 and OpenMPI 5.0.5, Using 24 MPI Rank and OMP_NUM_THREADS 1 with AMD EPYC 7443 CPU  which is full socket run
 ``` 