### PR TITLE
Add statistics and output post-processed fields

### DIFF
--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -18,6 +18,8 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
      snapshot_sp = .false.
      output_stride = 2, 2, 2
      output_pressure = .false.
+     output_vorticity = .false.
+     output_qcriterion = .false.
      restart_from_checkpoint = .false.
      restart_file = ""
    /End
@@ -46,6 +48,12 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
 ``output_pressure``: Boolean flag to include the pressure field in visualisation snapshots. When enabled, the pressure field is interpolated from its native cell-centred grid to the vertex grid (matching the velocity field locations) for ParaView compatibility. Note: pressure is not included in checkpoint files since it is a derived quantity recomputed from velocity.
   **Default:** ``false``
 
+``output_vorticity``: Boolean flag to include the vorticity magnitude field (``vort``) in visualisation snapshots. The vorticity magnitude is computed as :math:`|\omega| = \sqrt{\omega_x^2 + \omega_y^2 + \omega_z^2}` from the full velocity gradient tensor. When both ``output_vorticity`` and ``output_qcriterion`` are enabled, the velocity gradient is computed only once.
+  **Default:** ``false``
+
+``output_qcriterion``: Boolean flag to include the Q-criterion field (``qcrit``) in visualisation snapshots. The Q-criterion is defined as :math:`Q = -\frac{1}{2} \sum_{ij} \frac{\partial u_i}{\partial x_j} \frac{\partial u_j}{\partial x_i}`, which identifies vortical structures (positive Q indicates rotation-dominated regions).
+  **Default:** ``false``
+
 ``restart_from_checkpoint``: Boolean flag to restart the simulation from a checkpoint file.
   **Default:** ``false``
 
@@ -64,3 +72,53 @@ The checkpoint system uses ADIOS2 BP format for I/O which provides:
 - Visualisation files can use strided (lower resolution) output for performance
 
 To view snapshot files in ParaView, open the generated ``.bp`` files using the ADIOS2 reader plugin.
+
+Statistics Parameters
+~~~~~~~~~~~~~~~~~~~~~
+
+The statistics parameters control the accumulation and output of time-averaged flow statistics.
+These parameters are specified in the ``stats_params`` namelist block in the input file.
+
+.. code-block:: fortran
+
+   &stats_params
+     initstat = 0
+     istatfreq = 1
+     istatout = 0
+     stats_prefix = "statistics"
+   /
+
+``initstat``: Timestep at which to begin accumulating statistics. Statistics are not collected before this iteration. Set to ``0`` to disable statistics entirely.
+  **Default:** ``0``
+
+``istatfreq``: Frequency (in timesteps) at which statistics are accumulated. A value of ``1`` means statistics are accumulated every timestep; a value of ``N`` means every N-th timestep.
+  **Default:** ``1``
+
+``istatout``: Frequency (in timesteps) at which accumulated statistics are written to file. Set to ``0`` to disable output.
+  **Default:** ``0``
+
+``stats_prefix``: String prefix for statistics output filenames.
+  **Default:** ``"statistics"``
+
+Output Fields
+^^^^^^^^^^^^^
+
+Statistics are written to separate ADIOS2 ``.bp`` files (e.g. ``statistics_001000.bp``), independent of the snapshot system. The output contains:
+
+**Velocity statistics** (always present):
+
+- ``umean``, ``vmean``, ``wmean`` — time-averaged velocity components
+- ``uprime``, ``vprime``, ``wprime`` — RMS velocity fluctuations: :math:`u' = \sqrt{\max(0,\, \overline{u^2} - \bar{u}^2)}`
+- ``uvmean``, ``uwmean``, ``vwmean`` — Reynolds stresses: :math:`\langle u'v' \rangle = \overline{uv} - \bar{u}\bar{v}`
+- ``sample_count`` — number of samples accumulated
+
+**Pressure statistics** (when ``output_pressure = .true.`` in ``checkpoint_params``):
+
+- ``pmean`` — time-averaged pressure field
+
+**Scalar statistics** (when ``n_species > 0`` in ``solver_params``):
+
+- ``phimean_N`` — time-averaged scalar field for species N
+- ``phiprime_N`` — RMS scalar fluctuation for species N
+
+Accumulation uses Welford's numerically stable online algorithm. Statistics always restart from scratch — they are not saved in checkpoint files.

--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -17,9 +17,7 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
      snapshot_prefix = "snapshot"
      snapshot_sp = .false.
      output_stride = 2, 2, 2
-     output_pressure = .false.
-     output_vorticity = .false.
-     output_qcriterion = .false.
+     output_fields = 'pressure', 'vorticity', 'qcriterion'
      restart_from_checkpoint = .false.
      restart_file = ""
    /End
@@ -45,14 +43,14 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
 ``output_stride``: Three-element array specifying the spatial stride (subsampling) in ``X``, ``Y``, and ``Z`` directions for visualisation snapshots. Using values greater than ``1`` reduces file size and increases I/O performance, but decreases visualisation resolution.
   **Default:** ``[1, 1, 1]``
 
-``output_pressure``: Boolean flag to include the pressure field in visualisation snapshots. When enabled, the pressure field is interpolated from its native cell-centred grid to the vertex grid (matching the velocity field locations) for ParaView compatibility. Note: pressure is not included in checkpoint files since it is a derived quantity recomputed from velocity.
-  **Default:** ``false``
+``output_fields``: List of additional derived fields to include in visualisation snapshots. Velocity components (``u``, ``v``, ``w``) are always written. Supported field names:
 
-``output_vorticity``: Boolean flag to include the vorticity magnitude field (``vort``) in visualisation snapshots. The vorticity magnitude is computed as :math:`|\omega| = \sqrt{\omega_x^2 + \omega_y^2 + \omega_z^2}` from the full velocity gradient tensor. When both ``output_vorticity`` and ``output_qcriterion`` are enabled, the velocity gradient is computed only once.
-  **Default:** ``false``
+  - ``'pressure'`` — Pressure field, interpolated from its native cell-centred grid to the vertex grid for ParaView compatibility. Not included in checkpoint files since it is recomputed from velocity.
+  - ``'vorticity'`` — Vorticity magnitude :math:`|\omega| = \sqrt{\omega_x^2 + \omega_y^2 + \omega_z^2}`, computed from the full velocity gradient tensor.
+  - ``'qcriterion'`` — Q-criterion :math:`Q = -\frac{1}{2} \sum_{ij} \frac{\partial u_i}{\partial x_j} \frac{\partial u_j}{\partial x_i}`, identifying vortical structures (positive Q indicates rotation-dominated regions).
 
-``output_qcriterion``: Boolean flag to include the Q-criterion field (``qcrit``) in visualisation snapshots. The Q-criterion is defined as :math:`Q = -\frac{1}{2} \sum_{ij} \frac{\partial u_i}{\partial x_j} \frac{\partial u_j}{\partial x_i}`, which identifies vortical structures (positive Q indicates rotation-dominated regions).
-  **Default:** ``false``
+  When both ``'vorticity'`` and ``'qcriterion'`` are requested, the velocity gradient tensor is computed only once.
+  **Default:** (empty — only velocity is written)
 
 ``restart_from_checkpoint``: Boolean flag to restart the simulation from a checkpoint file.
   **Default:** ``false``
