### PR TITLE
Add species to snapshot output

### DIFF
--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -17,7 +17,7 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
      snapshot_prefix = "snapshot"
      snapshot_sp = .false.
      output_stride = 2, 2, 2
-     output_fields = 'pressure', 'vorticity', 'qcriterion'
+     output_fields = 'pressure', 'vorticity', 'qcriterion', 'species'
      restart_from_checkpoint = .false.
      restart_file = ""
    /End
@@ -43,12 +43,13 @@ These parameters are specified in the ``checkpoint_params`` namelist block in th
 ``output_stride``: Three-element array specifying the spatial stride (subsampling) in ``X``, ``Y``, and ``Z`` directions for visualisation snapshots. Using values greater than ``1`` reduces file size and increases I/O performance, but decreases visualisation resolution.
   **Default:** ``[1, 1, 1]``
 
-``output_fields``: List of additional derived fields to include in visualisation snapshots. Velocity components (``u``, ``v``, ``w``) are always written. Supported field names:
+``output_fields``: List of additional fields to include in visualisation snapshots. Velocity components (``u``, ``v``, ``w``) are always written. Supported field names:
 
   - ``'pressure'`` — Pressure field, interpolated from its native cell-centred grid to the vertex grid for ParaView compatibility. Not included in checkpoint files since it is recomputed from velocity.
   - ``'vorticity'`` — Vorticity magnitude :math:`|\omega| = \sqrt{\omega_x^2 + \omega_y^2 + \omega_z^2}`, computed from the full velocity gradient tensor.
   - ``'qcriterion'`` — Q-criterion :math:`Q = -\frac{1}{2} \sum_{ij} \frac{\partial u_i}{\partial x_j} \frac{\partial u_j}{\partial x_i}`, identifying vortical structures (positive Q indicates rotation-dominated regions).
   - ``'ibm'`` — Immersed boundary method mask field (``ep1``). Values are ``1`` in the fluid domain and ``0`` in the solid domain. Requires ``ibm_on = .true.`` in the input file.
+  - ``'species'`` — All transported species fields. In the input file, set ``n_species = N`` with ``N > 0`` and provide ``pr_species = ...`` in ``solver_params``, then add ``'species'`` to ``output_fields``. Snapshots then include ``phi_1`` through ``phi_N``.
 
   When both ``'vorticity'`` and ``'qcriterion'`` are requested, the velocity gradient tensor is computed only once.
   **Default:** (empty — only velocity is written)

--- a/src/config.f90
+++ b/src/config.f90
@@ -8,12 +8,10 @@ module m_config
 
   integer, parameter :: n_species_max = 99
 
-  !! Maximum number of additional (non-mandatory) output fields in a snapshot
+  !! Maximum number of additional snapshot output fields accepted from the
+  !! input file. Some entries, such as ``species``, can expand to multiple
+  !! written snapshot fields.
   integer, parameter :: MAX_OUTPUT_FIELDS = 10
-  !! Total number of possible snapshot fields: 3 mandatory (u,v,w) + 4 optional
-  !! (pressure, vorticity, qcriterion, ibm mask). Must be updated if new optional fields
-  !! are added to get_snapshot_fields in snapshot_manager.f90.
-  integer, parameter :: NUM_SNAPSHOT_FIELDS = 7
 
   type, abstract :: base_config_t
     !! All config types have a method read to initialise their data
@@ -78,7 +76,7 @@ module m_config
     character(len=256) :: restart_file = ""
     integer, dimension(3) :: output_stride = [2, 2, 2]     !! Spatial stride for snapshot output
     logical :: snapshot_sp = .false.                       !! if true, snapshot in single precision
-    character(len=32) :: output_fields(MAX_OUTPUT_FIELDS) = '' !! additional fields for snapshot output
+    character(len=32) :: output_fields(MAX_OUTPUT_FIELDS) = '' !! additional snapshot output fields
   contains
     procedure :: read => read_checkpoint_nml
   end type checkpoint_config_t
@@ -376,4 +374,3 @@ contains
   end function has_output_field
 
 end module m_config
-

--- a/src/io/io_field_utils.f90
+++ b/src/io/io_field_utils.f90
@@ -264,6 +264,29 @@ contains
       )
   end subroutine generate_coordinates
 
