### PR TITLE
Add per timestep execution time report

### DIFF
--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -5,7 +5,7 @@ module m_base_case
 
   use m_allocator, only: allocator_t
   use m_base_backend, only: base_backend_t
-  use m_common, only: dp, DIR_X, DIR_C, VERT
+  use m_common, only: dp, DIR_X, DIR_C, VERT, MPI_X3D2_DP
   use m_monitoring, only: monitoring_t
   use m_field, only: field_t, flist_t
   use m_mesh, only: mesh_t
@@ -13,7 +13,7 @@ module m_base_case
   use m_postprocess, only: compute_derived_fields, compute_pressure_vert
   use m_config, only: has_output_field
   use m_io_manager, only: io_manager_t
-  use mpi, only: MPI_COMM_WORLD
+  use mpi, only: MPI_COMM_WORLD, MPI_Wtime, MPI_Reduce, MPI_MAX
 
   implicit none
 
@@ -161,7 +161,7 @@ contains
 
   end subroutine set_init
 
-  subroutine run(self)
+subroutine run(self)
     !! Runs the solver forwards in time from t=t_0 to t=T, performing
     !! postprocessing/IO and reporting diagnostics.
     implicit none
@@ -174,9 +174,10 @@ contains
     real(dp) :: t
     integer :: i, iter, sub_iter, start_iter
     logical :: output_vorticity, output_qcriterion
-    real(dp) :: t_start, t_step0, t_step1, t_end
-    real(dp) :: t_total
-    logical :: do_report
+    real(dp) :: t_start, t_end, t_total_local, t_total
+    real(dp) :: t_step0, t_step1, t_step_local, t_step
+    logical :: do_timing_report, is_root
+    integer :: ierr
 
     output_vorticity = &
       has_output_field(self%io_mgr%snapshot_mgr%config, 'vorticity') &
@@ -191,6 +192,10 @@ contains
         ! for restarts current_iter is read from the checkpoint file
         print *, 'Continuing from iteration:', &
         self%solver%current_iter, 'at time ', t
+      if (self%solver%n_iters <= self%solver%current_iter) then
+        error stop &
+          'Restart requires n_iters greater than the restart iteration.'
+      end if
     else
       self%solver%current_iter = 0
       if (self%solver%mesh%par%is_root()) print *, 'initial conditions'
@@ -212,18 +217,23 @@ contains
       curr(3 + i)%ptr => self%solver%species(i)%ptr
     end do
 
-    call cpu_time(t_start)
+    is_root = self%solver%mesh%par%is_root()
+    t_start = MPI_Wtime()
 
     do iter = start_iter, self%solver%n_iters
-      ! nested guard so mod() is never evaluated when n_output == 0
-      do_report = (iter == start_iter .or. iter == self%solver%n_iters)
+      ! Report per-step timing on the final step and on every n_output-th
+      ! step. This is computed identically on every rank so that the
+      ! reduction below stays collective; the nested guard keeps mod()
+      ! from being evaluated when n_output is 0.
+      do_timing_report = (iter == self%solver%n_iters)
       if (self%solver%n_output > 0) then
-        if (mod(iter, self%solver%n_output) == 0) do_report = .true.
+        if (mod(iter, self%solver%n_output) == 0) do_timing_report = .true.
       end if
-      do_report = do_report .and. self%solver%mesh%par%is_root()
 
-      if (do_report) then
-        call cpu_time(t_step0)
+      ! Skip the first step: it carries one-off setup costs that would
+      ! make the per-step figure unrepresentative.
+      if (do_timing_report .and. iter > start_iter) then
+        t_step0 = MPI_Wtime()
       end if
       do sub_iter = 1, self%solver%time_integrator%nstage
         ! first apply case-specific BCs
@@ -255,6 +265,20 @@ contains
                                              self%solver%w)
       end do
 