@@ -112,7 +110,7 @@ Statistics are written to separate ADIOS2 ``.bp`` files (e.g. ``statistics_00100
 - ``uvmean``, ``uwmean``, ``vwmean`` — Reynolds stresses: :math:`\langle u'v' \rangle = \overline{uv} - \bar{u}\bar{v}`
 - ``sample_count`` — number of samples accumulated
 
-**Pressure statistics** (when ``output_pressure = .true.`` in ``checkpoint_params``):
+**Pressure statistics** (when ``'pressure'`` is in ``output_fields`` in ``checkpoint_params``):
 
 - ``pmean`` — time-averaged pressure field
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC
   ordering.f90
   poisson_fft.f90
   solver.f90
+  postprocess.f90
   tdsops.f90
   time_integrator.f90
   ordering.f90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ set(IOSRC
   io/io_field_utils.f90
   io/checkpoint_manager.f90
   io/snapshot_manager.f90
+  io/stats.f90
   io/io_manager.f90
 )
 

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -97,7 +97,9 @@ contains
     call self%io_mgr%init(self%solver, MPI_COMM_WORLD)
 
     ! Tell the solver to persist pressure if output is enabled
-    self%solver%keep_pressure = self%io_mgr%snapshot_mgr%config%output_pressure
+    self%solver%keep_pressure = &
+      self%io_mgr%snapshot_mgr%config%output_pressure .and. &
+      self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
 
     if (self%io_mgr%is_restart()) then
       call self%io_mgr%handle_restart(self%solver, MPI_COMM_WORLD)
@@ -278,20 +280,17 @@ contains
 
       self%solver%current_iter = iter
 
+      ! Compute pressure on VERT grid if output_pressure is enabled
+      if (self%solver%keep_pressure) then
+        call self%solver%compute_pressure_vert()
+      end if
+
       call self%io_mgr%update_stats(self%solver, iter)
 
       if (mod(iter, self%solver%n_output) == 0) then
         t = iter*self%solver%dt
 
         call self%postprocess(iter, t)
-      end if
-
-      ! Compute pressure on VERT grid for snapshot output if needed
-      if (self%io_mgr%snapshot_mgr%config%output_pressure .and. &
-          self%io_mgr%snapshot_mgr%config%snapshot_freq > 0 .and. &
-          mod(iter, self%io_mgr%snapshot_mgr%config%snapshot_freq) &
-          == 0) then
-        call self%solver%compute_pressure_vert()
       end if
 
       call self%io_mgr%handle_io_step(self%solver, &

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -10,6 +10,7 @@ module m_base_case
   use m_mesh, only: mesh_t
   use m_solver, only: solver_t, init
   use m_postprocess, only: compute_derived_fields, compute_pressure_vert
+  use m_config, only: has_output_field
   use m_io_manager, only: io_manager_t
   use mpi, only: MPI_COMM_WORLD
 
@@ -99,8 +100,8 @@ contains
 
     ! Tell the solver to persist pressure if output is enabled
     self%solver%keep_pressure = &
-      self%io_mgr%snapshot_mgr%config%output_pressure .and. &
-      self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
+      has_output_field(self%io_mgr%snapshot_mgr%config, 'pressure') &
+      .and. self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
 
     if (self%io_mgr%is_restart()) then
       call self%io_mgr%handle_restart(self%solver, MPI_COMM_WORLD)
@@ -223,11 +224,11 @@ contains
     logical :: output_vorticity, output_qcriterion
 
     output_vorticity = &
-      self%io_mgr%snapshot_mgr%config%output_vorticity .and. &
-      self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
+      has_output_field(self%io_mgr%snapshot_mgr%config, 'vorticity') &
+      .and. self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
     output_qcriterion = &
-      self%io_mgr%snapshot_mgr%config%output_qcriterion .and. &
-      self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
+      has_output_field(self%io_mgr%snapshot_mgr%config, 'qcriterion') &
+      .and. self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
 
     if (self%io_mgr%is_restart()) then
       t = self%solver%current_iter*self%solver%dt

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -9,6 +9,7 @@ module m_base_case
   use m_field, only: field_t, flist_t
   use m_mesh, only: mesh_t
   use m_solver, only: solver_t, init
+  use m_postprocess, only: compute_derived_fields, compute_pressure_vert
   use m_io_manager, only: io_manager_t
   use mpi, only: MPI_COMM_WORLD
 
@@ -219,6 +220,14 @@ contains
 
     real(dp) :: t
     integer :: i, iter, sub_iter, start_iter
+    logical :: output_vorticity, output_qcriterion
+
+    output_vorticity = &
+      self%io_mgr%snapshot_mgr%config%output_vorticity .and. &
+      self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
+    output_qcriterion = &
+      self%io_mgr%snapshot_mgr%config%output_qcriterion .and. &
+      self%io_mgr%snapshot_mgr%config%snapshot_freq > 0
 
     if (self%io_mgr%is_restart()) then
       t = self%solver%current_iter*self%solver%dt
@@ -282,7 +291,14 @@ contains
 
       ! Compute pressure on VERT grid if output_pressure is enabled
       if (self%solver%keep_pressure) then
-        call self%solver%compute_pressure_vert()
+        call compute_pressure_vert(self%solver)
+      end if
+
+      ! Compute postprocess fields (vorticity magnitude, Q-criterion)
+      if (output_vorticity .or. output_qcriterion) then
+        call compute_derived_fields(self%solver, &
+                                    output_vorticity, &
+                                    output_qcriterion)
       end if
 
       call self%io_mgr%update_stats(self%solver, iter)

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -94,7 +94,7 @@ contains
 
     self%solver = init(backend, mesh, host_allocator)
 
-    call self%io_mgr%init(MPI_COMM_WORLD)
+    call self%io_mgr%init(self%solver, MPI_COMM_WORLD)
 
     ! Tell the solver to persist pressure if output is enabled
     self%solver%keep_pressure = self%io_mgr%snapshot_mgr%config%output_pressure
@@ -277,6 +277,8 @@ contains
       end do
 
       self%solver%current_iter = iter
+
+      call self%io_mgr%update_stats(self%solver, iter)
 
       if (mod(iter, self%solver%n_output) == 0) then
         t = iter*self%solver%dt

--- a/src/config.f90
+++ b/src/config.f90
@@ -72,6 +72,8 @@ module m_config
     integer, dimension(3) :: output_stride = [2, 2, 2]     !! Spatial stride for snapshot output
     logical :: snapshot_sp = .false.                       !! if true, snapshot in single precision
     logical :: output_pressure = .false.                   !! if true, include pressure in snapshots
+    logical :: output_vorticity = .false.                   !! if true, include vorticity magnitude in snapshots
+    logical :: output_qcriterion = .false.                  !! if true, include Q-criterion in snapshots
   contains
     procedure :: read => read_checkpoint_nml
   end type checkpoint_config_t
@@ -282,11 +284,13 @@ contains
     integer, dimension(3) :: output_stride = [1, 1, 1]
     logical :: snapshot_sp = .false.
     logical :: output_pressure = .false.
+    logical :: output_vorticity = .false.
+    logical :: output_qcriterion = .false.
 
     namelist /checkpoint_params/ checkpoint_freq, snapshot_freq, &
       keep_checkpoint, checkpoint_prefix, snapshot_prefix, &
       restart_from_checkpoint, restart_file, output_stride, snapshot_sp, &
-      output_pressure
+      output_pressure, output_vorticity, output_qcriterion
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading checkpoint config failed! &
                  &Provide only a file name or source, not both.'
@@ -317,6 +321,8 @@ contains
     self%output_stride = output_stride
     self%snapshot_sp = snapshot_sp
     self%output_pressure = output_pressure
+    self%output_vorticity = output_vorticity
+    self%output_qcriterion = output_qcriterion
   end subroutine read_checkpoint_nml
 
   subroutine read_stats_nml(self, nml_file, nml_string)

--- a/src/config.f90
+++ b/src/config.f90
@@ -8,7 +8,12 @@ module m_config
 
   integer, parameter :: n_species_max = 99
 
+  !! Maximum number of additional (non-mandatory) output fields in a snapshot
   integer, parameter :: MAX_OUTPUT_FIELDS = 10
+  !! Total number of possible snapshot fields: 3 mandatory (u,v,w) + 3 optional
+  !! (pressure, vorticity, qcriterion). Must be updated if new optional fields
+  !! are added to get_snapshot_fields in snapshot_manager.f90.
+  integer, parameter :: NUM_SNAPSHOT_FIELDS = 6
 
   type, abstract :: base_config_t
     !! All config types have a method read to initialise their data

--- a/src/config.f90
+++ b/src/config.f90
@@ -52,6 +52,15 @@ module m_config
     procedure :: read => read_cylinder_nml
   end type cylinder_config_t
 
+  type, extends(base_config_t) :: stats_config_t
+    integer :: initstat = 0          !! iteration to start accumulating (0 = disabled)
+    integer :: istatfreq = 1         !! accumulate every N steps
+    integer :: istatout = 0          !! write stats every N steps (0 = disabled)
+    character(len=256) :: stats_prefix = "statistics"
+  contains
+    procedure :: read => read_stats_nml
+  end type stats_config_t
+
   type, extends(base_config_t) :: checkpoint_config_t
     integer :: checkpoint_freq = 0                         !! Frequency of checkpointing (0 = off)
     integer :: snapshot_freq = 0                           !! Frequency of snapshots (0 = off)
@@ -309,6 +318,47 @@ contains
     self%snapshot_sp = snapshot_sp
     self%output_pressure = output_pressure
   end subroutine read_checkpoint_nml
+
+  subroutine read_stats_nml(self, nml_file, nml_string)
+    implicit none
+
+    class(stats_config_t) :: self
+    character(*), optional, intent(in) :: nml_file
+    character(*), optional, intent(in) :: nml_string
+
+    integer :: unit, ierr
+
+    integer :: initstat = 0
+    integer :: istatfreq = 1
+    integer :: istatout = 0
+    character(len=256) :: stats_prefix = "statistics"
+
+    namelist /stats_params/ initstat, istatfreq, istatout, stats_prefix
+
+    if (present(nml_file) .and. present(nml_string)) then
+      error stop 'Reading stats config failed! &
+                 &Provide only a file name or source, not both.'
+    else if (present(nml_file)) then
+      open (newunit=unit, file=nml_file, iostat=ierr)
+      if (ierr == 0) then
+        read (unit, nml=stats_params, iostat=ierr)
+        if (ierr /= 0 .and. ierr /= -1) &
+          print *, 'WARNING: Error in stats_params namelist, &
+          & using defaults'
+      end if
+      close (unit)
+    else if (present(nml_string)) then
+      read (nml_string, nml=stats_params)
+    else
+      error stop 'Reading stats config failed! &
+                 &Provide at least one of the following: file name or source'
+    end if
+
+    self%initstat = initstat
+    self%istatfreq = istatfreq
+    self%istatout = istatout
+    self%stats_prefix = stats_prefix
+  end subroutine read_stats_nml
 
 end module m_config
 

--- a/src/config.f90
+++ b/src/config.f90
@@ -8,6 +8,8 @@ module m_config
 
   integer, parameter :: n_species_max = 99
 
+  integer, parameter :: MAX_OUTPUT_FIELDS = 10
+
   type, abstract :: base_config_t
     !! All config types have a method read to initialise their data
   contains
@@ -71,9 +73,7 @@ module m_config
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [2, 2, 2]     !! Spatial stride for snapshot output
     logical :: snapshot_sp = .false.                       !! if true, snapshot in single precision
-    logical :: output_pressure = .false.                   !! if true, include pressure in snapshots
-    logical :: output_vorticity = .false.                   !! if true, include vorticity magnitude in snapshots
-    logical :: output_qcriterion = .false.                  !! if true, include Q-criterion in snapshots
+    character(len=32) :: output_fields(MAX_OUTPUT_FIELDS) = '' !! additional fields for snapshot output
   contains
     procedure :: read => read_checkpoint_nml
   end type checkpoint_config_t
@@ -283,14 +283,12 @@ contains
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [1, 1, 1]
     logical :: snapshot_sp = .false.
-    logical :: output_pressure = .false.
-    logical :: output_vorticity = .false.
-    logical :: output_qcriterion = .false.
+    character(len=32) :: output_fields(MAX_OUTPUT_FIELDS) = ''
 
     namelist /checkpoint_params/ checkpoint_freq, snapshot_freq, &
       keep_checkpoint, checkpoint_prefix, snapshot_prefix, &
       restart_from_checkpoint, restart_file, output_stride, snapshot_sp, &
-      output_pressure, output_vorticity, output_qcriterion
+      output_fields
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading checkpoint config failed! &
                  &Provide only a file name or source, not both.'
@@ -320,9 +318,7 @@ contains
     self%restart_file = restart_file
     self%output_stride = output_stride
     self%snapshot_sp = snapshot_sp
-    self%output_pressure = output_pressure
-    self%output_vorticity = output_vorticity
-    self%output_qcriterion = output_qcriterion
+    self%output_fields = output_fields
   end subroutine read_checkpoint_nml
 
   subroutine read_stats_nml(self, nml_file, nml_string)
@@ -365,6 +361,14 @@ contains
     self%istatout = istatout
     self%stats_prefix = stats_prefix
   end subroutine read_stats_nml
+
+  pure logical function has_output_field(config, name)
+    !! Check whether a field name is present in the output_fields list.
+    type(checkpoint_config_t), intent(in) :: config
+    character(*), intent(in) :: name
+
+    has_output_field = any(config%output_fields == name)
+  end function has_output_field
 
 end module m_config
 

--- a/src/io/checkpoint_manager.f90
+++ b/src/io/checkpoint_manager.f90
@@ -21,6 +21,7 @@ module m_checkpoint_manager
   use m_solver, only: solver_t
   use m_io_session, only: reader_session_t, writer_session_t
   use m_config, only: checkpoint_config_t
+  use m_stats, only: stats_manager_t
   use m_io_field_utils, only: field_buffer_map_t, field_ptr_t, &
                               setup_field_arrays, cleanup_field_arrays, &
                               stride_data_to_buffer, get_output_dimensions, &
@@ -96,11 +97,12 @@ contains
     restart = self%config%restart_from_checkpoint
   end function is_restart
 
-  subroutine handle_restart(self, solver, comm)
+  subroutine handle_restart(self, solver, comm, stats_mgr)
     !! Handle restart from checkpoint
     class(checkpoint_manager_t), intent(inout) :: self
     class(solver_t), intent(inout) :: solver
     integer, intent(in), optional :: comm
+    type(stats_manager_t), intent(inout), optional :: stats_mgr
 
     character(len=256) :: restart_file
     integer :: restart_timestep
@@ -112,7 +114,7 @@ contains
     end if
 
     call self%restart_checkpoint(solver, restart_file, restart_timestep, &
-                                 restart_time, comm)
+                                 restart_time, comm, stats_mgr)
 
     solver%current_iter = restart_timestep
 
@@ -122,27 +124,29 @@ contains
     end if
   end subroutine handle_restart
 
-  subroutine handle_checkpoint_step(self, solver, timestep, comm)
+  subroutine handle_checkpoint_step(self, solver, timestep, comm, stats_mgr)
     !! Handle checkpoint writing at a given timestep
     class(checkpoint_manager_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
     integer, intent(in) :: timestep
     integer, intent(in), optional :: comm
+    type(stats_manager_t), intent(inout), optional :: stats_mgr
 
     integer :: comm_to_use
 
     comm_to_use = MPI_COMM_WORLD
     if (present(comm)) comm_to_use = comm
 
-    call self%write_checkpoint(solver, timestep, comm_to_use)
+    call self%write_checkpoint(solver, timestep, comm_to_use, stats_mgr)
   end subroutine handle_checkpoint_step
 
-  subroutine write_checkpoint(self, solver, timestep, comm)
+  subroutine write_checkpoint(self, solver, timestep, comm, stats_mgr)
     !! Write a checkpoint file for simulation restart
     class(checkpoint_manager_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
     integer, intent(in) :: timestep
     integer, intent(in) :: comm
+    type(stats_manager_t), intent(inout), optional :: stats_mgr
 
     character(len=256) :: filename, temp_filename, old_filename
     integer :: ierr, myrank
@@ -196,6 +200,11 @@ contains
     call writer_session%write_data('ti_order', solver%time_integrator%order)
     call writer_session%write_data('ti_istep', solver%time_integrator%istep)
     call writer_session%write_data('ti_nstep', solver%time_integrator%nstep)
+
+    ! Write stats running means into the same checkpoint
+    if (present(stats_mgr)) then
+      call stats_mgr%write_checkpoint(solver, writer_session)
+    end if
 
     ! for AB methods with order >1, keep derivative history olds(i,j)
     if (is_ab == 1 .and. solver%time_integrator%order > 1) then
@@ -308,7 +317,7 @@ contains
   end subroutine write_checkpoint
 
   subroutine restart_checkpoint( &
-    self, solver, filename, timestep, restart_time, comm &
+    self, solver, filename, timestep, restart_time, comm, stats_mgr &
     )
     !! Restart simulation state from checkpoint file
     class(checkpoint_manager_t), intent(inout) :: self
@@ -317,6 +326,7 @@ contains
     integer, intent(out) :: timestep
     real(dp), intent(out) :: restart_time
     integer, intent(in) :: comm
+    type(stats_manager_t), intent(inout), optional :: stats_mgr
 
     type(reader_session_t) :: reader_session
     integer :: ierr, myrank, data_loc
@@ -453,6 +463,11 @@ contains
           end block
         end if
       end if
+    end if
+
+    ! Restore stats running means from the same checkpoint
+    if (present(stats_mgr)) then
+      call stats_mgr%read_checkpoint(solver, reader_session)
     end if
 
     call reader_session%close()

--- a/src/io/checkpoint_manager.f90
+++ b/src/io/checkpoint_manager.f90
@@ -235,7 +235,10 @@ contains
                                               padded_dims(2), padded_dims(3)))
             end if
 
-            raw_buffers(idx)%data = solver%time_integrator%olds(i, j)%ptr%data
+            call solver%backend%get_field_data( &
+              raw_buffers(idx)%data, &
+              solver%time_integrator%olds(i, j)%ptr, &
+              solver%time_integrator%olds(i, j)%ptr%dir)
 
             ! Use -1 to signal local per-rank variables (not decomposed across ranks)
             ! Each rank writes to its own uniquely named variable (with _rank suffix)
@@ -426,7 +429,7 @@ contains
                 write (old_name, '(A,"_rhs_old",I0)') trim(var_names(i)), j
                 write (ranked_name, '(A,A)') trim(old_name), trim(rank_suffix)
 
-                padded_dims = shape(solver%time_integrator%olds(i, j)%ptr%data)
+                padded_dims = solver%time_integrator%olds(i, j)%ptr%get_shape()
                 if (allocated(old_field)) then
                   if (any(shape(old_field) /= padded_dims)) then
                     deallocate (old_field)
@@ -440,7 +443,9 @@ contains
                 ! Clear the buffer before reading
                 old_field = 0.0_dp
                 call reader_session%read_data(trim(ranked_name), old_field)
-                solver%time_integrator%olds(i, j)%ptr%data = old_field
+                call solver%backend%set_field_data( &
+                  solver%time_integrator%olds(i, j)%ptr, old_field, &
+                  solver%time_integrator%olds(i, j)%ptr%dir)
               end do
             end do
             if (allocated(old_field)) deallocate (old_field)

--- a/src/io/io_field_utils.f90
+++ b/src/io/io_field_utils.f90
@@ -294,6 +294,26 @@ contains
           error stop 1
         end if
         field_ptrs(i)%ptr => solver%pressure_vert
+      case ("vort")
+        if (.not. associated(solver%vort)) then
+          if (solver%mesh%par%is_root()) then
+            print *, 'ERROR: vorticity not computed. &
+                     &Enable output_vorticity and &
+                     &ensure snapshot_freq > 0.'
+          end if
+          error stop 1
+        end if
+        field_ptrs(i)%ptr => solver%vort
+      case ("qcrit")
+        if (.not. associated(solver%qcrit)) then
+          if (solver%mesh%par%is_root()) then
+            print *, 'ERROR: Q-criterion not computed. &
+                     &Enable output_qcriterion and &
+                     &ensure snapshot_freq > 0.'
+          end if
+          error stop 1
+        end if
+        field_ptrs(i)%ptr => solver%qcrit
       case default
         if (solver%mesh%par%is_root()) then
           print *, 'ERROR: Unknown field name: ', trim(field_names(i))

--- a/src/io/io_manager.f90
+++ b/src/io/io_manager.f90
@@ -48,13 +48,7 @@ contains
     class(solver_t), intent(inout) :: solver
     integer, intent(in), optional :: comm
 
-    integer :: comm_to_use
-
-    comm_to_use = MPI_COMM_WORLD
-    if (present(comm)) comm_to_use = comm
-
     call self%checkpoint_mgr%handle_restart(solver, comm)
-    call self%stats_mgr%handle_restart(solver, comm_to_use)
   end subroutine io_handle_restart
 
   subroutine io_update_stats(self, solver, iter)

--- a/src/io/io_manager.f90
+++ b/src/io/io_manager.f90
@@ -71,9 +71,9 @@ contains
     if (present(comm)) comm_to_use = comm
 
     call self%checkpoint_mgr%handle_checkpoint_step( &
-      solver, timestep, comm, self%stats_mgr &
+      solver, timestep, comm_to_use, self%stats_mgr &
       )
-    call self%snapshot_mgr%handle_snapshot_step(solver, timestep, comm)
+    call self%snapshot_mgr%handle_snapshot_step(solver, timestep, comm_to_use)
     call self%stats_mgr%write_stats(solver, timestep, comm_to_use)
   end subroutine io_handle_step
 

--- a/src/io/io_manager.f90
+++ b/src/io/io_manager.f90
@@ -1,14 +1,16 @@
 module m_io_manager
-!! @brief Provides a high-level manager that orchestrates all checkpoint and
-!! snapshot operations.
+!! Provides a high-level manager that orchestrates all checkpoint,
+!! snapshot, and statistics operations.
 !!
 !! @details This module acts as a facade to the I/O subsystem.
 !! Its purpose is to simplify the main simulation loop by providing
 !! a single point of contact for all I/O-related actions. The mainprogram only
 !! needs to interact with the `io_manager_t` type, which then delegates tasks
-!! to the specialised checkpoint and snapshot managers.
+!! to the specialised checkpoint, snapshot, and statistics managers.
+  use mpi, only: MPI_COMM_WORLD
   use m_checkpoint_manager, only: checkpoint_manager_t
   use m_snapshot_manager, only: snapshot_manager_t
+  use m_stats, only: stats_manager_t
   use m_solver, only: solver_t
 
   implicit none
@@ -19,22 +21,26 @@ module m_io_manager
   type :: io_manager_t
     type(checkpoint_manager_t) :: checkpoint_mgr
     type(snapshot_manager_t) :: snapshot_mgr
+    type(stats_manager_t) :: stats_mgr
   contains
     procedure :: init => io_init
     procedure :: handle_restart => io_handle_restart
     procedure :: handle_io_step => io_handle_step
+    procedure :: update_stats => io_update_stats
     procedure :: finalise => io_finalise
     procedure :: is_restart => io_is_restart
   end type io_manager_t
 
 contains
 
-  subroutine io_init(self, comm)
+  subroutine io_init(self, solver, comm)
     class(io_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
     integer, intent(in) :: comm
 
     call self%checkpoint_mgr%init(comm)
     call self%snapshot_mgr%init(comm)
+    call self%stats_mgr%init(solver, comm)
   end subroutine io_init
 
   subroutine io_handle_restart(self, solver, comm)
@@ -42,8 +48,22 @@ contains
     class(solver_t), intent(inout) :: solver
     integer, intent(in), optional :: comm
 
+    integer :: comm_to_use
+
+    comm_to_use = MPI_COMM_WORLD
+    if (present(comm)) comm_to_use = comm
+
     call self%checkpoint_mgr%handle_restart(solver, comm)
+    call self%stats_mgr%handle_restart(solver, comm_to_use)
   end subroutine io_handle_restart
+
+  subroutine io_update_stats(self, solver, iter)
+    class(io_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    integer, intent(in) :: iter
+
+    call self%stats_mgr%update(solver, iter)
+  end subroutine io_update_stats
 
   subroutine io_handle_step(self, solver, timestep, comm)
     class(io_manager_t), intent(inout) :: self
@@ -51,8 +71,14 @@ contains
     integer, intent(in) :: timestep
     integer, intent(in), optional :: comm
 
+    integer :: comm_to_use
+
+    comm_to_use = MPI_COMM_WORLD
+    if (present(comm)) comm_to_use = comm
+
     call self%checkpoint_mgr%handle_checkpoint_step(solver, timestep, comm)
     call self%snapshot_mgr%handle_snapshot_step(solver, timestep, comm)
+    call self%stats_mgr%write_stats(solver, timestep, comm_to_use)
   end subroutine io_handle_step
 
   function io_is_restart(self) result(is_restart)
@@ -67,6 +93,7 @@ contains
 
     call self%checkpoint_mgr%finalise()
     call self%snapshot_mgr%finalise()
+    call self%stats_mgr%finalise()
   end subroutine io_finalise
 
 end module m_io_manager

--- a/src/io/io_manager.f90
+++ b/src/io/io_manager.f90
@@ -48,7 +48,7 @@ contains
     class(solver_t), intent(inout) :: solver
     integer, intent(in), optional :: comm
 
-    call self%checkpoint_mgr%handle_restart(solver, comm)
+    call self%checkpoint_mgr%handle_restart(solver, comm, self%stats_mgr)
   end subroutine io_handle_restart
 
   subroutine io_update_stats(self, solver, iter)
@@ -70,7 +70,9 @@ contains
     comm_to_use = MPI_COMM_WORLD
     if (present(comm)) comm_to_use = comm
 
-    call self%checkpoint_mgr%handle_checkpoint_step(solver, timestep, comm)
+    call self%checkpoint_mgr%handle_checkpoint_step( &
+      solver, timestep, comm, self%stats_mgr &
+      )
     call self%snapshot_mgr%handle_snapshot_step(solver, timestep, comm)
     call self%stats_mgr%write_stats(solver, timestep, comm_to_use)
   end subroutine io_handle_step

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -125,6 +125,7 @@ contains
     if (self%config%snapshot_freq <= 0) return
     if (mod(timestep, self%config%snapshot_freq) /= 0) return
 
+    allocate (field_names(0))
     field_names = get_snapshot_fields(self%config)
 
     call MPI_Comm_rank(comm, myrank, ierr)

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -11,7 +11,8 @@ module m_snapshot_manager
   use m_field, only: field_t
   use m_solver, only: solver_t
   use m_io_session, only: writer_session_t
-  use m_config, only: checkpoint_config_t, has_output_field
+  use m_config, only: checkpoint_config_t, has_output_field, &
+                      NUM_SNAPSHOT_FIELDS
   use m_io_field_utils, only: field_buffer_map_t, field_ptr_t, &
                               setup_field_arrays, cleanup_field_arrays, &
                               stride_data_to_buffer, get_output_dimensions, &
@@ -191,7 +192,7 @@ contains
     type(checkpoint_config_t), intent(in) :: config
     character(len=32), allocatable :: names(:)
 
-    character(len=32) :: tmp(6)
+    character(len=32) :: tmp(NUM_SNAPSHOT_FIELDS)
     integer :: n
 
     n = 3

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -83,6 +83,12 @@ contains
       if (self%config%output_pressure) then
         print *, 'Pressure output: Enabled'
       end if
+      if (self%config%output_vorticity) then
+        print *, 'Vorticity magnitude output: Enabled'
+      end if
+      if (self%config%output_qcriterion) then
+        print *, 'Q-criterion output: Enabled'
+      end if
     end if
   end subroutine configure_output
 
@@ -124,12 +130,7 @@ contains
     if (self%config%snapshot_freq <= 0) return
     if (mod(timestep, self%config%snapshot_freq) /= 0) return
 
-    ! Build field names list based on configuration
-    if (self%config%output_pressure) then
-      field_names = [character(len=32) :: "u", "v", "w", "p"]
-    else
-      field_names = [character(len=32) :: "u", "v", "w"]
-    end if
+    field_names = get_snapshot_fields(self%config)
 
     call MPI_Comm_rank(comm, myrank, ierr)
 
@@ -188,6 +189,28 @@ contains
     call cleanup_field_arrays(solver, field_ptrs, host_fields)
     deallocate (field_names)
   end subroutine write_snapshot
+
+  function get_snapshot_fields(config) result(names)
+    !! Build the list of field names for snapshot output
+    type(checkpoint_config_t), intent(in) :: config
+    character(len=32), allocatable :: names(:)
+
+    character(len=32) :: tmp(6)
+    integer :: n
+
+    n = 3
+    tmp(1:3) = [character(len=32) :: "u", "v", "w"]
+    if (config%output_pressure) then
+      n = n + 1; tmp(n) = "p"
+    end if
+    if (config%output_vorticity) then
+      n = n + 1; tmp(n) = "vort"
+    end if
+    if (config%output_qcriterion) then
+      n = n + 1; tmp(n) = "qcrit"
+    end if
+    names = tmp(1:n)
+  end function get_snapshot_fields
 
   subroutine generate_vtk_xml(self, dims, fields, origin, spacing)
     !! Generate VTK XML string for ImageData format for ParaView's ADIOS2VTXReader

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -11,7 +11,7 @@ module m_snapshot_manager
   use m_field, only: field_t
   use m_solver, only: solver_t
   use m_io_session, only: writer_session_t
-  use m_config, only: checkpoint_config_t
+  use m_config, only: checkpoint_config_t, has_output_field
   use m_io_field_utils, only: field_buffer_map_t, field_ptr_t, &
                               setup_field_arrays, cleanup_field_arrays, &
                               stride_data_to_buffer, get_output_dimensions, &
@@ -80,14 +80,9 @@ contains
       print *, 'Output stride: ', self%output_stride
       print *, 'Snapshot precision: ', merge('Single', 'Double', &
                                              self%config%snapshot_sp)
-      if (self%config%output_pressure) then
-        print *, 'Pressure output: Enabled'
-      end if
-      if (self%config%output_vorticity) then
-        print *, 'Vorticity magnitude output: Enabled'
-      end if
-      if (self%config%output_qcriterion) then
-        print *, 'Q-criterion output: Enabled'
+      if (any(self%config%output_fields /= '')) then
+        print *, 'Additional output fields: ', &
+          trim(adjustl(join_output_fields(self%config%output_fields)))
       end if
     end if
   end subroutine configure_output
@@ -200,13 +195,13 @@ contains
 
     n = 3
     tmp(1:3) = [character(len=32) :: "u", "v", "w"]
-    if (config%output_pressure) then
+    if (has_output_field(config, 'pressure')) then
       n = n + 1; tmp(n) = "p"
     end if
-    if (config%output_vorticity) then
+    if (has_output_field(config, 'vorticity')) then
       n = n + 1; tmp(n) = "vort"
     end if
-    if (config%output_qcriterion) then
+    if (has_output_field(config, 'qcriterion')) then
       n = n + 1; tmp(n) = "qcrit"
     end if
     names = tmp(1:n)
@@ -355,5 +350,20 @@ contains
       self%is_snapshot_file_open = .false.
     end if
   end subroutine close_snapshot_file
+
+  function join_output_fields(fields) result(str)
+    !! Join non-empty output field names into a comma-separated string.
+    use m_config, only: MAX_OUTPUT_FIELDS
+    character(len=32), intent(in) :: fields(MAX_OUTPUT_FIELDS)
+    character(len=256) :: str
+    integer :: i
+
+    str = ''
+    do i = 1, MAX_OUTPUT_FIELDS
+      if (fields(i) == '') cycle
+      if (len_trim(str) > 0) str = trim(str)//', '
+      str = trim(str)//trim(fields(i))
+    end do
+  end function join_output_fields
 
 end module m_snapshot_manager

--- a/src/io/stats.f90
+++ b/src/io/stats.f90
@@ -1,0 +1,258 @@
+module m_stats
+  !! Online accumulation of flow field statistics.
+  !!
+  !! Nine running means are maintained using the incremental update:
+  !! \[ \bar{x}_n = \bar{x}_{n-1} + \frac{x_n - \bar{x}_{n-1}}{n} \]
+  !! applied to \(u, v, w, u^2, v^2, w^2, uv, uw, vw\).
+  !! At write time the fluctuation quantities are derived:
+  !! \[ u' = \sqrt{\max(0,\, \overline{u^2} - \bar{u}^2)}, \quad
+  !!    \langle u'v' \rangle = \overline{uv} - \bar{u}\bar{v} \]
+  !!
+  !! Statistics are written at `istatout` frequency. Accumulation starts
+  !! at `initstat` and samples every `istatfreq` steps.
+  !!
+  !! Note: velocity fields must be at `VERT` data location when `update`
+  !! is called (i.e. after `pressure_correction`).
+  use mpi, only: MPI_COMM_WORLD, MPI_Comm_rank
+  use m_common, only: dp, i8, DIR_C, VERT, get_argument
+  use m_config, only: stats_config_t
+  use m_field, only: field_t
+  use m_solver, only: solver_t
+  use m_io_session, only: writer_session_t
+
+  implicit none
+
+  private
+  public :: stats_manager_t
+
+  type :: stats_manager_t
+    type(stats_config_t) :: config
+    integer :: sample_count = 0
+    logical :: is_active = .false.
+    !! Running means of first moments
+    real(dp), allocatable :: umean(:, :, :)
+    real(dp), allocatable :: vmean(:, :, :)
+    real(dp), allocatable :: wmean(:, :, :)
+    !! Running means of second moments
+    real(dp), allocatable :: uumean(:, :, :)  !! \(\overline{u^2}\)
+    real(dp), allocatable :: vvmean(:, :, :)  !! \(\overline{v^2}\)
+    real(dp), allocatable :: wwmean(:, :, :)  !! \(\overline{w^2}\)
+    real(dp), allocatable :: uvmean(:, :, :)  !! \(\overline{uv}\)
+    real(dp), allocatable :: uwmean(:, :, :)  !! \(\overline{uw}\)
+    real(dp), allocatable :: vwmean(:, :, :)  !! \(\overline{vw}\)
+  contains
+    procedure :: init
+    procedure :: update
+    procedure :: write_stats
+    procedure :: handle_restart
+    procedure :: finalise
+  end type stats_manager_t
+
+contains
+
+  subroutine init(self, solver, comm)
+    !! Initialise the statistics manager: read config and allocate accumulators.
+    class(stats_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    integer, intent(in) :: comm
+
+    integer :: dims(3), myrank, ierr
+
+    self%config = stats_config_t()
+    call self%config%read(nml_file=get_argument(1))
+
+    if (self%config%initstat <= 0) return
+
+    self%is_active = .true.
+    dims = solver%mesh%get_dims(VERT)
+
+    allocate (self%umean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%vmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%wmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%uumean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%vvmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%wwmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%uvmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%uwmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    allocate (self%vwmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+
+    call MPI_Comm_rank(comm, myrank, ierr)
+    if (myrank == 0) then
+      print *, 'Statistics: initstat=', self%config%initstat, &
+        ' istatfreq=', self%config%istatfreq, &
+        ' istatout=', self%config%istatout
+    end if
+  end subroutine init
+
+  subroutine update(self, solver, iter)
+    !! Accumulate running means for the current iteration.
+    !! Velocity fields must be at `VERT` data location.
+    class(stats_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    integer, intent(in) :: iter
+
+    class(field_t), pointer :: u_tmp, v_tmp, w_tmp
+    integer :: dims(3)
+    real(dp) :: stat_inc
+
+    if (.not. self%is_active) return
+    if (iter < self%config%initstat) return
+    if (mod(iter - self%config%initstat, self%config%istatfreq) /= 0) return
+
+    dims = solver%mesh%get_dims(VERT)
+
+    u_tmp => solver%host_allocator%get_block(DIR_C, VERT)
+    v_tmp => solver%host_allocator%get_block(DIR_C, VERT)
+    w_tmp => solver%host_allocator%get_block(DIR_C, VERT)
+
+    call solver%backend%get_field_data(u_tmp%data, solver%u)
+    call solver%backend%get_field_data(v_tmp%data, solver%v)
+    call solver%backend%get_field_data(w_tmp%data, solver%w)
+
+    self%sample_count = self%sample_count + 1
+    stat_inc = 1.0_dp/real(self%sample_count, dp)
+
+    associate ( &
+      u => u_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)), &
+      v => v_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)), &
+      w => w_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)) &
+      )
+      self%umean  = self%umean  + (u   - self%umean)  * stat_inc
+      self%vmean  = self%vmean  + (v   - self%vmean)  * stat_inc
+      self%wmean  = self%wmean  + (w   - self%wmean)  * stat_inc
+      self%uumean = self%uumean + (u*u - self%uumean) * stat_inc
+      self%vvmean = self%vvmean + (v*v - self%vvmean) * stat_inc
+      self%wwmean = self%wwmean + (w*w - self%wwmean) * stat_inc
+      self%uvmean = self%uvmean + (u*v - self%uvmean) * stat_inc
+      self%uwmean = self%uwmean + (u*w - self%uwmean) * stat_inc
+      self%vwmean = self%vwmean + (v*w - self%vwmean) * stat_inc
+    end associate
+
+    call solver%host_allocator%release_block(u_tmp)
+    call solver%host_allocator%release_block(v_tmp)
+    call solver%host_allocator%release_block(w_tmp)
+  end subroutine update
+
+  subroutine write_stats(self, solver, timestep, comm)
+    !! Write statistics to file. Output fields are mean velocities
+    !! (`umean`, `vmean`, `wmean`), RMS fluctuations (`uprime`, `vprime`,
+    !! `wprime`), and Reynolds stresses (`uvmean`, `uwmean`, `vwmean`).
+    class(stats_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    integer, intent(in) :: timestep
+    integer, intent(in) :: comm
+
+    type(writer_session_t) :: writer_session
+    character(len=256) :: filename
+    integer(i8), dimension(3) :: shape_dims, start_dims, count_dims
+    integer :: dims(3), myrank, ierr
+    real(dp), allocatable :: uprime(:, :, :)
+    real(dp), allocatable :: vprime(:, :, :)
+    real(dp), allocatable :: wprime(:, :, :)
+    real(dp), allocatable :: uv(:, :, :)
+    real(dp), allocatable :: uw(:, :, :)
+    real(dp), allocatable :: vw(:, :, :)
+
+    if (.not. self%is_active) return
+    if (self%config%istatout <= 0) return
+    if (mod(timestep, self%config%istatout) /= 0) return
+
+    call MPI_Comm_rank(comm, myrank, ierr)
+
+    write (filename, '(A,A,I0.6,A)') &
+      trim(self%config%stats_prefix), '_', timestep, '.bp'
+
+    dims = solver%mesh%get_dims(VERT)
+    shape_dims = int(solver%mesh%get_global_dims(VERT), i8)
+    start_dims = int(solver%mesh%par%n_offset, i8)
+    count_dims = int(dims, i8)
+
+    allocate (uprime(dims(1), dims(2), dims(3)))
+    allocate (vprime(dims(1), dims(2), dims(3)))
+    allocate (wprime(dims(1), dims(2), dims(3)))
+    allocate (uv(dims(1), dims(2), dims(3)))
+    allocate (uw(dims(1), dims(2), dims(3)))
+    allocate (vw(dims(1), dims(2), dims(3)))
+
+    uprime = sqrt(max(0.0_dp, self%uumean - self%umean**2))
+    vprime = sqrt(max(0.0_dp, self%vvmean - self%vmean**2))
+    wprime = sqrt(max(0.0_dp, self%wwmean - self%wmean**2))
+    uv = self%uvmean - self%umean*self%vmean
+    uw = self%uwmean - self%umean*self%wmean
+    vw = self%vwmean - self%vmean*self%wmean
+
+    call writer_session%open(filename, comm)
+    if (writer_session%is_session_functional() .and. myrank == 0) then
+      print *, 'Writing statistics: ', trim(filename), &
+        ' (samples=', self%sample_count, ')'
+    end if
+
+    call writer_session%write_data("sample_count", self%sample_count)
+    call writer_session%write_data("umean",  self%umean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("vmean",  self%vmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("wmean",  self%wmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("uprime", uprime, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("vprime", vprime, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("wprime", wprime, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("uvmean", uv, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("uwmean", uw, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("vwmean", vw, &
+                                   shape_dims, start_dims, count_dims)
+
+    call writer_session%close()
+
+    deallocate (uprime, vprime, wprime, uv, uw, vw)
+  end subroutine write_stats
+
+  subroutine handle_restart(self, solver, comm)
+    !! Zero-initialise all accumulators on restart, so statistics accumulate
+    !! from scratch rather than resuming from a previous run.
+    class(stats_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    integer, intent(in) :: comm
+
+    integer :: myrank, ierr
+
+    if (.not. self%is_active) return
+
+    call MPI_Comm_rank(comm, myrank, ierr)
+    if (myrank == 0) then
+      print *, 'Statistics: re-initialising accumulators for restart'
+    end if
+
+    self%sample_count = 0
+    self%umean  = 0.0_dp
+    self%vmean  = 0.0_dp
+    self%wmean  = 0.0_dp
+    self%uumean = 0.0_dp
+    self%vvmean = 0.0_dp
+    self%wwmean = 0.0_dp
+    self%uvmean = 0.0_dp
+    self%uwmean = 0.0_dp
+    self%vwmean = 0.0_dp
+  end subroutine handle_restart
+
+  subroutine finalise(self)
+    !! Deallocate all accumulator arrays.
+    class(stats_manager_t), intent(inout) :: self
+
+    if (allocated(self%umean))  deallocate (self%umean)
+    if (allocated(self%vmean))  deallocate (self%vmean)
+    if (allocated(self%wmean))  deallocate (self%wmean)
+    if (allocated(self%uumean)) deallocate (self%uumean)
+    if (allocated(self%vvmean)) deallocate (self%vvmean)
+    if (allocated(self%wwmean)) deallocate (self%wwmean)
+    if (allocated(self%uvmean)) deallocate (self%uvmean)
+    if (allocated(self%uwmean)) deallocate (self%uwmean)
+    if (allocated(self%vwmean)) deallocate (self%vwmean)
+  end subroutine finalise
+
+end module m_stats

--- a/src/io/stats.f90
+++ b/src/io/stats.f90
@@ -1,9 +1,10 @@
 module m_stats
   !! Online accumulation of flow field statistics.
   !!
-  !! Nine running means are maintained using the incremental update:
+  !! Running means are maintained using the incremental update:
   !! \[ \bar{x}_n = \bar{x}_{n-1} + \frac{x_n - \bar{x}_{n-1}}{n} \]
-  !! applied to \(u, v, w, u^2, v^2, w^2, uv, uw, vw\).
+  !! applied to \(u, v, w, u^2, v^2, w^2, uv, uw, vw\), plus pressure
+  !! mean and scalar statistics (\(\phi, \phi^2\)) when present.
   !! At write time the fluctuation quantities are derived:
   !! \[ u' = \sqrt{\max(0,\, \overline{u^2} - \bar{u}^2)}, \quad
   !!    \langle u'v' \rangle = \overline{uv} - \bar{u}\bar{v} \]
@@ -14,7 +15,7 @@ module m_stats
   !! Note: velocity fields must be at `VERT` data location when `update`
   !! is called (i.e. after `pressure_correction`).
   use mpi, only: MPI_COMM_WORLD, MPI_Comm_rank
-  use m_common, only: dp, i8, DIR_C, VERT, get_argument
+  use m_common, only: dp, i8, DIR_C, DIR_X, VERT, get_argument
   use m_config, only: stats_config_t
   use m_field, only: field_t
   use m_solver, only: solver_t
@@ -40,11 +41,16 @@ module m_stats
     real(dp), allocatable :: uvmean(:, :, :)  !! \(\overline{uv}\)
     real(dp), allocatable :: uwmean(:, :, :)  !! \(\overline{uw}\)
     real(dp), allocatable :: vwmean(:, :, :)  !! \(\overline{vw}\)
+    !! Pressure mean
+    real(dp), allocatable :: pmean(:, :, :)
+    !! Scalar (species) statistics
+    integer :: nspecies = 0
+    real(dp), allocatable :: phimean(:, :, :, :)     !! \(\overline{\phi}\)
+    real(dp), allocatable :: phiphimean(:, :, :, :)  !! \(\overline{\phi^2}\)
   contains
     procedure :: init
     procedure :: update
     procedure :: write_stats
-    procedure :: handle_restart
     procedure :: finalise
   end type stats_manager_t
 
@@ -76,6 +82,18 @@ contains
     allocate (self%uwmean(dims(1), dims(2), dims(3)), source=0.0_dp)
     allocate (self%vwmean(dims(1), dims(2), dims(3)), source=0.0_dp)
 
+    if (solver%keep_pressure) then
+      allocate (self%pmean(dims(1), dims(2), dims(3)), source=0.0_dp)
+    end if
+
+    self%nspecies = solver%nspecies
+    if (self%nspecies > 0) then
+      allocate (self%phimean(dims(1), dims(2), dims(3), self%nspecies), &
+                source=0.0_dp)
+      allocate (self%phiphimean(dims(1), dims(2), dims(3), self%nspecies), &
+                source=0.0_dp)
+    end if
+
     call MPI_Comm_rank(comm, myrank, ierr)
     if (myrank == 0) then
       print *, 'Statistics: initstat=', self%config%initstat, &
@@ -91,8 +109,8 @@ contains
     class(solver_t), intent(in) :: solver
     integer, intent(in) :: iter
 
-    class(field_t), pointer :: u_tmp, v_tmp, w_tmp
-    integer :: dims(3)
+    class(field_t), pointer :: u_tmp, v_tmp, w_tmp, p_tmp, phi_tmp
+    integer :: dims(3), is
     real(dp) :: stat_inc
 
     if (.not. self%is_active) return
@@ -117,16 +135,42 @@ contains
       v => v_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)), &
       w => w_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)) &
       )
-      self%umean  = self%umean  + (u   - self%umean)  * stat_inc
-      self%vmean  = self%vmean  + (v   - self%vmean)  * stat_inc
-      self%wmean  = self%wmean  + (w   - self%wmean)  * stat_inc
-      self%uumean = self%uumean + (u*u - self%uumean) * stat_inc
-      self%vvmean = self%vvmean + (v*v - self%vvmean) * stat_inc
-      self%wwmean = self%wwmean + (w*w - self%wwmean) * stat_inc
-      self%uvmean = self%uvmean + (u*v - self%uvmean) * stat_inc
-      self%uwmean = self%uwmean + (u*w - self%uwmean) * stat_inc
-      self%vwmean = self%vwmean + (v*w - self%vwmean) * stat_inc
+      self%umean = self%umean + (u - self%umean)*stat_inc
+      self%vmean = self%vmean + (v - self%vmean)*stat_inc
+      self%wmean = self%wmean + (w - self%wmean)*stat_inc
+      self%uumean = self%uumean + (u*u - self%uumean)*stat_inc
+      self%vvmean = self%vvmean + (v*v - self%vvmean)*stat_inc
+      self%wwmean = self%wwmean + (w*w - self%wwmean)*stat_inc
+      self%uvmean = self%uvmean + (u*v - self%uvmean)*stat_inc
+      self%uwmean = self%uwmean + (u*w - self%uwmean)*stat_inc
+      self%vwmean = self%vwmean + (v*w - self%vwmean)*stat_inc
     end associate
+
+    ! Pressure mean (from pressure_vert, already on VERT grid)
+    if (allocated(self%pmean) .and. associated(solver%pressure_vert)) then
+      p_tmp => solver%host_allocator%get_block(DIR_C, VERT)
+      call solver%backend%get_field_data(p_tmp%data, solver%pressure_vert)
+      associate (p => p_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)))
+        self%pmean = self%pmean + (p - self%pmean)*stat_inc
+      end associate
+      call solver%host_allocator%release_block(p_tmp)
+    end if
+
+    ! Scalar (species) statistics
+    do is = 1, self%nspecies
+      phi_tmp => solver%host_allocator%get_block(DIR_C, VERT)
+      call solver%backend%get_field_data(phi_tmp%data, &
+                                         solver%species(is)%ptr)
+      associate (phi => phi_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)))
+        self%phimean(:, :, :, is) = &
+          self%phimean(:, :, :, is) &
+          + (phi - self%phimean(:, :, :, is))*stat_inc
+        self%phiphimean(:, :, :, is) = &
+          self%phiphimean(:, :, :, is) &
+          + (phi*phi - self%phiphimean(:, :, :, is))*stat_inc
+      end associate
+      call solver%host_allocator%release_block(phi_tmp)
+    end do
 
     call solver%host_allocator%release_block(u_tmp)
     call solver%host_allocator%release_block(v_tmp)
@@ -145,13 +189,15 @@ contains
     type(writer_session_t) :: writer_session
     character(len=256) :: filename
     integer(i8), dimension(3) :: shape_dims, start_dims, count_dims
-    integer :: dims(3), myrank, ierr
+    integer :: dims(3), myrank, ierr, is
     real(dp), allocatable :: uprime(:, :, :)
     real(dp), allocatable :: vprime(:, :, :)
     real(dp), allocatable :: wprime(:, :, :)
     real(dp), allocatable :: uv(:, :, :)
     real(dp), allocatable :: uw(:, :, :)
     real(dp), allocatable :: vw(:, :, :)
+    real(dp), allocatable :: phiprime(:, :, :)
+    character(len=64) :: field_name
 
     if (.not. self%is_active) return
     if (self%config%istatout <= 0) return
@@ -188,11 +234,11 @@ contains
     end if
 
     call writer_session%write_data("sample_count", self%sample_count)
-    call writer_session%write_data("umean",  self%umean, &
+    call writer_session%write_data("umean", self%umean, &
                                    shape_dims, start_dims, count_dims)
-    call writer_session%write_data("vmean",  self%vmean, &
+    call writer_session%write_data("vmean", self%vmean, &
                                    shape_dims, start_dims, count_dims)
-    call writer_session%write_data("wmean",  self%wmean, &
+    call writer_session%write_data("wmean", self%wmean, &
                                    shape_dims, start_dims, count_dims)
     call writer_session%write_data("uprime", uprime, &
                                    shape_dims, start_dims, count_dims)
@@ -207,52 +253,53 @@ contains
     call writer_session%write_data("vwmean", vw, &
                                    shape_dims, start_dims, count_dims)
 
+    ! Pressure mean (only when output_pressure is enabled)
+    if (allocated(self%pmean)) then
+      call writer_session%write_data("pmean", self%pmean, &
+                                     shape_dims, start_dims, count_dims)
+    end if
+
+    ! Scalar statistics
+    if (self%nspecies > 0) then
+      allocate (phiprime(dims(1), dims(2), dims(3)))
+      do is = 1, self%nspecies
+        write (field_name, '(A,I0)') 'phimean_', is
+        call writer_session%write_data( &
+          trim(field_name), self%phimean(:, :, :, is), &
+          shape_dims, start_dims, count_dims &
+          )
+
+        phiprime = sqrt(max(0.0_dp, self%phiphimean(:, :, :, is) &
+                            - self%phimean(:, :, :, is)**2))
+        write (field_name, '(A,I0)') 'phiprime_', is
+        call writer_session%write_data( &
+          trim(field_name), phiprime, shape_dims, start_dims, count_dims &
+          )
+      end do
+      deallocate (phiprime)
+    end if
+
     call writer_session%close()
 
     deallocate (uprime, vprime, wprime, uv, uw, vw)
   end subroutine write_stats
 
-  subroutine handle_restart(self, solver, comm)
-    !! Zero-initialise all accumulators on restart, so statistics accumulate
-    !! from scratch rather than resuming from a previous run.
-    class(stats_manager_t), intent(inout) :: self
-    class(solver_t), intent(in) :: solver
-    integer, intent(in) :: comm
-
-    integer :: myrank, ierr
-
-    if (.not. self%is_active) return
-
-    call MPI_Comm_rank(comm, myrank, ierr)
-    if (myrank == 0) then
-      print *, 'Statistics: re-initialising accumulators for restart'
-    end if
-
-    self%sample_count = 0
-    self%umean  = 0.0_dp
-    self%vmean  = 0.0_dp
-    self%wmean  = 0.0_dp
-    self%uumean = 0.0_dp
-    self%vvmean = 0.0_dp
-    self%wwmean = 0.0_dp
-    self%uvmean = 0.0_dp
-    self%uwmean = 0.0_dp
-    self%vwmean = 0.0_dp
-  end subroutine handle_restart
-
   subroutine finalise(self)
     !! Deallocate all accumulator arrays.
     class(stats_manager_t), intent(inout) :: self
 
-    if (allocated(self%umean))  deallocate (self%umean)
-    if (allocated(self%vmean))  deallocate (self%vmean)
-    if (allocated(self%wmean))  deallocate (self%wmean)
+    if (allocated(self%umean)) deallocate (self%umean)
+    if (allocated(self%vmean)) deallocate (self%vmean)
+    if (allocated(self%wmean)) deallocate (self%wmean)
     if (allocated(self%uumean)) deallocate (self%uumean)
     if (allocated(self%vvmean)) deallocate (self%vvmean)
     if (allocated(self%wwmean)) deallocate (self%wwmean)
     if (allocated(self%uvmean)) deallocate (self%uvmean)
     if (allocated(self%uwmean)) deallocate (self%uwmean)
     if (allocated(self%vwmean)) deallocate (self%vwmean)
+    if (allocated(self%pmean)) deallocate (self%pmean)
+    if (allocated(self%phimean)) deallocate (self%phimean)
+    if (allocated(self%phiphimean)) deallocate (self%phiphimean)
   end subroutine finalise
 
 end module m_stats

--- a/src/io/stats.f90
+++ b/src/io/stats.f90
@@ -19,7 +19,7 @@ module m_stats
   use m_config, only: stats_config_t
   use m_field, only: field_t
   use m_solver, only: solver_t
-  use m_io_session, only: writer_session_t
+  use m_io_session, only: writer_session_t, reader_session_t
 
   implicit none
 
@@ -51,6 +51,8 @@ module m_stats
     procedure :: init
     procedure :: update
     procedure :: write_stats
+    procedure :: write_checkpoint
+    procedure :: read_checkpoint
     procedure :: finalise
   end type stats_manager_t
 
@@ -283,6 +285,148 @@ contains
 
     deallocate (uprime, vprime, wprime, uv, uw, vw)
   end subroutine write_stats
+
+  subroutine write_checkpoint(self, solver, writer_session)
+    !! Write running means into an already-open checkpoint session.
+    !! Saves all accumulator arrays and sample_count so that
+    !! statistics can be resumed exactly after a restart.
+    class(stats_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    type(writer_session_t), intent(inout) :: writer_session
+
+    integer(i8), dimension(3) :: shape_dims, start_dims, count_dims
+    integer :: dims(3), is
+    character(len=64) :: field_name
+
+    if (.not. self%is_active) return
+
+    dims = solver%mesh%get_dims(VERT)
+    shape_dims = int(solver%mesh%get_global_dims(VERT), i8)
+    start_dims = int(solver%mesh%par%n_offset, i8)
+    count_dims = int(dims, i8)
+
+    call writer_session%write_data("stats_sample_count", self%sample_count)
+
+    ! First moments
+    call writer_session%write_data("stats_umean", self%umean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_vmean", self%vmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_wmean", self%wmean, &
+                                   shape_dims, start_dims, count_dims)
+
+    ! Second moments
+    call writer_session%write_data("stats_uumean", self%uumean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_vvmean", self%vvmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_wwmean", self%wwmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_uvmean", self%uvmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_uwmean", self%uwmean, &
+                                   shape_dims, start_dims, count_dims)
+    call writer_session%write_data("stats_vwmean", self%vwmean, &
+                                   shape_dims, start_dims, count_dims)
+
+    ! Pressure mean
+    if (allocated(self%pmean)) then
+      call writer_session%write_data("stats_pmean", self%pmean, &
+                                     shape_dims, start_dims, count_dims)
+    end if
+
+    ! Scalar statistics
+    do is = 1, self%nspecies
+      write (field_name, '(A,I0)') 'stats_phimean_', is
+      call writer_session%write_data( &
+        trim(field_name), self%phimean(:, :, :, is), &
+        shape_dims, start_dims, count_dims &
+        )
+      write (field_name, '(A,I0)') 'stats_phiphimean_', is
+      call writer_session%write_data( &
+        trim(field_name), self%phiphimean(:, :, :, is), &
+        shape_dims, start_dims, count_dims &
+        )
+    end do
+  end subroutine write_checkpoint
+
+  subroutine read_checkpoint(self, solver, reader_session)
+    !! Restore running means from an already-open checkpoint session.
+    !! If stats were not present in the checkpoint, statistics start fresh.
+    class(stats_manager_t), intent(inout) :: self
+    class(solver_t), intent(in) :: solver
+    type(reader_session_t), intent(inout) :: reader_session
+
+    integer(i8), dimension(3) :: start_dims, count_dims
+    integer :: dims(3), myrank, ierr, is
+    character(len=64) :: field_name
+
+    if (.not. self%is_active) return
+
+    call MPI_Comm_rank(MPI_COMM_WORLD, myrank, ierr)
+
+    dims = solver%mesh%get_dims(VERT)
+    start_dims = int(solver%mesh%par%n_offset, i8)
+    count_dims = int(dims, i8)
+
+    call reader_session%read_data("stats_sample_count", self%sample_count)
+
+    ! First moments
+    call reader_session%read_data("stats_umean", self%umean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_vmean", self%vmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_wmean", self%wmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+
+    ! Second moments
+    call reader_session%read_data("stats_uumean", self%uumean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_vvmean", self%vvmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_wwmean", self%wwmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_uvmean", self%uvmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_uwmean", self%uwmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+    call reader_session%read_data("stats_vwmean", self%vwmean, &
+                                  start_dims=start_dims, &
+                                  count_dims=count_dims)
+
+    ! Pressure mean
+    if (allocated(self%pmean)) then
+      call reader_session%read_data("stats_pmean", self%pmean, &
+                                    start_dims=start_dims, &
+                                    count_dims=count_dims)
+    end if
+
+    ! Scalar statistics
+    do is = 1, self%nspecies
+      write (field_name, '(A,I0)') 'stats_phimean_', is
+      call reader_session%read_data( &
+        trim(field_name), self%phimean(:, :, :, is), &
+        start_dims=start_dims, count_dims=count_dims &
+        )
+      write (field_name, '(A,I0)') 'stats_phiphimean_', is
+      call reader_session%read_data( &
+        trim(field_name), self%phiphimean(:, :, :, is), &
+        start_dims=start_dims, count_dims=count_dims &
+        )
+    end do
+
+    if (myrank == 0) then
+      print *, 'Stats checkpoint restored: sample_count=', self%sample_count
+    end if
+  end subroutine read_checkpoint
 
   subroutine finalise(self)
     !! Deallocate all accumulator arrays.

--- a/src/io/stats.f90
+++ b/src/io/stats.f90
@@ -24,7 +24,7 @@ module m_stats
   implicit none
 
   private
-  public :: stats_manager_t
+  public :: stats_manager_t, accumulate_mean
 
   type :: stats_manager_t
     type(stats_config_t) :: config
@@ -57,6 +57,17 @@ module m_stats
   end type stats_manager_t
 
 contains
+
+  pure subroutine accumulate_mean(mean, val, stat_inc)
+    !! Incremental running-mean update:
+    !! \( \bar{x}_n = \bar{x}_{n-1} + (x_n - \bar{x}_{n-1})/n \)
+    !! where `stat_inc = 1/n`.
+    real(dp), intent(inout) :: mean(:, :, :)
+    real(dp), intent(in) :: val(:, :, :)
+    real(dp), intent(in) :: stat_inc
+
+    mean = mean + (val - mean)*stat_inc
+  end subroutine accumulate_mean
 
   subroutine init(self, solver, comm)
     !! Initialise the statistics manager: read config and allocate accumulators.
@@ -137,15 +148,15 @@ contains
       v => v_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)), &
       w => w_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)) &
       )
-      self%umean = self%umean + (u - self%umean)*stat_inc
-      self%vmean = self%vmean + (v - self%vmean)*stat_inc
-      self%wmean = self%wmean + (w - self%wmean)*stat_inc
-      self%uumean = self%uumean + (u*u - self%uumean)*stat_inc
-      self%vvmean = self%vvmean + (v*v - self%vvmean)*stat_inc
-      self%wwmean = self%wwmean + (w*w - self%wwmean)*stat_inc
-      self%uvmean = self%uvmean + (u*v - self%uvmean)*stat_inc
-      self%uwmean = self%uwmean + (u*w - self%uwmean)*stat_inc
-      self%vwmean = self%vwmean + (v*w - self%vwmean)*stat_inc
+      call accumulate_mean(self%umean, u, stat_inc)
+      call accumulate_mean(self%vmean, v, stat_inc)
+      call accumulate_mean(self%wmean, w, stat_inc)
+      call accumulate_mean(self%uumean, u*u, stat_inc)
+      call accumulate_mean(self%vvmean, v*v, stat_inc)
+      call accumulate_mean(self%wwmean, w*w, stat_inc)
+      call accumulate_mean(self%uvmean, u*v, stat_inc)
+      call accumulate_mean(self%uwmean, u*w, stat_inc)
+      call accumulate_mean(self%vwmean, v*w, stat_inc)
     end associate
 
     ! Pressure mean (from pressure_vert, already on VERT grid)
@@ -153,7 +164,7 @@ contains
       p_tmp => solver%host_allocator%get_block(DIR_C, VERT)
       call solver%backend%get_field_data(p_tmp%data, solver%pressure_vert)
       associate (p => p_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)))
-        self%pmean = self%pmean + (p - self%pmean)*stat_inc
+        call accumulate_mean(self%pmean, p, stat_inc)
       end associate
       call solver%host_allocator%release_block(p_tmp)
     end if
@@ -164,12 +175,8 @@ contains
       call solver%backend%get_field_data(phi_tmp%data, &
                                          solver%species(is)%ptr)
       associate (phi => phi_tmp%data(1:dims(1), 1:dims(2), 1:dims(3)))
-        self%phimean(:, :, :, is) = &
-          self%phimean(:, :, :, is) &
-          + (phi - self%phimean(:, :, :, is))*stat_inc
-        self%phiphimean(:, :, :, is) = &
-          self%phiphimean(:, :, :, is) &
-          + (phi*phi - self%phiphimean(:, :, :, is))*stat_inc
+        call accumulate_mean(self%phimean(:, :, :, is), phi, stat_inc)
+        call accumulate_mean(self%phiphimean(:, :, :, is), phi*phi, stat_inc)
       end associate
       call solver%host_allocator%release_block(phi_tmp)
     end do

--- a/src/postprocess.f90
+++ b/src/postprocess.f90
@@ -1,0 +1,205 @@
+module m_postprocess
+  !! Computation of derived fields for snapshot output.
+  !!
+  !! Provides routines to compute quantities that are not part of
+  !! the core time-stepping algorithm but are useful for analysis
+  !! and visualisation (e.g. pressure on the vertex grid, vorticity
+  !! magnitude, Q-criterion).
+
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, VERT, &
+                      RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Z2X
+  use m_field, only: field_t
+  use m_solver, only: solver_t
+
+  implicit none
+
+  private
+  public :: compute_derived_fields, compute_pressure_vert
+
+contains
+
+  subroutine compute_derived_fields(solver, output_vorticity, &
+                                    output_qcriterion)
+    !! Compute derived fields from the velocity gradient tensor.
+    !!
+    !! All 9 components of the velocity gradient tensor are computed
+    !! once, then used to evaluate whichever quantities are enabled
+    !! (vorticity magnitude, Q-criterion).
+    implicit none
+
+    class(solver_t), intent(inout) :: solver
+    logical, intent(in) :: output_vorticity, output_qcriterion
+
+    class(field_t), pointer :: &
+      dudx, dudy_x, dudz_x, &
+      dvdx, dvdy_x, dvdz_x, &
+      dwdx, dwdy_x, dwdz_x
+    class(field_t), pointer :: &
+      u_y, dudy_y, u_z, dudz_z, &
+      v_y, dvdy_y, v_z, dvdz_z, &
+      w_y, dwdy_y, w_z, dwdz_z
+
+    ! Lazily allocate output fields
+    if (output_vorticity .and. .not. associated(solver%vort)) &
+      solver%vort => solver%backend%allocator%get_block(DIR_X, VERT)
+    if (output_qcriterion .and. .not. associated(solver%qcrit)) &
+      solver%qcrit => solver%backend%allocator%get_block(DIR_X, VERT)
+
+    ! --- Compute all 9 velocity gradient components ---
+
+    ! du/dx (x-derivative in x-pencil, no reorder needed)
+    dudx => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%tds_solve(dudx, solver%u, &
+                                  solver%xdirps%der1st)
+
+    ! dv/dx
+    dvdx => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%tds_solve(dvdx, solver%v, &
+                                  solver%xdirps%der1st)
+
+    ! dw/dx
+    dwdx => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%tds_solve(dwdx, solver%w, &
+                                  solver%xdirps%der1st)
+
+    ! du/dy
+    u_y => solver%backend%allocator%get_block(DIR_Y)
+    dudy_y => solver%backend%allocator%get_block(DIR_Y)
+    call solver%backend%reorder(u_y, solver%u, RDR_X2Y)
+    call solver%backend%tds_solve(dudy_y, u_y, &
+                                  solver%ydirps%der1st)
+    dudy_x => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%reorder(dudy_x, dudy_y, RDR_Y2X)
+    call solver%backend%allocator%release_block(u_y)
+    call solver%backend%allocator%release_block(dudy_y)
+
+    ! dv/dy
+    v_y => solver%backend%allocator%get_block(DIR_Y)
+    dvdy_y => solver%backend%allocator%get_block(DIR_Y)
+    call solver%backend%reorder(v_y, solver%v, RDR_X2Y)
+    call solver%backend%tds_solve(dvdy_y, v_y, &
+                                  solver%ydirps%der1st)
+    dvdy_x => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%reorder(dvdy_x, dvdy_y, RDR_Y2X)
+    call solver%backend%allocator%release_block(v_y)
+    call solver%backend%allocator%release_block(dvdy_y)
+
+    ! dw/dy
+    w_y => solver%backend%allocator%get_block(DIR_Y)
+    dwdy_y => solver%backend%allocator%get_block(DIR_Y)
+    call solver%backend%reorder(w_y, solver%w, RDR_X2Y)
+    call solver%backend%tds_solve(dwdy_y, w_y, &
+                                  solver%ydirps%der1st)
+    dwdy_x => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%reorder(dwdy_x, dwdy_y, RDR_Y2X)
+    call solver%backend%allocator%release_block(w_y)
+    call solver%backend%allocator%release_block(dwdy_y)
+
+    ! du/dz
+    u_z => solver%backend%allocator%get_block(DIR_Z)
+    dudz_z => solver%backend%allocator%get_block(DIR_Z)
+    call solver%backend%reorder(u_z, solver%u, RDR_X2Z)
+    call solver%backend%tds_solve(dudz_z, u_z, &
+                                  solver%zdirps%der1st)
+    dudz_x => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%reorder(dudz_x, dudz_z, RDR_Z2X)
+    call solver%backend%allocator%release_block(u_z)
+    call solver%backend%allocator%release_block(dudz_z)
+
+    ! dv/dz
+    v_z => solver%backend%allocator%get_block(DIR_Z)
+    dvdz_z => solver%backend%allocator%get_block(DIR_Z)
+    call solver%backend%reorder(v_z, solver%v, RDR_X2Z)
+    call solver%backend%tds_solve(dvdz_z, v_z, &
+                                  solver%zdirps%der1st)
+    dvdz_x => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%reorder(dvdz_x, dvdz_z, RDR_Z2X)
+    call solver%backend%allocator%release_block(v_z)
+    call solver%backend%allocator%release_block(dvdz_z)
+
+    ! dw/dz
+    w_z => solver%backend%allocator%get_block(DIR_Z)
+    dwdz_z => solver%backend%allocator%get_block(DIR_Z)
+    call solver%backend%reorder(w_z, solver%w, RDR_X2Z)
+    call solver%backend%tds_solve(dwdz_z, w_z, &
+                                  solver%zdirps%der1st)
+    dwdz_x => solver%backend%allocator%get_block(DIR_X)
+    call solver%backend%reorder(dwdz_x, dwdz_z, RDR_Z2X)
+    call solver%backend%allocator%release_block(w_z)
+    call solver%backend%allocator%release_block(dwdz_z)
+
+    ! All 9 derivatives now in x-pencil layout:
+    ! dudx, dudy_x, dudz_x
+    ! dvdx, dvdy_x, dvdz_x
+    ! dwdx, dwdy_x, dwdz_x
+
+    ! Vorticity magnitude:
+    ! |w| = sqrt((dw/dy-dv/dz)^2+(du/dz-dw/dx)^2+(dv/dx-du/dy)^2)
+    if (output_vorticity) then
+      solver%vort%data = sqrt( &
+                         (dwdy_x%data - dvdz_x%data)**2 + &
+                         (dudz_x%data - dwdx%data)**2 + &
+                         (dvdx%data - dudy_x%data)**2 &
+                         )
+    end if
+
+    ! Q-criterion:
+    ! Q = -0.5*(dudx^2+dvdy^2+dwdz^2)
+    !     - dudy*dvdx - dudz*dwdx - dvdz*dwdy
+    if (output_qcriterion) then
+      solver%qcrit%data = &
+        -0.5_dp*(dudx%data**2 &
+                 + dvdy_x%data**2 &
+                 + dwdz_x%data**2) &
+        - dudy_x%data*dvdx%data &
+        - dudz_x%data*dwdx%data &
+        - dvdz_x%data*dwdy_x%data
+    end if
+
+    ! Release all gradient fields
+    call solver%backend%allocator%release_block(dudx)
+    call solver%backend%allocator%release_block(dvdx)
+    call solver%backend%allocator%release_block(dwdx)
+    call solver%backend%allocator%release_block(dudy_x)
+    call solver%backend%allocator%release_block(dvdy_x)
+    call solver%backend%allocator%release_block(dwdy_x)
+    call solver%backend%allocator%release_block(dudz_x)
+    call solver%backend%allocator%release_block(dvdz_x)
+    call solver%backend%allocator%release_block(dwdz_x)
+
+  end subroutine compute_derived_fields
+
+  subroutine compute_pressure_vert(solver)
+    !! Interpolates the pressure field from CELL (DIR_Z) to VERT
+    !! (DIR_X) for snapshot output and rescales from pseudo-pressure
+    !! to physical (kinematic) pressure.
+    implicit none
+
+    class(solver_t), intent(inout) :: solver
+
+    if (.not. associated(solver%pressure)) then
+      error stop 'compute_pressure_vert: pressure not yet computed'
+    end if
+
+    ! Lazy allocate pressure_vert on first call
+    if (.not. associated(solver%pressure_vert)) then
+      solver%pressure_vert => &
+        solver%backend%allocator%get_block(DIR_X, VERT)
+    end if
+
+    call solver%vector_calculus%interpl_c2v( &
+      solver%pressure_vert, solver%pressure, &
+      solver%xdirps%interpl_p2v, &
+      solver%ydirps%interpl_p2v, &
+      solver%zdirps%interpl_p2v &
+      )
+
+    ! Rescale pseudo-pressure to physical pressure: p'/dt -> p
+    call solver%backend%vecadd( &
+      1._dp/solver%dt, solver%pressure_vert, &
+      0._dp, solver%pressure_vert &
+      )
+
+  end subroutine compute_pressure_vert
+
+end module m_postprocess

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -59,6 +59,8 @@ module m_solver
     class(field_t), pointer :: pressure => null()      !! Pressure on CELL grid (DIR_Z)
     class(field_t), pointer :: pressure_vert => null() !! Pressure on VERT grid (DIR_X)
     logical :: keep_pressure = .false.                 !! If true, persist pressure for output
+    class(field_t), pointer :: vort => null()  !! Vorticity magnitude on VERT grid
+    class(field_t), pointer :: qcrit => null() !! Q-criterion on VERT grid
     type(flist_t), dimension(:), pointer :: species => null()
 
     class(base_backend_t), pointer :: backend
@@ -74,8 +76,6 @@ module m_solver
   contains
     procedure :: transeq_species
     procedure :: pressure_correction
-    procedure :: compute_pressure_vert
-    procedure :: rescale_pressure
     procedure :: divergence_v2p
     procedure :: gradient_p2v
     procedure :: curl
@@ -735,46 +735,5 @@ contains
     call self%backend%allocator%release_block(dpdz)
 
   end subroutine pressure_correction
-
-  subroutine compute_pressure_vert(self)
-    !! Interpolates the pressure field from CELL (DIR_Z) to VERT (DIR_X)
-    !! for snapshot output. Must be called after pressure_correction.
-    implicit none
-
-    class(solver_t) :: self
-
-    if (.not. associated(self%pressure)) then
-      error stop 'compute_pressure_vert: pressure not yet computed'
-    end if
-
-    ! Lazy allocate pressure_vert on first call
-    if (.not. associated(self%pressure_vert)) then
-      self%pressure_vert => self%backend%allocator%get_block(DIR_X, VERT)
-    end if
-
-    call self%vector_calculus%interpl_c2v( &
-      self%pressure_vert, self%pressure, &
-      self%xdirps%interpl_p2v, &
-      self%ydirps%interpl_p2v, &
-      self%zdirps%interpl_p2v &
-      )
-
-    call self%rescale_pressure(self%pressure_vert)
-
-  end subroutine compute_pressure_vert
-
-  subroutine rescale_pressure(self, pressure)
-    !! Rescale pseudo-pressure to physical (kinematic) pressure.
-    !!
-    !! The Poisson solve returns \(p'\) where \(u^{n+1} = u* - \nabla{p'}\),
-    !! so \(p' = \frac{\Delta t}{\rho}p\). Divide by dt to recover p/rho.
-    implicit none
-
-    class(solver_t) :: self
-    class(field_t), intent(inout) :: pressure
-
-    call self%backend%vecadd(1._dp/self%dt, pressure, 0._dp, pressure)
-
-  end subroutine rescale_pressure
 
 end module m_solver

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ if(WITH_ADIOS2)
 endif()
 
 define_test(test_setget_field.f90 1 omp)
+define_test(test_statistics.f90 1 omp)
 
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")

--- a/tests/test_statistics.f90
+++ b/tests/test_statistics.f90
@@ -1,8 +1,8 @@
 program test_statistics
-  !! Unit tests for the flow field statistics accumulation logic in m_stats.
-  !! No I/O required.
+  !! Unit tests for the accumulate_mean subroutine in m_stats.
 
   use m_common, only: dp
+  use m_stats, only: accumulate_mean
   use mpi
 
   implicit none
@@ -24,10 +24,10 @@ contains
 
   subroutine test_constant_field()
     !! Constant field c=1: umean==1, uprime==0.
-    !! c=1 is chosen so that c^2 is exact in floating-point.
     real(dp), parameter :: c = 1.0_dp
     integer, parameter :: n_samples = 100
-    real(dp) :: umean, uumean, uprime, stat_inc
+    real(dp) :: umean(1, 1, 1), uumean(1, 1, 1), val(1, 1, 1)
+    real(dp) :: uprime, stat_inc
     integer :: n
     real(dp), parameter :: tol = 1.0e-12_dp
 
@@ -35,14 +35,17 @@ contains
 
     do n = 1, n_samples
       stat_inc = 1.0_dp/n
-      umean  = umean  + (c   - umean)  * stat_inc
-      uumean = uumean + (c*c - uumean) * stat_inc
+      val(1, 1, 1) = c
+      call accumulate_mean(umean, val, stat_inc)
+      val(1, 1, 1) = c*c
+      call accumulate_mean(uumean, val, stat_inc)
     end do
 
-    uprime = sqrt(max(0.0_dp, uumean - umean**2))
+    uprime = sqrt(max(0.0_dp, uumean(1, 1, 1) - umean(1, 1, 1)**2))
 
-    if (abs(umean - c) > tol) then
-      print *, 'FAIL test_constant_field: umean =', umean, 'expected', c
+    if (abs(umean(1, 1, 1) - c) > tol) then
+      print *, 'FAIL test_constant_field: umean =', umean(1, 1, 1), &
+        'expected', c
       error stop 'test_constant_field: umean /= constant'
     end if
     if (abs(uprime) > tol) then
@@ -52,9 +55,10 @@ contains
   end subroutine test_constant_field
 
   subroutine test_known_mean()
-    !! Values 1..N: Welford mean must equal (N+1)/2.
+    !! Values 1..N: mean must equal (N+1)/2.
     integer, parameter :: n_samples = 50
-    real(dp) :: umean, stat_inc, expected
+    real(dp) :: umean(1, 1, 1), val(1, 1, 1)
+    real(dp) :: stat_inc, expected
     integer :: n
     real(dp), parameter :: tol = 1.0e-12_dp
 
@@ -63,11 +67,13 @@ contains
 
     do n = 1, n_samples
       stat_inc = 1.0_dp/n
-      umean = umean + (real(n, dp) - umean)*stat_inc
+      val(1, 1, 1) = real(n, dp)
+      call accumulate_mean(umean, val, stat_inc)
     end do
 
-    if (abs(umean - expected) > tol) then
-      print *, 'FAIL test_known_mean: umean =', umean, 'expected', expected
+    if (abs(umean(1, 1, 1) - expected) > tol) then
+      print *, 'FAIL test_known_mean: umean =', umean(1, 1, 1), &
+        'expected', expected
       error stop 'test_known_mean: mean /= analytical mean'
     end if
   end subroutine test_known_mean
@@ -75,23 +81,26 @@ contains
   subroutine test_rms_nonzero()
     !! Alternating -1/+1: mean==0, uprime==1.
     integer, parameter :: n_samples = 200
-    real(dp) :: umean, uumean, uprime, stat_inc, val
+    real(dp) :: umean(1, 1, 1), uumean(1, 1, 1), val(1, 1, 1)
+    real(dp) :: uprime, stat_inc
     integer :: n
     real(dp), parameter :: tol = 1.0e-10_dp
 
     umean = 0.0_dp; uumean = 0.0_dp
 
     do n = 1, n_samples
-      val = merge(1.0_dp, -1.0_dp, mod(n, 2) == 0)
+      val(1, 1, 1) = merge(1.0_dp, -1.0_dp, mod(n, 2) == 0)
       stat_inc = 1.0_dp/n
-      umean  = umean  + (val     - umean)  * stat_inc
-      uumean = uumean + (val*val - uumean) * stat_inc
+      call accumulate_mean(umean, val, stat_inc)
+      val(1, 1, 1) = val(1, 1, 1)**2
+      call accumulate_mean(uumean, val, stat_inc)
     end do
 
-    uprime = sqrt(max(0.0_dp, uumean - umean**2))
+    uprime = sqrt(max(0.0_dp, uumean(1, 1, 1) - umean(1, 1, 1)**2))
 
-    if (abs(umean) > tol) then
-      print *, 'FAIL test_rms_nonzero: umean =', umean, 'expected 0'
+    if (abs(umean(1, 1, 1)) > tol) then
+      print *, 'FAIL test_rms_nonzero: umean =', umean(1, 1, 1), &
+        'expected 0'
       error stop 'test_rms_nonzero: mean of alternating series /= 0'
     end if
     if (abs(uprime - 1.0_dp) > tol) then
@@ -104,7 +113,9 @@ contains
     !! u=v=1..N: Reynolds stress <u'v'> = <uv> - <u><v> must equal var(u).
     !! u=-v: Reynolds stress must equal -var(u).
     integer, parameter :: n_samples = 100
-    real(dp) :: umean, vmean, uumean, uvmean, stat_inc
+    real(dp) :: umean(1, 1, 1), vmean(1, 1, 1)
+    real(dp) :: uumean(1, 1, 1), uvmean(1, 1, 1)
+    real(dp) :: val(1, 1, 1), stat_inc
     real(dp) :: uprime2, reynolds_stress
     integer :: n
     real(dp), parameter :: tol = 1.0e-10_dp
@@ -115,14 +126,16 @@ contains
 
     do n = 1, n_samples
       stat_inc = 1.0_dp/n
-      umean  = umean  + (real(n, dp)          - umean)  * stat_inc
-      vmean  = vmean  + (real(n, dp)          - vmean)  * stat_inc
-      uumean = uumean + (real(n, dp)**2       - uumean) * stat_inc
-      uvmean = uvmean + (real(n, dp)**2       - uvmean) * stat_inc
+      val(1, 1, 1) = real(n, dp)
+      call accumulate_mean(umean, val, stat_inc)
+      call accumulate_mean(vmean, val, stat_inc)
+      val(1, 1, 1) = real(n, dp)**2
+      call accumulate_mean(uumean, val, stat_inc)
+      call accumulate_mean(uvmean, val, stat_inc)
     end do
 
-    uprime2 = uumean - umean**2
-    reynolds_stress = uvmean - umean*vmean
+    uprime2 = uumean(1, 1, 1) - umean(1, 1, 1)**2
+    reynolds_stress = uvmean(1, 1, 1) - umean(1, 1, 1)*vmean(1, 1, 1)
 
     if (abs(reynolds_stress - uprime2) > tol*abs(uprime2)) then
       print *, 'FAIL test_reynolds_stress: <u''v''> /= var(u) for u==v'
@@ -135,14 +148,18 @@ contains
 
     do n = 1, n_samples
       stat_inc = 1.0_dp/n
-      umean  = umean  + (real(n, dp)          - umean)  * stat_inc
-      vmean  = vmean  + (-real(n, dp)         - vmean)  * stat_inc
-      uumean = uumean + (real(n, dp)**2       - uumean) * stat_inc
-      uvmean = uvmean + (-real(n, dp)**2      - uvmean) * stat_inc
+      val(1, 1, 1) = real(n, dp)
+      call accumulate_mean(umean, val, stat_inc)
+      val(1, 1, 1) = -real(n, dp)
+      call accumulate_mean(vmean, val, stat_inc)
+      val(1, 1, 1) = real(n, dp)**2
+      call accumulate_mean(uumean, val, stat_inc)
+      val(1, 1, 1) = -real(n, dp)**2
+      call accumulate_mean(uvmean, val, stat_inc)
     end do
 
-    uprime2 = uumean - umean**2
-    reynolds_stress = uvmean - umean*vmean
+    uprime2 = uumean(1, 1, 1) - umean(1, 1, 1)**2
+    reynolds_stress = uvmean(1, 1, 1) - umean(1, 1, 1)*vmean(1, 1, 1)
 
     if (abs(reynolds_stress + uprime2) > tol*abs(uprime2)) then
       print *, 'FAIL test_reynolds_stress: <u''v''> /= -var(u) for u==-v'

--- a/tests/test_statistics.f90
+++ b/tests/test_statistics.f90
@@ -1,0 +1,153 @@
+program test_statistics
+  !! Unit tests for the flow field statistics accumulation logic in m_stats.
+  !! No I/O required.
+
+  use m_common, only: dp
+  use mpi
+
+  implicit none
+
+  integer :: ierr
+
+  call MPI_Init(ierr)
+
+  call test_constant_field()
+  call test_known_mean()
+  call test_rms_nonzero()
+  call test_reynolds_stress()
+
+  print *, 'All statistics accumulation tests passed'
+
+  call MPI_Finalize(ierr)
+
+contains
+
+  subroutine test_constant_field()
+    !! Constant field c=1: umean==1, uprime==0.
+    !! c=1 is chosen so that c^2 is exact in floating-point.
+    real(dp), parameter :: c = 1.0_dp
+    integer, parameter :: n_samples = 100
+    real(dp) :: umean, uumean, uprime, stat_inc
+    integer :: n
+    real(dp), parameter :: tol = 1.0e-12_dp
+
+    umean = 0.0_dp; uumean = 0.0_dp
+
+    do n = 1, n_samples
+      stat_inc = 1.0_dp/n
+      umean  = umean  + (c   - umean)  * stat_inc
+      uumean = uumean + (c*c - uumean) * stat_inc
+    end do
+
+    uprime = sqrt(max(0.0_dp, uumean - umean**2))
+
+    if (abs(umean - c) > tol) then
+      print *, 'FAIL test_constant_field: umean =', umean, 'expected', c
+      error stop 'test_constant_field: umean /= constant'
+    end if
+    if (abs(uprime) > tol) then
+      print *, 'FAIL test_constant_field: uprime =', uprime, 'expected 0'
+      error stop 'test_constant_field: uprime /= 0 for constant field'
+    end if
+  end subroutine test_constant_field
+
+  subroutine test_known_mean()
+    !! Values 1..N: Welford mean must equal (N+1)/2.
+    integer, parameter :: n_samples = 50
+    real(dp) :: umean, stat_inc, expected
+    integer :: n
+    real(dp), parameter :: tol = 1.0e-12_dp
+
+    umean = 0.0_dp
+    expected = (n_samples + 1)/2.0_dp
+
+    do n = 1, n_samples
+      stat_inc = 1.0_dp/n
+      umean = umean + (real(n, dp) - umean)*stat_inc
+    end do
+
+    if (abs(umean - expected) > tol) then
+      print *, 'FAIL test_known_mean: umean =', umean, 'expected', expected
+      error stop 'test_known_mean: mean /= analytical mean'
+    end if
+  end subroutine test_known_mean
+
+  subroutine test_rms_nonzero()
+    !! Alternating -1/+1: mean==0, uprime==1.
+    integer, parameter :: n_samples = 200
+    real(dp) :: umean, uumean, uprime, stat_inc, val
+    integer :: n
+    real(dp), parameter :: tol = 1.0e-10_dp
+
+    umean = 0.0_dp; uumean = 0.0_dp
+
+    do n = 1, n_samples
+      val = merge(1.0_dp, -1.0_dp, mod(n, 2) == 0)
+      stat_inc = 1.0_dp/n
+      umean  = umean  + (val     - umean)  * stat_inc
+      uumean = uumean + (val*val - uumean) * stat_inc
+    end do
+
+    uprime = sqrt(max(0.0_dp, uumean - umean**2))
+
+    if (abs(umean) > tol) then
+      print *, 'FAIL test_rms_nonzero: umean =', umean, 'expected 0'
+      error stop 'test_rms_nonzero: mean of alternating series /= 0'
+    end if
+    if (abs(uprime - 1.0_dp) > tol) then
+      print *, 'FAIL test_rms_nonzero: uprime =', uprime, 'expected 1'
+      error stop 'test_rms_nonzero: rms of alternating series /= 1'
+    end if
+  end subroutine test_rms_nonzero
+
+  subroutine test_reynolds_stress()
+    !! u=v=1..N: Reynolds stress <u'v'> = <uv> - <u><v> must equal var(u).
+    !! u=-v: Reynolds stress must equal -var(u).
+    integer, parameter :: n_samples = 100
+    real(dp) :: umean, vmean, uumean, uvmean, stat_inc
+    real(dp) :: uprime2, reynolds_stress
+    integer :: n
+    real(dp), parameter :: tol = 1.0e-10_dp
+
+    ! Perfectly correlated: u == v
+    umean = 0.0_dp; vmean = 0.0_dp
+    uumean = 0.0_dp; uvmean = 0.0_dp
+
+    do n = 1, n_samples
+      stat_inc = 1.0_dp/n
+      umean  = umean  + (real(n, dp)          - umean)  * stat_inc
+      vmean  = vmean  + (real(n, dp)          - vmean)  * stat_inc
+      uumean = uumean + (real(n, dp)**2       - uumean) * stat_inc
+      uvmean = uvmean + (real(n, dp)**2       - uvmean) * stat_inc
+    end do
+
+    uprime2 = uumean - umean**2
+    reynolds_stress = uvmean - umean*vmean
+
+    if (abs(reynolds_stress - uprime2) > tol*abs(uprime2)) then
+      print *, 'FAIL test_reynolds_stress: <u''v''> /= var(u) for u==v'
+      error stop 'test_reynolds_stress: correlated case failed'
+    end if
+
+    ! Anticorrelated: u = -v
+    umean = 0.0_dp; vmean = 0.0_dp
+    uumean = 0.0_dp; uvmean = 0.0_dp
+
+    do n = 1, n_samples
+      stat_inc = 1.0_dp/n
+      umean  = umean  + (real(n, dp)          - umean)  * stat_inc
+      vmean  = vmean  + (-real(n, dp)         - vmean)  * stat_inc
+      uumean = uumean + (real(n, dp)**2       - uumean) * stat_inc
+      uvmean = uvmean + (-real(n, dp)**2      - uvmean) * stat_inc
+    end do
+
+    uprime2 = uumean - umean**2
+    reynolds_stress = uvmean - umean*vmean
+
+    if (abs(reynolds_stress + uprime2) > tol*abs(uprime2)) then
+      print *, 'FAIL test_reynolds_stress: <u''v''> /= -var(u) for u==-v'
+      error stop 'test_reynolds_stress: anticorrelated case failed'
+    end if
+  end subroutine test_reynolds_stress
+
+end program test_statistics


### PR DESCRIPTION
Adds runtime stats accumulation and adds additional optional fields to snapshots (vorticity magnitude and Q-criterion), which closes #285 .  Note that this PR also fixes #286 

#### Stats module
- Created new module: `stats.f90` to create the running means
- Obtains mean velocities (`umean`, `vmean`, `wmean`), mean squares (`uumean`, `vvmean` and `wwmean`) and cross-moments (`uvmean`, `uwmean`, `vwmean`) 
- Pressure stats (`pmean`) - if pressure output is enabled
- Scalar species stats (`phimean`, `phiphimean`) - if `n_species >0`
- Stats parameters can be configured from the input file (`initstat`, `istatfreq`, `istatout`)
- Velocity fluctuations ($$u' = \sqrt{\overline{u^2} - \bar{u}^2}$$) and Reynolds-stresses ($$\overline{u'v'} = \overline{uv} - \bar{u}\,\bar{v}$$) are computed at write time (note that Xcompact3d writes the raw means `umean`, `uumean` etc. and rms velocity and Reynolds stresses are later computed using post-processing tools such as Py4Incompact3D.)
- Includes stats for restart runs (uses current checkpointing architecture) 
- In Xcompact3d stats output uses the same frequency as checkpoints, here the two are independent.
- We don't allow stats to be done on a coarse grid (possible aliasing issues)
- Added a new test case 

#### Post-process module
- moved some post-processing done in `solver.f90` to this new module
- added new post-processed fields
- vorticity magnitude: $$|\boldsymbol{\omega}| = \sqrt{\omega_x^2 + \omega_y^2 + \omega_z^2}$$
- Q-criterion: $$Q = -\frac{1}{2} \sum_{i,j} \frac{\partial u_i}{\partial x_j} \frac{\partial u_j}{\partial x_i}$$

#### Input changes
- Invdivdual boolean flag (`output_pressure` for example) replaced with a single extensible namelist array: `output_fields = 'pressure', 'vorticity', 'qcriterion'`

#### Tests
- Tested on simple TGV and channel cases to make sure that the stats are written to file and that restarts work. Full testing to be done on the cylinder case.