### PR TITLE
Add Build Type Default as Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(cmake_minimum_version 3.10)
 cmake_minimum_required(VERSION ${cmake_minimum_version})
 project(x3d2 LANGUAGES Fortran CXX C)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
 enable_testing()
 
 set(WITH_2DECOMPFFT ON CACHE BOOL


### PR DESCRIPTION
During the testing I was running the cmake as:
```
FC=mpif90 cmake -B build-cpu-test-release-flag . -DWITH_2DECOMPFFT=ON -DWITH_ADIOS2=ON
```
Later on, I noticed that although the release was mentioned, the flags for release wasn't appended to the build recipe. 
```
FC=mpif90 cmake -B build-cpu-adios2 . -DWITH_2DECOMPFFT=ON -DWITH_ADIOS2=ON -DCMAKE_BUILD_TYPE=Release
```
When built with providing the `-DCMAKE_BUILD_TYPE=Release` there were massive performance gains because of -O0 vs -O3.

The CI builds with `-DCMAKE_BUILD_TYPE=Release` but the end user might miss providing this flag like me so thought might be good idea to make it default 