### PR TITLE
capture fprettify stderr in GitHub Actions check

### DIFF
--- a/.github/workflows/check_policies.yml
+++ b/.github/workflows/check_policies.yml
@@ -15,7 +15,7 @@ jobs:
         id: fprettify-check
         run: |
           echo "Running fprettify..."
-          FPRETTIFY_OUTPUT=$(fprettify --config .fprettify.ini --diff --recursive src)
+          FPRETTIFY_OUTPUT=$(fprettify --config .fprettify.ini --diff --recursive src 2>&1)
           echo "$FPRETTIFY_OUTPUT"
           {
             echo "fprettify_output<<EOF"


### PR DESCRIPTION
The fprettify check in GitHub Actions was passing and GitLab is failing because
fprettify writes its failing line split WARNINGs output to stderr, which was not being captured
by the $() command substitution.

Fix by redirecting stderr to stdout with 2>&1:
```
- FPRETTIFY_OUTPUT=$(fprettify --config .fprettify.ini --diff --recursive src)
+ FPRETTIFY_OUTPUT=$(fprettify --config .fprettify.ini --diff --recursive src 2>&1)
```
It requires a lot of extra effort from user and it is not just a "safe" warning which is not ideal 

Closes #304 