+      ! All ranks measure and reduce; only root prints. Gating the
+      ! measurement on is_root would break the collective MPI_Reduce.
+      if (do_timing_report .and. iter > start_iter) then
+        t_step1 = MPI_Wtime()
+        t_step_local = t_step1 - t_step0
+
+        call MPI_Reduce(t_step_local, t_step, 1, MPI_X3D2_DP, MPI_MAX, &
+                        0, MPI_COMM_WORLD, ierr)
+
+        if (is_root) then
+          print *, 'Time for this time step (s):', real(t_step, 4)
+        end if
+      end if
+
       self%solver%current_iter = iter
 
       ! Compute pressure on VERT grid if output_pressure is enabled
@@ -283,9 +307,13 @@ contains
     end do
 
     ! total + averaged-per-step over the whole run
-    call cpu_time(t_end)
-    t_total = t_end - t_start
-    if (self%solver%mesh%par%is_root()) then
+    t_end = MPI_Wtime()
+    t_total_local = t_end - t_start
+
+    call MPI_Reduce(t_total_local, t_total, 1, MPI_X3D2_DP, MPI_MAX, &
+                    0, MPI_COMM_WORLD, ierr)
+
+    if (is_root) then
       print *, '==========================================================='
       print *, 'Averaged time per step (s):', &
         real(t_total/(self%solver%n_iters - (start_iter - 1)), 4)

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -222,6 +222,9 @@ contains
     real(dp) :: t
     integer :: i, iter, sub_iter, start_iter
     logical :: output_vorticity, output_qcriterion
+    real(dp) :: t_start, t_step0, t_step1, t_end
+    real(dp) :: t_total
+    logical  :: do_report
 
     output_vorticity = &
       has_output_field(self%io_mgr%snapshot_mgr%config, 'vorticity') &
@@ -257,7 +260,19 @@ contains
       curr(3 + i)%ptr => self%solver%species(i)%ptr
     end do
 
+    call cpu_time(t_start)
+    
     do iter = start_iter, self%solver%n_iters
+      ! nested guard so mod() is never evaluated when n_output == 0
+      do_report = (iter == start_iter .or. iter == self%solver%n_iters)
+      if (self%solver%n_output > 0) then
+        if (mod(iter, self%solver%n_output) == 0) do_report = .true.
+      end if
+      do_report = do_report .and. self%solver%mesh%par%is_root()
+      
+      if (do_report) then
+        call cpu_time(t_step0)
+      end if
       do sub_iter = 1, self%solver%time_integrator%nstage
         ! first apply case-specific BCs
         call self%boundary_conditions()
@@ -304,16 +319,28 @@ contains
 
       call self%io_mgr%update_stats(self%solver, iter)
 
-      if (mod(iter, self%solver%n_output) == 0) then
+        ! guard skips the first step and avoids the divide-by-zero in the ETA.
+      if (do_report .and. iter > start_iter) then
+        call cpu_time(t_step1)
+        print *, 'Time for this time step (s):', real(t_step1 - t_step0)
         t = iter*self%solver%dt
-
         call self%postprocess(iter, t)
       end if
-
       call self%io_mgr%handle_io_step(self%solver, &
                                       iter, MPI_COMM_WORLD)
     end do
 
+    ! total + averaged-per-step over the whole run
+    call cpu_time(t_end)
+    t_total = t_end - t_start
+    if (self%solver%mesh%par%is_root()) then
+      print *, '==========================================================='
+      print *, 'Averaged time per step (s):', &
+        real(t_total/(self%solver%n_iters - (start_iter - 1)), 4)
+      print *, 'Total wallclock (s):', real(t_total, 4)
+      print *, 'Total wallclock (m):', real(t_total/60.0_dp, 4)
+      print *, 'Total wallclock (h):', real(t_total/3600.0_dp, 4)
+    end if
     call self%case_finalise
 
     ! deallocate memory

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -224,7 +224,7 @@ contains
     logical :: output_vorticity, output_qcriterion
     real(dp) :: t_start, t_step0, t_step1, t_end
     real(dp) :: t_total
-    logical  :: do_report
+    logical :: do_report
 
     output_vorticity = &
       has_output_field(self%io_mgr%snapshot_mgr%config, 'vorticity') &
@@ -261,7 +261,7 @@ contains
     end do
 
     call cpu_time(t_start)