+  logical function parse_species_snapshot_field(field_name, species_index)
+    !! Parse snapshot field names of the form ``phi_N``.
+    character(len=*), intent(in) :: field_name
+    integer, intent(out) :: species_index
+
+    integer :: field_name_len, ios
+
+    parse_species_snapshot_field = .false.
+    species_index = 0
+
+    field_name_len = len_trim(field_name)
+    if (field_name_len <= 4) return
+    if (field_name(1:4) /= 'phi_') return
+
+    read (field_name(5:field_name_len), *, iostat=ios) species_index
+    if (ios /= 0 .or. species_index < 1) then
+      species_index = 0
+      return
+    end if
+
+    parse_species_snapshot_field = .true.
+  end function parse_species_snapshot_field
+
   subroutine setup_field_arrays( &
     solver, field_names, field_ptrs, host_fields &
     )
@@ -271,64 +294,85 @@ contains
     character(len=*), dimension(:), intent(in) :: field_names
     type(field_ptr_t), allocatable, intent(out) :: field_ptrs(:)
     type(field_ptr_t), allocatable, intent(out) :: host_fields(:)
-    integer :: i, num_fields
+    integer :: i, num_fields, species_index
+    character(len=32) :: field_name
 
     num_fields = size(field_names)
     allocate (field_ptrs(num_fields))
     allocate (host_fields(num_fields))
 
     do i = 1, num_fields
-      select case (trim(field_names(i)))
-      case ("u")
-        field_ptrs(i)%ptr => solver%u
-      case ("v")
-        field_ptrs(i)%ptr => solver%v
-      case ("w")
-        field_ptrs(i)%ptr => solver%w
-      case ("p")
-        if (.not. associated(solver%pressure_vert)) then
+      field_name = trim(field_names(i))
+
+      if (parse_species_snapshot_field(field_name, species_index)) then
+        if (species_index > solver%nspecies .or. .not. associated(solver%species)) then
           if (solver%mesh%par%is_root()) then
-            print *, 'ERROR: pressure_vert not computed. &
-                     &Call compute_pressure_vert before writing snapshots.'
+            print *, 'ERROR: Species snapshot field out of range: ', &
+                     trim(field_name)
           end if
           error stop 1
         end if
-        field_ptrs(i)%ptr => solver%pressure_vert
-      case ("vort")
-        if (.not. associated(solver%vort)) then
+        if (.not. associated(solver%species(species_index)%ptr)) then
           if (solver%mesh%par%is_root()) then
-            print *, 'ERROR: vorticity not computed. &
-                     &Enable output_vorticity and &
-                     &ensure snapshot_freq > 0.'
+            print *, 'ERROR: Species field not available: ', &
+                     trim(field_name)
           end if
           error stop 1
         end if
-        field_ptrs(i)%ptr => solver%vort
-      case ("qcrit")
-        if (.not. associated(solver%qcrit)) then
+        field_ptrs(i)%ptr => solver%species(species_index)%ptr
+      else
+        select case (field_name)
+        case ("u")
+          field_ptrs(i)%ptr => solver%u
+        case ("v")
+          field_ptrs(i)%ptr => solver%v
+        case ("w")
+          field_ptrs(i)%ptr => solver%w
+        case ("p")
+          if (.not. associated(solver%pressure_vert)) then
+            if (solver%mesh%par%is_root()) then
+              print *, 'ERROR: pressure_vert not computed. &
+                       &Call compute_pressure_vert before writing snapshots.'
+            end if
+            error stop 1
+          end if
+          field_ptrs(i)%ptr => solver%pressure_vert
+        case ("vort")
+          if (.not. associated(solver%vort)) then
+            if (solver%mesh%par%is_root()) then
+              print *, 'ERROR: vorticity not computed. &
+                       &Enable output_vorticity and &
+                       &ensure snapshot_freq > 0.'
+            end if
+            error stop 1
+          end if
+          field_ptrs(i)%ptr => solver%vort
+        case ("qcrit")
+          if (.not. associated(solver%qcrit)) then
+            if (solver%mesh%par%is_root()) then
+              print *, 'ERROR: Q-criterion not computed. &
+                       &Enable output_qcriterion and &
+                       &ensure snapshot_freq > 0.'
+            end if
+            error stop 1
+          end if
+          field_ptrs(i)%ptr => solver%qcrit
+        case ("ibm")
+          if (.not. solver%ibm_on .or. .not. associated(solver%ibm%ep1)) then
+            if (solver%mesh%par%is_root()) then
+              print *, 'ERROR: IBM mask not available. &
+                       &Enable ibm_on in the input file.'
+            end if
+            error stop 1
+          end if
+          field_ptrs(i)%ptr => solver%ibm%ep1
+        case default
           if (solver%mesh%par%is_root()) then
