### PR TITLE
Add IBM as an optional snapshot output file

### DIFF
--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -48,6 +48,7 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
   - ``'pressure'`` — Pressure field, interpolated from its native cell-centred grid to the vertex grid for ParaView compatibility. Not included in checkpoint files since it is recomputed from velocity.
   - ``'vorticity'`` — Vorticity magnitude :math:`|\omega| = \sqrt{\omega_x^2 + \omega_y^2 + \omega_z^2}`, computed from the full velocity gradient tensor.
   - ``'qcriterion'`` — Q-criterion :math:`Q = -\frac{1}{2} \sum_{ij} \frac{\partial u_i}{\partial x_j} \frac{\partial u_j}{\partial x_i}`, identifying vortical structures (positive Q indicates rotation-dominated regions).
+  - ``'ibm'`` — Immersed boundary method mask field (``ep1``). Values are ``1`` in the fluid domain and ``0`` in the solid domain. Requires ``ibm_on = .true.`` in the input file.
 
   When both ``'vorticity'`` and ``'qcriterion'`` are requested, the velocity gradient tensor is computed only once.
   **Default:** (empty — only velocity is written)

--- a/src/config.f90
+++ b/src/config.f90
@@ -13,7 +13,7 @@ module m_config
   !! Total number of possible snapshot fields: 3 mandatory (u,v,w) + 3 optional
   !! (pressure, vorticity, qcriterion). Must be updated if new optional fields
   !! are added to get_snapshot_fields in snapshot_manager.f90.
-  integer, parameter :: NUM_SNAPSHOT_FIELDS = 6
+  integer, parameter :: NUM_SNAPSHOT_FIELDS = 7
 
   type, abstract :: base_config_t
     !! All config types have a method read to initialise their data

--- a/src/config.f90
+++ b/src/config.f90
@@ -10,8 +10,8 @@ module m_config
 
   !! Maximum number of additional (non-mandatory) output fields in a snapshot
   integer, parameter :: MAX_OUTPUT_FIELDS = 10
-  !! Total number of possible snapshot fields: 3 mandatory (u,v,w) + 3 optional
-  !! (pressure, vorticity, qcriterion). Must be updated if new optional fields
+  !! Total number of possible snapshot fields: 3 mandatory (u,v,w) + 4 optional
+  !! (pressure, vorticity, qcriterion, ibm mask). Must be updated if new optional fields
   !! are added to get_snapshot_fields in snapshot_manager.f90.
   integer, parameter :: NUM_SNAPSHOT_FIELDS = 7
 

--- a/src/io/io_field_utils.f90
+++ b/src/io/io_field_utils.f90
@@ -314,6 +314,15 @@ contains
           error stop 1
         end if
         field_ptrs(i)%ptr => solver%qcrit
+      case ("ibm")
+        if (.not. solver%ibm_on .or. .not. associated(solver%ibm%ep1)) then
+          if (solver%mesh%par%is_root()) then
+            print *, 'ERROR: IBM mask not available. &
+                     &Enable ibm_on in solver_params.'
+          end if
+          error stop 1
+        end if
+        field_ptrs(i)%ptr => solver%ibm%ep1
       case default
         if (solver%mesh%par%is_root()) then
           print *, 'ERROR: Unknown field name: ', trim(field_names(i))

--- a/src/io/io_field_utils.f90
+++ b/src/io/io_field_utils.f90
@@ -318,7 +318,7 @@ contains
         if (.not. solver%ibm_on .or. .not. associated(solver%ibm%ep1)) then
           if (solver%mesh%par%is_root()) then
             print *, 'ERROR: IBM mask not available. &
-                     &Enable ibm_on in solver_params.'
+                     &Enable ibm_on in the input file.'
           end if
           error stop 1
         end if

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -206,6 +206,9 @@ contains
     if (has_output_field(config, 'qcriterion')) then
       n = n + 1; tmp(n) = "qcrit"
     end if
+    if (has_output_field(config, 'ibm')) then
+      n = n + 1; tmp(n) = "ibm"
+    end if
     names = tmp(1:n)
   end function get_snapshot_fields
 


### PR DESCRIPTION
This PR adds supports for writing IBM masks to snapshots. 

Users can now add `ibm` in `output_fields`, which writes the IBM mask (`ep1`) alongside the existing snapshot fields. The user documentation is also updated to describe the new option and its requirements.

#### Changes

- Increase the supported snapshot field count to include one additional optional field
- Extend snapshot field selection so `ibm` is added when requested in `output_fields`
- Map the `ibm` snapshot field to `solver%ibm%ep1`
- Add a runtime check that stops with an error if `ibm` is requested while `ibm_on` is not enabled or the mask is unavailable
- Document the new `ibm` output field in the input-file reference, including that it is `1` in fluid cells and `0` in solid cells

Closes #259