-    
+
     do iter = start_iter, self%solver%n_iters
       ! nested guard so mod() is never evaluated when n_output == 0
       do_report = (iter == start_iter .or. iter == self%solver%n_iters)
@@ -269,7 +269,7 @@ contains
         if (mod(iter, self%solver%n_output) == 0) do_report = .true.
       end if
       do_report = do_report .and. self%solver%mesh%par%is_root()
-      
+
       if (do_report) then
         call cpu_time(t_step0)
       end if
@@ -319,7 +319,7 @@ contains
 
       call self%io_mgr%update_stats(self%solver, iter)
 
-        ! guard skips the first step and avoids the divide-by-zero in the ETA.
+      ! guard skips the first step and avoids the divide-by-zero in the ETA.
       if (do_report .and. iter > start_iter) then
         call cpu_time(t_step1)
         print *, 'Time for this time step (s):', real(t_step1 - t_step0)

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -161,7 +161,7 @@ contains
 
   end subroutine set_init
 
-subroutine run(self)
+  subroutine run(self)
     !! Runs the solver forwards in time from t=t_0 to t=T, performing
     !! postprocessing/IO and reporting diagnostics.
     implicit none
@@ -174,8 +174,11 @@ subroutine run(self)
     real(dp) :: t
     integer :: i, iter, sub_iter, start_iter
     logical :: output_vorticity, output_qcriterion
-    real(dp) :: t_start, t_end, t_total_local, t_total
-    real(dp) :: t_step0, t_step1, t_step_local, t_step
+    ! t_start/t_end/t_step0/t_step1 hold raw MPI_Wtime readings, which
+    ! are double precision; subtract in double, then convert
+    ! it to the working precision.
+    double precision :: t_start, t_end, t_step0, t_step1
+    real(dp) :: t_total_local, t_total, t_step_local, t_step
     logical :: do_timing_report, is_root
     integer :: ierr
 
@@ -272,7 +275,7 @@ subroutine run(self)
       ! measurement on is_root would break the collective MPI_Reduce.
       if (do_timing_report .and. iter > start_iter) then
         t_step1 = MPI_Wtime()
-        t_step_local = t_step1 - t_step0
+        t_step_local = real(t_step1 - t_step0, 4)
 
         call MPI_Reduce(t_step_local, t_step, 1, MPI_X3D2_DP, MPI_MAX, &
                         0, MPI_COMM_WORLD, ierr)
@@ -311,7 +314,7 @@ subroutine run(self)
 
     ! total + averaged-per-step over the whole run
     t_end = MPI_Wtime()
-    t_total_local = t_end - t_start
+    t_total_local = real(t_end - t_start, 4)
 
     call MPI_Reduce(t_total_local, t_total, 1, MPI_X3D2_DP, MPI_MAX, &
                     0, MPI_COMM_WORLD, ierr)

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -179,6 +179,9 @@ subroutine run(self)
     logical :: do_timing_report, is_root
     integer :: ierr
 
+    ! Error: ‘t_step0’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+    t_step0 = 0.0_dp
+
     output_vorticity = &
       has_output_field(self%io_mgr%snapshot_mgr%config, 'vorticity') &
       .and. self%io_mgr%snapshot_mgr%config%snapshot_freq > 0

--- a/src/xcompact.f90
+++ b/src/xcompact.f90
@@ -39,8 +39,6 @@ program xcompact
 
   type(allocator_t), target :: omp_allocator
 
-  real(dp) :: t_start, t_end
-
   type(domain_config_t) :: domain_cfg
   type(solver_config_t) :: solver_cfg
   character(32) :: backend_name
@@ -128,13 +126,7 @@ program xcompact
   end select
   if (nrank == 0) print *, 'solver instantiated'
 
-  call cpu_time(t_start)
-
   call flow_case%run()
-
-  call cpu_time(t_end)
-
-  if (nrank == 0) print *, 'Time: ', t_end - t_start
 
   call MPI_Finalize(ierr)
 


### PR DESCRIPTION
Adding per timestep average execution time printing like Incompact3d, 
`do_report` condition is set according to the input file variables so we only print every `nth` iteration
The printed `Time for this time step (s)` is the execution time of that one single iteration on which the report fires.