-            print *, 'ERROR: Q-criterion not computed. &
-                     &Enable output_qcriterion and &
-                     &ensure snapshot_freq > 0.'
+            print *, 'ERROR: Unknown field name: ', trim(field_name)
           end if
           error stop 1
-        end if
-        field_ptrs(i)%ptr => solver%qcrit
-      case ("ibm")
-        if (.not. solver%ibm_on .or. .not. associated(solver%ibm%ep1)) then
-          if (solver%mesh%par%is_root()) then
-            print *, 'ERROR: IBM mask not available. &
-                     &Enable ibm_on in the input file.'
-          end if
-          error stop 1
-        end if
-        field_ptrs(i)%ptr => solver%ibm%ep1
-      case default
-        if (solver%mesh%par%is_root()) then
-          print *, 'ERROR: Unknown field name: ', trim(field_names(i))
-        end if
-        error stop 1
-      end select
+        end select
+      end if
     end do
 
     do i = 1, num_fields

--- a/src/io/io_field_utils.f90
+++ b/src/io/io_field_utils.f90
@@ -305,17 +305,18 @@ contains
       field_name = trim(field_names(i))
 
       if (parse_species_snapshot_field(field_name, species_index)) then
-        if (species_index > solver%nspecies .or. .not. associated(solver%species)) then
+        if (species_index > solver%nspecies .or. &
+            .not. associated(solver%species)) then
           if (solver%mesh%par%is_root()) then
             print *, 'ERROR: Species snapshot field out of range: ', &
-                     trim(field_name)
+              trim(field_name)
           end if
           error stop 1
         end if
         if (.not. associated(solver%species(species_index)%ptr)) then
           if (solver%mesh%par%is_root()) then
             print *, 'ERROR: Species field not available: ', &
-                     trim(field_name)
+              trim(field_name)
           end if
           error stop 1
         end if

--- a/src/io/snapshot_manager.f90
+++ b/src/io/snapshot_manager.f90
@@ -11,8 +11,7 @@ module m_snapshot_manager
   use m_field, only: field_t
   use m_solver, only: solver_t
   use m_io_session, only: writer_session_t
-  use m_config, only: checkpoint_config_t, has_output_field, &
-                      NUM_SNAPSHOT_FIELDS
+  use m_config, only: checkpoint_config_t, has_output_field
   use m_io_field_utils, only: field_buffer_map_t, field_ptr_t, &
                               setup_field_arrays, cleanup_field_arrays, &
                               stride_data_to_buffer, get_output_dimensions, &
@@ -31,7 +30,7 @@ module m_snapshot_manager
     integer(i8), dimension(3) :: last_shape_dims = 0
     integer, dimension(3) :: last_stride_factors = 0
     integer(i8), dimension(3) :: last_output_shape = 0
-    character(len=4096) :: vtk_xml = ""
+    character(len=:), allocatable :: vtk_xml
     logical :: is_snapshot_file_open = .false.
     type(writer_session_t) :: snapshot_writer
     logical :: convert_to_sp = .false.              !! Flag for single precision snapshots
@@ -126,10 +125,19 @@ contains
     if (self%config%snapshot_freq <= 0) return
     if (mod(timestep, self%config%snapshot_freq) /= 0) return
 
-    allocate (field_names(0))
-    field_names = get_snapshot_fields(self%config)
-
     call MPI_Comm_rank(comm, myrank, ierr)
+
+    if (has_output_field(self%config, 'species')) then
+      if (solver%nspecies <= 0) then
+        if (myrank == 0) then
+          print *, 'ERROR: species snapshot output requested, &
+                   &but no transported species are configured.'
+        end if
+        error stop 1
+      end if
+    end if
+
+    field_names = get_snapshot_fields(self%config, solver%nspecies)
 
     write (filename, '(A,A)') trim(self%config%snapshot_prefix), '.bp'
 
@@ -187,29 +195,51 @@ contains
     deallocate (field_names)
   end subroutine write_snapshot
 
-  function get_snapshot_fields(config) result(names)
-    !! Build the list of field names for snapshot output
+  function get_snapshot_fields(config, nspecies) result(names)
+    !! Build the list of field names written to each snapshot.
     type(checkpoint_config_t), intent(in) :: config
+    integer, intent(in) :: nspecies
     character(len=32), allocatable :: names(:)
 
