### PR TITLE
Pass global dimensions to ADIOS2 write routines

### DIFF
--- a/src/io/adios2/io.f90
+++ b/src/io/adios2/io.f90
@@ -468,40 +468,21 @@ contains
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: array(:, :, :)
     class(io_file_t), intent(inout) :: file_handle
-    integer(i8), intent(in), optional :: shape_dims(3)
-    integer(i8), intent(in), optional :: start_dims(3)
-    integer(i8), intent(in), optional :: count_dims(3)
+    integer(i8), intent(in) :: shape_dims(3)
+    integer(i8), intent(in) :: start_dims(3)
+    integer(i8), intent(in) :: count_dims(3)
 
     type(adios2_variable) :: var
     integer :: ierr
-    integer(i8) :: local_shape(3), local_start(3), local_count(3)
 
     select type (file_handle)
     type is (io_adios2_file_t)
-      if (present(shape_dims)) then
-        local_shape = shape_dims
-      else
-        local_shape = int(shape(array), i8)
-      end if
-
-      if (present(start_dims)) then
-        local_start = start_dims
-      else
-        local_start = 0_i8
-      end if
-
-      if (present(count_dims)) then
-        local_count = count_dims
-      else
-        local_count = int(shape(array), i8)
-      end if
-
       call adios2_inquire_variable(var, self%io_handle, variable_name, ierr)
 
       if (ierr /= adios2_found) then
         call adios2_define_variable(var, self%io_handle, variable_name, &
-                                    adios2_type_dp, 3, local_shape, &
-                                    local_start, local_count, &
+                                    adios2_type_dp, 3, shape_dims, &
+                                    start_dims, count_dims, &
                                     adios2_constant_dims, ierr)
         call self%handle_error(ierr, "Error defining ADIOS2 3D array &
                                      & double precision real variable")

--- a/src/io/checkpoint_manager.f90
+++ b/src/io/checkpoint_manager.f90
@@ -323,7 +323,8 @@ contains
       call writer_session%write_data( &
         trim(field_names(i_field)), &
         self%field_buffers(i_field)%buffer, &
-        start_dims=output_start, count_dims=output_count &
+        self%last_output_shape, &
+        output_start, output_count &
         )
     end do
   end subroutine write_fields

--- a/src/io/dummy/io.f90
+++ b/src/io/dummy/io.f90
@@ -252,9 +252,9 @@ contains
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: array(:, :, :)
     class(io_file_t), intent(inout) :: file_handle
-    integer(i8), intent(in), optional :: shape_dims(3)
-    integer(i8), intent(in), optional :: start_dims(3)
-    integer(i8), intent(in), optional :: count_dims(3)
+    integer(i8), intent(in) :: shape_dims(3)
+    integer(i8), intent(in) :: start_dims(3)
+    integer(i8), intent(in) :: count_dims(3)
     ! silently ignore write operations
   end subroutine write_data_array_3d_dummy
 

--- a/src/io/io_base.f90
+++ b/src/io/io_base.f90
@@ -240,9 +240,9 @@ contains
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: array(:, :, :)
     class(io_file_t), intent(inout) :: file_handle
-    integer(i8), intent(in), optional :: shape_dims(3)
-    integer(i8), intent(in), optional :: start_dims(3)
-    integer(i8), intent(in), optional :: count_dims(3)
+    integer(i8), intent(in) :: shape_dims(3)
+    integer(i8), intent(in) :: start_dims(3)
+    integer(i8), intent(in) :: count_dims(3)
     error stop "write_data_array_3d should not be called - &
       & use concrete implementation"
   end subroutine write_data_array_3d

--- a/src/io/io_session.f90
+++ b/src/io/io_session.f90
@@ -250,19 +250,19 @@ contains
   end subroutine write_data_real
 
   subroutine write_data_array_3d( &
-    self, variable_name, array, start_dims, count_dims, shape_dims &
+    self, variable_name, array, shape_dims, start_dims, count_dims &
     )
     class(writer_session_t), intent(inout) :: self
     character(len=*), intent(in) :: variable_name
     real(dp), intent(in) :: array(:, :, :)
-    integer(i8), intent(in), optional :: start_dims(3)
-    integer(i8), intent(in), optional :: count_dims(3)
-    integer(i8), intent(in), optional :: shape_dims(3)
+    integer(i8), intent(in) :: shape_dims(3)
+    integer(i8), intent(in) :: start_dims(3)
+    integer(i8), intent(in) :: count_dims(3)
 
     if (.not. self%is_open) error stop "IO session not open"
     call self%writer%write_data( &
       variable_name, array, self%file, &
-      start_dims=start_dims, count_dims=count_dims, shape_dims=shape_dims &
+      shape_dims, start_dims, count_dims &
       )
   end subroutine write_data_array_3d
 

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -254,7 +254,8 @@ contains
       call writer_session%write_data( &
         trim(field_names(i_field)), &
         self%field_buffers(i_field)%buffer, &
-        start_dims=output_start, count_dims=output_count &
+        self%last_output_shape, &
+        output_start, output_count &
         )
     end do
   end subroutine write_fields

--- a/tests/test_io_session.f90
+++ b/tests/test_io_session.f90
@@ -46,8 +46,8 @@ program test_io_session
     call writer%write_data("timestep", timestep_write)
     call writer%write_data("time", time_write)
   end if
-  call writer%write_data("velocity_u", write_data, local_start, &
-    local_count, global_dims)
+  call writer%write_data("velocity_u", write_data, global_dims, &
+    local_start, local_count)
   call writer%close()
   
   call MPI_Barrier(MPI_COMM_WORLD, ierr)


### PR DESCRIPTION
The bug was that the global dimensions were not passed in snapshots and checkpoints, and the adios2 routines were then using the local dimensions. 

Now the arguments to the adios2 write routines are required and passing the global shape.

Fixes #245 