### PR TITLE
Add optional pressure field output to snapshots (ADIOS2)

### DIFF
--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -17,6 +17,7 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
      snapshot_prefix = "snapshot"
      snapshot_sp = .false.
      output_stride = 2, 2, 2
+     output_pressure = .false.
      restart_from_checkpoint = .false.
      restart_file = ""
    /End
@@ -41,6 +42,9 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
 
 ``output_stride``: Three-element array specifying the spatial stride (subsampling) in ``X``, ``Y``, and ``Z`` directions for visualisation snapshots. Using values greater than ``1`` reduces file size and increases I/O performance, but decreases visualisation resolution.
   **Default:** ``[1, 1, 1]``
+
+``output_pressure``: Boolean flag to include the pressure field in visualisation snapshots. When enabled, the pressure field is interpolated from its native cell-centred grid to the vertex grid (matching the velocity field locations) for ParaView compatibility. Note: pressure is not included in checkpoint files since it is a derived quantity recomputed from velocity.
+  **Default:** ``false``
 
 ``restart_from_checkpoint``: Boolean flag to restart the simulation from a checkpoint file.
   **Default:** ``false``

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -16,7 +16,7 @@ module m_base_case
 
   type, abstract :: base_case_t
     class(solver_t), allocatable :: solver
-    type(io_manager_t) :: checkpoint_mgr
+    type(io_manager_t) :: io_mgr
   contains
     procedure(boundary_conditions), deferred :: boundary_conditions
     procedure(initial_conditions), deferred :: initial_conditions
@@ -94,9 +94,9 @@ contains
 
     self%solver = init(backend, mesh, host_allocator)
 
-    call self%checkpoint_mgr%init(MPI_COMM_WORLD)
-    if (self%checkpoint_mgr%is_restart()) then
-      call self%checkpoint_mgr%handle_restart(self%solver, MPI_COMM_WORLD)
+    call self%io_mgr%init(MPI_COMM_WORLD)
+    if (self%io_mgr%is_restart()) then
+      call self%io_mgr%handle_restart(self%solver, MPI_COMM_WORLD)
     else
       call self%initial_conditions()
     end if
@@ -108,7 +108,7 @@ contains
 
     if (self%solver%mesh%par%is_root()) print *, 'run end'
 
-    call self%checkpoint_mgr%finalise()
+    call self%io_mgr%finalise()
   end subroutine case_finalise
 
   subroutine set_init(self, field, field_func)
@@ -214,7 +214,7 @@ contains
     real(dp) :: t
     integer :: i, iter, sub_iter, start_iter
 
-    if (self%checkpoint_mgr%is_restart()) then
+    if (self%io_mgr%is_restart()) then
       t = self%solver%current_iter*self%solver%dt
       if (self%solver%mesh%par%is_root()) &
         ! for restarts current_iter is read from the checkpoint file
@@ -280,7 +280,15 @@ contains
         call self%postprocess(iter, t)
       end if
 
-      call self%checkpoint_mgr%handle_io_step(self%solver, &
+      ! Compute pressure on VERT grid for snapshot output if needed
+      if (self%io_mgr%snapshot_mgr%config%output_pressure .and. &
+          self%io_mgr%snapshot_mgr%config%snapshot_freq > 0 .and. &
+          mod(iter, self%io_mgr%snapshot_mgr%config%snapshot_freq) &
+          == 0) then
+        call self%solver%compute_pressure_vert()
+      end if
+
+      call self%io_mgr%handle_io_step(self%solver, &
                                               iter, MPI_COMM_WORLD)
     end do
 

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -95,6 +95,10 @@ contains
     self%solver = init(backend, mesh, host_allocator)
 
     call self%io_mgr%init(MPI_COMM_WORLD)
+
+    ! Tell the solver to persist pressure if output is enabled
+    self%solver%keep_pressure = self%io_mgr%snapshot_mgr%config%output_pressure
+
     if (self%io_mgr%is_restart()) then
       call self%io_mgr%handle_restart(self%solver, MPI_COMM_WORLD)
     else

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -293,7 +293,7 @@ contains
       end if
 
       call self%io_mgr%handle_io_step(self%solver, &
-                                              iter, MPI_COMM_WORLD)
+                                      iter, MPI_COMM_WORLD)
     end do
 
     call self%case_finalise

--- a/src/config.f90
+++ b/src/config.f90
@@ -62,6 +62,7 @@ module m_config
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [2, 2, 2]     !! Spatial stride for snapshot output
     logical :: snapshot_sp = .false.                       !! if true, snapshot in single precision