-    character(len=32) :: tmp(NUM_SNAPSHOT_FIELDS)
-    integer :: n
+    integer :: n, num_fields, is
+    logical :: include_pressure, include_vorticity
+    logical :: include_qcriterion, include_ibm, include_species
+
+    include_pressure = has_output_field(config, 'pressure')
+    include_vorticity = has_output_field(config, 'vorticity')
+    include_qcriterion = has_output_field(config, 'qcriterion')
+    include_ibm = has_output_field(config, 'ibm')
+    include_species = has_output_field(config, 'species')
+
+    num_fields = 3
+    if (include_pressure) num_fields = num_fields + 1
+    if (include_vorticity) num_fields = num_fields + 1
+    if (include_qcriterion) num_fields = num_fields + 1
+    if (include_ibm) num_fields = num_fields + 1
+    if (include_species) num_fields = num_fields + nspecies
+
+    allocate (names(num_fields))
 
     n = 3
-    tmp(1:3) = [character(len=32) :: "u", "v", "w"]
-    if (has_output_field(config, 'pressure')) then
-      n = n + 1; tmp(n) = "p"
+    names(1:3) = [character(len=32) :: "u", "v", "w"]
+    if (include_pressure) then
+      n = n + 1; names(n) = "p"
     end if
-    if (has_output_field(config, 'vorticity')) then
-      n = n + 1; tmp(n) = "vort"
+    if (include_vorticity) then
+      n = n + 1; names(n) = "vort"
     end if
-    if (has_output_field(config, 'qcriterion')) then
-      n = n + 1; tmp(n) = "qcrit"
+    if (include_qcriterion) then
+      n = n + 1; names(n) = "qcrit"
     end if
-    if (has_output_field(config, 'ibm')) then
-      n = n + 1; tmp(n) = "ibm"
+    if (include_ibm) then
+      n = n + 1; names(n) = "ibm"
     end if
-    names = tmp(1:n)
+    if (include_species) then
+      do is = 1, nspecies
+        n = n + 1
+        write (names(n), '(A,I0)') 'phi_', is
+      end do
+    end if
   end function get_snapshot_fields
 
   subroutine generate_vtk_xml(self, dims, fields, origin, spacing)
@@ -219,7 +249,7 @@ contains
     character(len=*), dimension(:), intent(in) :: fields
     real(dp), dimension(3), intent(in) :: origin, spacing
 
