### PR TITLE
Add extensible checkpoint and scalar output support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRC
   solver.f90
   postprocess/postprocess.f90
   postprocess/monitoring.f90
+  postprocess/scalar_series.f90
   tdsops.f90
   time_integrator.f90
   ordering.f90
@@ -61,6 +62,7 @@ set(IOSRC
   io/io_session.f90
   io/io_field_utils.f90
   io/checkpoint_manager.f90
+  io/checkpoint_state.f90
   io/snapshot_manager.f90
   io/stats.f90
   io/io_manager.f90

--- a/src/io/checkpoint_manager.f90
+++ b/src/io/checkpoint_manager.f90
@@ -21,6 +21,7 @@ module m_checkpoint_manager
   use m_solver, only: solver_t
   use m_io_session, only: reader_session_t, writer_session_t
   use m_config, only: checkpoint_config_t
+  use m_checkpoint_state, only: checkpoint_state_t
   use m_stats, only: stats_manager_t
   use m_io_field_utils, only: field_buffer_map_t, field_ptr_t, &
                               setup_field_arrays, cleanup_field_arrays, &
@@ -49,6 +50,7 @@ module m_checkpoint_manager
     procedure :: init
     procedure :: handle_restart
     procedure :: handle_checkpoint_step
+    procedure :: restore_state
     procedure :: is_restart
     procedure :: finalise
     procedure, private :: write_checkpoint
@@ -124,29 +126,37 @@ contains
     end if
   end subroutine handle_restart
 
-  subroutine handle_checkpoint_step(self, solver, timestep, comm, stats_mgr)
+  subroutine handle_checkpoint_step( &
+    self, solver, timestep, comm, stats_mgr, checkpoint_state &
+    )
     !! Handle checkpoint writing at a given timestep
     class(checkpoint_manager_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
     integer, intent(in) :: timestep
     integer, intent(in), optional :: comm
     type(stats_manager_t), intent(inout), optional :: stats_mgr
+    class(checkpoint_state_t), intent(inout), optional :: checkpoint_state
 
     integer :: comm_to_use
 
     comm_to_use = MPI_COMM_WORLD
     if (present(comm)) comm_to_use = comm
 
-    call self%write_checkpoint(solver, timestep, comm_to_use, stats_mgr)
+    call self%write_checkpoint( &
+      solver, timestep, comm_to_use, stats_mgr, checkpoint_state &
+      )
   end subroutine handle_checkpoint_step
 
-  subroutine write_checkpoint(self, solver, timestep, comm, stats_mgr)
+  subroutine write_checkpoint( &
+    self, solver, timestep, comm, stats_mgr, checkpoint_state &
+    )
     !! Write a checkpoint file for simulation restart
     class(checkpoint_manager_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
     integer, intent(in) :: timestep
     integer, intent(in) :: comm
     type(stats_manager_t), intent(inout), optional :: stats_mgr
+    class(checkpoint_state_t), intent(inout), optional :: checkpoint_state
 
     character(len=256) :: filename, temp_filename, old_filename
     integer :: ierr, myrank
@@ -204,6 +214,9 @@ contains
     ! Write stats running means into the same checkpoint
     if (present(stats_mgr)) then
       call stats_mgr%write_checkpoint(solver, writer_session)
+    end if
+    if (present(checkpoint_state)) then
+      call checkpoint_state%write_checkpoint(writer_session)
     end if
 
     ! for AB methods with order >1, keep derivative history olds(i,j)
@@ -315,6 +328,20 @@ contains
 
     self%last_checkpoint_step = timestep
   end subroutine write_checkpoint
+
+  subroutine restore_state(self, checkpoint_state, comm)
+    !! Restore registered case/model state after that object has been created.
+    class(checkpoint_manager_t), intent(inout) :: self
+    class(checkpoint_state_t), intent(inout) :: checkpoint_state
+    integer, intent(in) :: comm
+
+    type(reader_session_t) :: reader_session
+
+    if (.not. self%config%restart_from_checkpoint) return
+    call reader_session%open(trim(self%config%restart_file), comm)
+    call checkpoint_state%read_checkpoint(reader_session)
+    call reader_session%close()
+  end subroutine restore_state
 
   subroutine restart_checkpoint( &
     self, solver, filename, timestep, restart_time, comm, stats_mgr &

--- a/src/io/checkpoint_state.f90
+++ b/src/io/checkpoint_state.f90
@@ -1,0 +1,27 @@
+module m_checkpoint_state
+  !! Interface for case- or model-specific state stored in solver checkpoints.
+  use m_io_session, only: reader_session_t, writer_session_t
+
+  implicit none
+
+  type, abstract :: checkpoint_state_t
+  contains
+    procedure(write_checkpoint_iface), deferred :: write_checkpoint
+    procedure(read_checkpoint_iface), deferred :: read_checkpoint
+  end type checkpoint_state_t
+
+  abstract interface
+    subroutine write_checkpoint_iface(self, writer)
+      import :: checkpoint_state_t, writer_session_t
+      class(checkpoint_state_t), intent(inout) :: self
+      type(writer_session_t), intent(inout) :: writer
+    end subroutine write_checkpoint_iface
+
+    subroutine read_checkpoint_iface(self, reader)
+      import :: checkpoint_state_t, reader_session_t
+      class(checkpoint_state_t), intent(inout) :: self
+      type(reader_session_t), intent(inout) :: reader
+    end subroutine read_checkpoint_iface
+  end interface
+
+end module m_checkpoint_state

--- a/src/io/io_manager.f90
+++ b/src/io/io_manager.f90
@@ -9,6 +9,7 @@ module m_io_manager
 !! to the specialised checkpoint, snapshot, and statistics managers.
   use mpi, only: MPI_COMM_WORLD
   use m_checkpoint_manager, only: checkpoint_manager_t
+  use m_checkpoint_state, only: checkpoint_state_t
   use m_snapshot_manager, only: snapshot_manager_t
   use m_stats, only: stats_manager_t
   use m_solver, only: solver_t
@@ -22,11 +23,14 @@ module m_io_manager
     type(checkpoint_manager_t) :: checkpoint_mgr
     type(snapshot_manager_t) :: snapshot_mgr
     type(stats_manager_t) :: stats_mgr
+    class(checkpoint_state_t), pointer :: additional_checkpoint_state => null()
   contains
     procedure :: init => io_init
     procedure :: handle_restart => io_handle_restart
     procedure :: handle_io_step => io_handle_step
     procedure :: update_stats => io_update_stats
+    procedure :: register_checkpoint_state
+    procedure :: unregister_checkpoint_state
     procedure :: finalise => io_finalise
     procedure :: is_restart => io_is_restart
   end type io_manager_t
@@ -59,6 +63,25 @@ contains
     call self%stats_mgr%update(solver, iter)
   end subroutine io_update_stats
 
+  subroutine register_checkpoint_state(self, checkpoint_state, comm)
+    class(io_manager_t), intent(inout) :: self
+    class(checkpoint_state_t), target, intent(inout) :: checkpoint_state
+    integer, intent(in), optional :: comm
+
+    integer :: comm_to_use
+
+    comm_to_use = MPI_COMM_WORLD
+    if (present(comm)) comm_to_use = comm
+    self%additional_checkpoint_state => checkpoint_state
+    call self%checkpoint_mgr%restore_state(checkpoint_state, comm_to_use)
+  end subroutine register_checkpoint_state
+
+  subroutine unregister_checkpoint_state(self)
+    class(io_manager_t), intent(inout) :: self
+
+    nullify (self%additional_checkpoint_state)
+  end subroutine unregister_checkpoint_state
+
   subroutine io_handle_step(self, solver, timestep, comm)
     class(io_manager_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
@@ -70,9 +93,16 @@ contains
     comm_to_use = MPI_COMM_WORLD
     if (present(comm)) comm_to_use = comm
 
-    call self%checkpoint_mgr%handle_checkpoint_step( &
-      solver, timestep, comm_to_use, self%stats_mgr &
-      )
+    if (associated(self%additional_checkpoint_state)) then
+      call self%checkpoint_mgr%handle_checkpoint_step( &
+        solver, timestep, comm_to_use, self%stats_mgr, &
+        self%additional_checkpoint_state &
+        )
+    else
+      call self%checkpoint_mgr%handle_checkpoint_step( &
+        solver, timestep, comm_to_use, self%stats_mgr &
+        )
+    end if
     call self%snapshot_mgr%handle_snapshot_step(solver, timestep, comm_to_use)
     call self%stats_mgr%write_stats(solver, timestep, comm_to_use)
   end subroutine io_handle_step

--- a/src/postprocess/monitoring.f90
+++ b/src/postprocess/monitoring.f90
@@ -8,13 +8,14 @@ module m_monitoring
 
   use m_common, only: dp, DIR_X, DIR_Z, VERT
   use m_field, only: field_t
+  use m_scalar_series, only: scalar_series_t
   use m_solver, only: solver_t
 
   implicit none
 
   type :: monitoring_t
-    integer, private :: file_unit = -1
     logical, private :: is_root = .false.
+    type(scalar_series_t), private :: series
   contains
     procedure :: init
     procedure :: write_step
@@ -23,18 +24,22 @@ module m_monitoring
 
 contains
 
-  subroutine init(self, solver)
+  subroutine init(self, solver, append)
     class(monitoring_t), intent(inout) :: self
     class(solver_t), intent(in) :: solver
+    logical, intent(in), optional :: append
+
+    logical :: append_output
+    character(len=16), parameter :: columns(3) = &
+                                    ['enstrophy      ', &
+                                     'div_u_max      ', &
+                                     'div_u_mean     ']
 
     self%is_root = solver%mesh%par%is_root()
-
-    if (self%is_root) then
-      open (newunit=self%file_unit, file='monitoring.csv', &
-            status='replace', action='write')
-      write (self%file_unit, '(A)') &
-        '# time, enstrophy, div_u_max, div_u_mean'
-    end if
+    append_output = .false.
+    if (present(append)) append_output = append
+    call self%series%init('monitoring.csv', &
+                          columns, self%is_root, append_output)
 
   end subroutine init
 
@@ -79,9 +84,7 @@ contains
       print *, 'enstrophy:', enstrophy
       print *, 'div u max mean:', div_u_max, div_u_mean
 
-      write (self%file_unit, '(ES20.12,3(",",ES20.12))') &
-        t, enstrophy, div_u_max, div_u_mean
-      flush (self%file_unit)
+      call self%series%write_step(t, [enstrophy, div_u_max, div_u_mean])
     end if
 
   end subroutine write_step
@@ -89,10 +92,7 @@ contains
   subroutine finalise(self)
     class(monitoring_t), intent(inout) :: self
 
-    if (self%is_root .and. self%file_unit /= -1) then
-      close (self%file_unit)
-      self%file_unit = -1
-    end if
+    call self%series%finalise()
 
   end subroutine finalise
 

--- a/src/postprocess/scalar_series.f90
+++ b/src/postprocess/scalar_series.f90
@@ -1,0 +1,78 @@
+module m_scalar_series
+  !! Root-only writer for named scalar time series.
+  use m_common, only: dp
+
+  implicit none
+
+  private
+  public :: scalar_series_t
+
+  type :: scalar_series_t
+    integer, private :: file_unit = -1
+    integer, private :: n_columns = 0
+    logical, private :: is_root = .false.
+  contains
+    procedure :: init
+    procedure :: write_step
+    procedure :: finalise
+  end type scalar_series_t
+
+contains
+
+  subroutine init(self, filename, column_names, is_root, append)
+    class(scalar_series_t), intent(inout) :: self
+    character(len=*), intent(in) :: filename
+    character(len=*), intent(in) :: column_names(:)
+    logical, intent(in) :: is_root, append
+
+    integer :: i
+    logical :: exists
+
+    self%is_root = is_root
+    self%n_columns = size(column_names)
+    if (.not. is_root) return
+
+    inquire (file=filename, exist=exists)
+    if (append .and. exists) then
+      open (newunit=self%file_unit, file=filename, status='old', &
+            position='append', action='write')
+      return
+    end if
+
+    open (newunit=self%file_unit, file=filename, status='replace', &
+          action='write')
+    write (self%file_unit, '(A)', advance='no') '# time'
+    do i = 1, size(column_names)
+      write (self%file_unit, '(A)', advance='no') ', '//trim(column_names(i))
+    end do
+    write (self%file_unit, *)
+  end subroutine init
+
+  subroutine write_step(self, t, values)
+    class(scalar_series_t), intent(inout) :: self
+    real(dp), intent(in) :: t
+    real(dp), intent(in) :: values(:)
+
+    integer :: i
+
+    if (.not. self%is_root) return
+    if (size(values) /= self%n_columns) then
+      error stop 'Scalar series value count does not match its header.'
+    end if
+    write (self%file_unit, '(ES20.12)', advance='no') t
+    do i = 1, size(values)
+      write (self%file_unit, '(",",ES20.12)', advance='no') values(i)
+    end do
+    write (self%file_unit, *)
+    flush (self%file_unit)
+  end subroutine write_step
+
+  subroutine finalise(self)
+    class(scalar_series_t), intent(inout) :: self
+
+    if (self%is_root .and. self%file_unit /= -1) close (self%file_unit)
+    self%file_unit = -1
+    self%n_columns = 0
+  end subroutine finalise
+
+end module m_scalar_series

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ define_test(unit/test_sum_intox.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(unit/test_setget_field.f90 1 omp)
 define_test(unit/test_snapshot_species_fields.f90 1 omp)
 define_test(unit/test_statistics.f90 1 omp)
+define_test(unit/test_output_scalars.f90 1 omp)
 
 if(WITH_ADIOS2)
   define_test(unit/test_adios2_read_write.f90 4 omp)

--- a/tests/unit/test_output_scalars.f90
+++ b/tests/unit/test_output_scalars.f90
@@ -1,0 +1,216 @@
+program test_output_scalars
+  !! Unit tests for the scalar CSV output helper used by post-processing.
+  !!
+  !! These checks validate the file-writing behavior shared by scalar time
+  !! series outputs, including the infrastructure used by monitoring.csv.
+  use iso_fortran_env, only: stderr => error_unit, iostat_end
+  use mpi
+
+  use m_common, only: dp
+  use m_scalar_series, only: scalar_series_t
+
+  implicit none
+
+  integer :: ierr, irank
+
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
+
+  if (irank == 0) then
+    call test_root_writes_named_columns()
+    call test_append_adds_rows_without_header()
+    call test_non_root_is_noop()
+    write (stderr, '(a)') 'Output scalar tests passed.'
+  end if
+
+  call MPI_Finalize(ierr)
+
+contains
+
+  subroutine test_root_writes_named_columns()
+    !! Verify that a root writer creates a fresh CSV file with the requested
+    !! column names. The test writes two rows and reads them back to check both
+    !! the header formatting and numeric values.
+    type(scalar_series_t) :: series
+    character(len=*), parameter :: filename = 'test_output_scalars_write.csv'
+    character(len=128) :: header
+    integer :: unit, ios
+    real(dp) :: t, a, b, c
+
+    call remove_file(filename)
+
+    call series%init(filename, &
+                     [character(len=16) :: 'lift', 'drag', 'moment'], &
+                     is_root=.true., append=.false.)
+    call series%write_step(0.0_dp, [1.25_dp, -2.5_dp, 3.75_dp])
+    call series%write_step(0.5_dp, [4.0_dp, 5.5_dp, -6.25_dp])
+    call series%finalise()
+
+    open (newunit=unit, file=filename, status='old', action='read', iostat=ios)
+    call assert_iostat_ok(ios, 'open root output')
+
+    read (unit, '(A)', iostat=ios) header
+    call assert_iostat_ok(ios, 'read root header')
+    call assert_equal(trim(header), '# time, lift, drag, moment', &
+                      'root header')
+
+    read (unit, *, iostat=ios) t, a, b, c
+    call assert_iostat_ok(ios, 'read first root row')
+    call assert_close(t, 0.0_dp, 'first row time')
+    call assert_close(a, 1.25_dp, 'first row lift')
+    call assert_close(b, -2.5_dp, 'first row drag')
+    call assert_close(c, 3.75_dp, 'first row moment')
+
+    read (unit, *, iostat=ios) t, a, b, c
+    call assert_iostat_ok(ios, 'read second root row')
+    call assert_close(t, 0.5_dp, 'second row time')
+    call assert_close(a, 4.0_dp, 'second row lift')
+    call assert_close(b, 5.5_dp, 'second row drag')
+    call assert_close(c, -6.25_dp, 'second row moment')
+
+    read (unit, *, iostat=ios)
+    call assert_eof(ios, 'root output')
+    close (unit)
+
+    call remove_file(filename)
+  end subroutine test_root_writes_named_columns
+
+  subroutine test_append_adds_rows_without_header()
+    !! Verify append mode for an existing scalar output file. The first writer
+    !! creates the header and one row, then the second writer appends a row
+    !! without emitting a duplicate header.
+    type(scalar_series_t) :: series
+    character(len=*), parameter :: filename = 'test_output_scalars_append.csv'
+    character(len=128) :: header
+    integer :: unit, ios
+    real(dp) :: t, a, b
+
+    call remove_file(filename)
+
+    call series%init(filename, [character(len=16) :: 'ke', 'enstrophy'], &
+                     is_root=.true., append=.false.)
+    call series%write_step(1.0_dp, [10.0_dp, 20.0_dp])
+    call series%finalise()
+
+    call series%init(filename, [character(len=16) :: 'ke', 'enstrophy'], &
+                     is_root=.true., append=.true.)
+    call series%write_step(2.0_dp, [30.0_dp, 40.0_dp])
+    call series%finalise()
+
+    open (newunit=unit, file=filename, status='old', action='read', iostat=ios)
+    call assert_iostat_ok(ios, 'open append output')
+
+    read (unit, '(A)', iostat=ios) header
+    call assert_iostat_ok(ios, 'read append header')
+    call assert_equal(trim(header), '# time, ke, enstrophy', 'append header')
+
+    read (unit, *, iostat=ios) t, a, b
+    call assert_iostat_ok(ios, 'read first append row')
+    call assert_close(t, 1.0_dp, 'first append row time')
+    call assert_close(a, 10.0_dp, 'first append row ke')
+    call assert_close(b, 20.0_dp, 'first append row enstrophy')
+
+    read (unit, *, iostat=ios) t, a, b
+    call assert_iostat_ok(ios, 'read second append row')
+    call assert_close(t, 2.0_dp, 'second append row time')
+    call assert_close(a, 30.0_dp, 'second append row ke')
+    call assert_close(b, 40.0_dp, 'second append row enstrophy')
+
+    read (unit, *, iostat=ios)
+    call assert_eof(ios, 'append output')
+    close (unit)
+
+    call remove_file(filename)
+  end subroutine test_append_adds_rows_without_header
+
+  subroutine test_non_root_is_noop()
+    !! Verify that non-root ranks do not create or write scalar output files.
+    !! This mirrors the intended root-only behavior used during MPI runs.
+    type(scalar_series_t) :: series
+    character(len=*), parameter :: filename = 'test_output_scalars_nonroot.csv'
+    logical :: exists
+
+    call remove_file(filename)
+
+    call series%init(filename, [character(len=16) :: 'ignored'], &
+                     is_root=.false., append=.false.)
+    call series%write_step(1.0_dp, [99.0_dp])
+    call series%finalise()
+
+    inquire (file=filename, exist=exists)
+    if (exists) then
+      call remove_file(filename)
+      error stop 'non-root scalar series writer created a file'
+    end if
+  end subroutine test_non_root_is_noop
+
+  subroutine remove_file(filename)
+    !! Delete a test output file if it already exists. This keeps each test
+    !! independent of stale files from earlier failed or interrupted runs.
+    character(len=*), intent(in) :: filename
+
+    integer :: unit, ios
+    logical :: exists
+
+    inquire (file=filename, exist=exists)
+    if (.not. exists) return
+
+    open (newunit=unit, file=filename, status='old', action='readwrite', &
+          iostat=ios)
+    call assert_iostat_ok(ios, 'open file for cleanup')
+    close (unit, status='delete')
+  end subroutine remove_file
+
+  subroutine assert_equal(actual, expected, label)
+    !! Compare two strings and stop the test with a useful diagnostic if they
+    !! differ. The label identifies which output field or line failed.
+    character(len=*), intent(in) :: actual, expected, label
+
+    if (actual /= expected) then
+      write (stderr, '(a,": expected [",a,"], got [",a,"]")') &
+        trim(label), expected, actual
+      error stop 'scalar series string assertion failed'
+    end if
+  end subroutine assert_equal
+
+  subroutine assert_close(actual, expected, label)
+    !! Compare two floating-point values using a tight tolerance appropriate
+    !! for values written and read in this unit test. The label makes failures
+    !! point to the specific CSV row or column being checked.
+    real(dp), intent(in) :: actual, expected
+    character(len=*), intent(in) :: label
+
+    real(dp), parameter :: tol = 1.0e-12_dp
+
+    if (abs(actual - expected) > tol) then
+      write (stderr, '(a,": expected ",ES20.12,", got ",ES20.12)') &
+        trim(label), expected, actual
+      error stop 'scalar series numeric assertion failed'
+    end if
+  end subroutine assert_close
+
+  subroutine assert_iostat_ok(ios, label)
+    !! Check that a file operation completed successfully. Non-zero iostat
+    !! values are reported with context before stopping the test.
+    integer, intent(in) :: ios
+    character(len=*), intent(in) :: label
+
+    if (ios /= 0) then
+      write (stderr, '(a,": iostat=",i0)') trim(label), ios
+      error stop 'scalar series file operation failed'
+    end if
+  end subroutine assert_iostat_ok
+
+  subroutine assert_eof(ios, label)
+    !! Check that reading past the expected rows reaches end-of-file. This
+    !! catches accidental extra output, such as duplicate headers in append mode.
+    integer, intent(in) :: ios
+    character(len=*), intent(in) :: label
+
+    if (ios /= iostat_end) then
+      write (stderr, '(a,": expected EOF, iostat=",i0)') trim(label), ios
+      error stop 'scalar series output had unexpected extra data'
+    end if
+  end subroutine assert_eof
+
+end program test_output_scalars


### PR DESCRIPTION
#### Changes

- Add a reusable root-only writer for named scalar time-series data.
- Refactor `monitoring.csv` output to use the new writer.
- Support appending output when restarting a simulation.
- Add an interface for case- and model-specific checkpoint state.
- Allow the I/O manager to register and restore additional checkpoint state.
- Added a unit test for the scalar time-series output infrastructure

#### Motivation

Monitoring output was previously hard-coded for enstrophy and the maximum and mean velocity divergence. Some flow cases and models need additional scalar outputs, such as turbulent kinetic energy, dissipation, or turbine measurements.

The new scalar-series abstraction centralises CSV file handling while allowing each caller to select its filename and columns. Separate outputs therefore remain in separate files rather than being combined into `monitoring.csv`.

The checkpoint extension allows model-specific state to participate in normal checkpoint and restart operations without coupling the I/O layer to a particular flow case or model.

This PR does not change how monitoring is called, including the existing n_output > 0 condition. It only generalises the CSV-writing functionality.

We are not adding new columns to monitoring.csv. Instead, the PR introduces a reusable `scalar_series_t` writer, allowing users to write their own computed scalar values at each output time step to separate files with user-defined columns.

To add a new scalar, a case would compute it and create its own `scalar_series_t` object. 

closes #314 