+    logical :: output_pressure = .false.                   !! if true, include pressure in snapshots
   contains
     procedure :: read => read_checkpoint_nml
   end type checkpoint_config_t
@@ -271,10 +272,12 @@ contains
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [1, 1, 1]
     logical :: snapshot_sp = .false.
+    logical :: output_pressure = .false.
 
     namelist /checkpoint_params/ checkpoint_freq, snapshot_freq, &
       keep_checkpoint, checkpoint_prefix, snapshot_prefix, &
-      restart_from_checkpoint, restart_file, output_stride, snapshot_sp
+      restart_from_checkpoint, restart_file, output_stride, snapshot_sp, &
+      output_pressure
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading checkpoint config failed! &
                  &Provide only a file name or source, not both.'
@@ -304,6 +307,7 @@ contains
     self%restart_file = restart_file
     self%output_stride = output_stride
     self%snapshot_sp = snapshot_sp
+    self%output_pressure = output_pressure
   end subroutine read_checkpoint_nml
 
 end module m_config

--- a/src/io/io_field_utils.f90
+++ b/src/io/io_field_utils.f90
@@ -285,6 +285,15 @@ contains
         field_ptrs(i)%ptr => solver%v
       case ("w")
         field_ptrs(i)%ptr => solver%w
+      case ("p")
+        if (.not. associated(solver%pressure_vert)) then
+          if (solver%mesh%par%is_root()) then
+            print *, 'ERROR: pressure_vert not computed. &
+                     &Call compute_pressure_vert before writing snapshots.'
+          end if
+          error stop 1
+        end if
+        field_ptrs(i)%ptr => solver%pressure_vert
       case default
         if (solver%mesh%par%is_root()) then
           print *, 'ERROR: Unknown field name: ', trim(field_names(i))

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -75,6 +75,7 @@ module m_solver
     procedure :: transeq_species
     procedure :: pressure_correction
     procedure :: compute_pressure_vert
+    procedure :: rescale_pressure
     procedure :: divergence_v2p
     procedure :: gradient_p2v
     procedure :: curl
@@ -758,6 +759,22 @@ contains
       self%zdirps%interpl_p2v &
       )
 
+    call self%rescale_pressure(self%pressure_vert)
+
   end subroutine compute_pressure_vert
+
+  subroutine rescale_pressure(self, pressure)
+    !! Rescale pseudo-pressure to physical (kinematic) pressure.
+    !!
+    !! The Poisson solve returns \(p'\) where \(u^{n+1} = u* - \nabla{p'}\),
+    !! so \(p' = \frac{\Delta t}{\rho}p\). Divide by dt to recover p/rho.
+    implicit none
+
+    class(solver_t) :: self
+    class(field_t), intent(inout) :: pressure
+
+    call self%backend%vecadd(1._dp/self%dt, pressure, 0._dp, pressure)
+
+  end subroutine rescale_pressure
 
 end module m_solver


### PR DESCRIPTION
This PR adds optional pressure output to snapshots. When enabled, pressure is retained after pressure correction, interpolated from cell-centred grid to vertex grid, rescaled to physical (kinematic) pressure, and written as `p` alongside velocity field `u, v, w`.  Closes #222 

Pressure is excluded from checkpoint files because it's a derived quantity that's recomputed from velocity (it's not required for restarts).

Changes:
- added `output_pressure` (default `.false.`) to `checkpoint_config_t` and namelist parsing
- documented `output_pressure` in user docs
- updated `pressure_correction` subroutine to retain pressure when `keep_pressure=.true.`
- added `compute_pressure_vert()` to convert pseudo-pressure to kinematic pressure via division by `dt`
- Added `interpl_c2v()` in `vector_calculus_t` (general scalar interpolation from `CELL (DIR_Z)` to `VERT (DIR_X)`
- Renamed `checkpoint_mgr` to `io_mgr` in `base_case`
- In snapshot manager build the field list dynamically 

Note that when pressure output is enabled, extra memory is used to store `pressure (CELL, DIR_Z)` and `pressure_vert (VERT, DIR_X)`. If `output_pressure` is not set (or `.false.`) then we get the current behaviour.

Tested on TGV case (see output below)
<img width="1098" height="561" alt="pressure_output" src="https://github.com/user-attachments/assets/5fdd8bee-cff6-453d-80c2-3de25b7485fd" />