-    character(len=4096) :: xml
+    character(len=:), allocatable :: xml
     character(len=96) :: extent_str, origin_str, spacing_str
     integer :: i
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ define_test(unit/test_vecadd.f90 1 omp)
 define_test(unit/test_scalar_product.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(unit/test_sum_intox.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(unit/test_setget_field.f90 1 omp)
+define_test(unit/test_snapshot_species_fields.f90 1 omp)
 define_test(unit/test_statistics.f90 1 omp)
 
 if(WITH_ADIOS2)

--- a/tests/unit/test_snapshot_species_fields.f90
+++ b/tests/unit/test_snapshot_species_fields.f90
@@ -1,0 +1,150 @@
+program test_snapshot_species_fields
+  use iso_fortran_env, only: stderr => error_unit
+  use mpi
+
+  use m_allocator, only: allocator_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, DIR_X, VERT
+  use m_io_field_utils, only: field_ptr_t, setup_field_arrays, &
+                              cleanup_field_arrays
+  use m_mesh, only: mesh_t
+  use m_omp_backend, only: omp_backend_t
+  use m_omp_common, only: SZ
+  use m_solver, only: solver_t
+
+  implicit none
+
+  integer, parameter :: nspecies = 2
+  real(dp), parameter :: tol = 1.0e-12_dp
+
+  type(mesh_t), target :: mesh
+  type(allocator_t), target :: omp_allocator
+  class(allocator_t), pointer :: allocator
+  type(omp_backend_t), target :: omp_backend
+  class(base_backend_t), pointer :: backend
+  type(solver_t) :: solver
+  type(field_ptr_t), allocatable :: field_ptrs(:), host_fields(:)
+  character(len=32) :: field_names(3)
+
+  integer :: ierr, irank
+  integer :: dims(3)
+  logical :: allpass
+
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
+
+  allpass = .true.
+
+  mesh = mesh_t([4, 4, 4], [1, 1, 1], [1.0_dp, 1.0_dp, 1.0_dp], &
+                ['periodic', 'periodic'], &
+                ['periodic', 'periodic'], &
+                ['periodic', 'periodic'])
+
+  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
+  allocator => omp_allocator
+  omp_backend = omp_backend_t(mesh, allocator)
+  backend => omp_backend
+
+  call init_solver_with_species(solver, backend, mesh, allocator)
+
+  field_names = [character(len=32) :: 'u', 'phi_1', 'phi_2']
+  call setup_field_arrays(solver, field_names, field_ptrs, host_fields)
+
+  dims = mesh%get_dims(VERT)
+
+  if (maxval(abs(host_fields(1)%ptr%data(1:dims(1), 1:dims(2), 1:dims(3)) &
+                 - 11.0_dp)) > tol) then
+    allpass = .false.
+    if (irank == 0) print *, 'Velocity field was not copied correctly'
+  end if
+
+  if (maxval(abs(host_fields(2)%ptr%data(1:dims(1), 1:dims(2), 1:dims(3)) &
+                 - 101.0_dp)) > tol) then
+    allpass = .false.
+    if (irank == 0) print *, 'phi_1 was not mapped to species 1'
+  end if
+
+  if (maxval(abs(host_fields(3)%ptr%data(1:dims(1), 1:dims(2), 1:dims(3)) &
+                 - 202.0_dp)) > tol) then
+    allpass = .false.
+    if (irank == 0) print *, 'phi_2 was not mapped to species 2'
+  end if
+
+  call cleanup_field_arrays(solver, field_ptrs, host_fields)
+  call release_solver_fields(solver)
+
+  call MPI_Finalize(ierr)
+
+  if (irank == 0) then
+    if (allpass) then
+      write (stderr, '(a)') 'Snapshot species field test passed.'
+    else
+      error stop 'Snapshot species field test failed.'
+    end if
+  end if
+
+contains
+
+  subroutine init_solver_with_species(solver, backend, mesh, allocator)
+    type(solver_t), intent(inout) :: solver
+    class(base_backend_t), pointer, intent(inout) :: backend
+    type(mesh_t), target, intent(inout) :: mesh
+    class(allocator_t), pointer, intent(inout) :: allocator
+
+    integer :: is
+
+    solver%backend => backend
+    solver%mesh => mesh
+    solver%host_allocator => allocator
+    solver%nvars = 3 + nspecies
+    solver%nspecies = nspecies
+    solver%ngrid = product(mesh%get_global_dims(VERT))
+
+    solver%u => allocator%get_block(DIR_X)
+    solver%v => allocator%get_block(DIR_X)
+    solver%w => allocator%get_block(DIR_X)
+    call solver%u%set_data_loc(VERT)
+    call solver%v%set_data_loc(VERT)
+    call solver%w%set_data_loc(VERT)
+    call solver%u%fill(11.0_dp)
+    call solver%v%fill(22.0_dp)
+    call solver%w%fill(33.0_dp)
+
+    allocate (solver%species(nspecies))
+    do is = 1, nspecies
+      solver%species(is)%ptr => allocator%get_block(DIR_X)
+      call solver%species(is)%ptr%set_data_loc(VERT)
+      call solver%species(is)%ptr%fill(real(101*is, dp))
+    end do
+  end subroutine init_solver_with_species
+
+  subroutine release_solver_fields(solver)
+    type(solver_t), intent(inout) :: solver
+
+    integer :: is
+
+    if (associated(solver%backend)) then
+      if (associated(solver%u)) &
+        call solver%backend%allocator%release_block(solver%u)
+      if (associated(solver%v)) &
+        call solver%backend%allocator%release_block(solver%v)
+      if (associated(solver%w)) &
+        call solver%backend%allocator%release_block(solver%w)
+
+      if (associated(solver%species)) then
+        do is = 1, size(solver%species)
+          if (associated(solver%species(is)%ptr)) then
+            call solver%backend%allocator%release_block(solver%species(is)%ptr)
+          end if
+        end do
+        deallocate (solver%species)
+      end if
+    end if
+
+    nullify (solver%u)
+    nullify (solver%v)
+    nullify (solver%w)
+    nullify (solver%species)
+  end subroutine release_solver_fields
+
+end program test_snapshot_species_fields


### PR DESCRIPTION
When `output_fields` includes `species`, snapshot writing now expands that entry into `phi_1` through `phi_N` based on `n_species`.

#### Changes
- add `species`  to `output_fields`
- build the snapshot field list at runtime so species output scales with `n_species`
- write transported species to snapshots as `phi_1`, `phi_2`, ..., `phi_N`
- map `phi_N` snapshot fields to `solver%species(N)` in the field setup path
- add runtime validation for invalid species snapshot requests, including the case `n_species <= 0`
- replace fixed-size VTK XML buffers with allocatable strings to avoid hard-coded size limits when many species are written
- add a unit test covering `phi_N` field mapping for snapshot output

Closes #298 