### PR TITLE
Fix qcrit/vort snapshots in post-process

### DIFF
--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -50,6 +50,8 @@ module m_base_backend
     procedure(field_reduce), deferred :: field_volume_integral
     procedure(field_set_face), deferred :: field_set_face
     procedure(field_set_face_from_field), deferred :: field_set_face_from_field
+    procedure(derive_field_from_gradients), deferred :: compute_vorticity
+    procedure(derive_field_from_gradients), deferred :: compute_qcriterion
     procedure(copy_data_to_f), deferred :: copy_data_to_f
     procedure(copy_f_to_data), deferred :: copy_f_to_data
     procedure(alloc_tdsops), deferred :: alloc_tdsops
@@ -304,6 +306,22 @@ module m_base_backend
       integer, optional, intent(in) :: bc_end
       real(dp), optional, intent(in) :: flow_rate_diff
     end subroutine field_set_face_from_field
+  end interface
+
+  abstract interface
+    subroutine derive_field_from_gradients( &
+      self, field_out, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+      !! Computes derived fields (vorticity, qcriterion) from velocity gradients
+      import :: base_backend_t
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(inout) :: field_out
+      class(field_t), intent(in) :: dudx, dudy, dudz
+      class(field_t), intent(in) :: dvdx, dvdy, dvdz
+      class(field_t), intent(in) :: dwdx, dwdy, dwdz
+    end subroutine derive_field_from_gradients
   end interface
 
   abstract interface

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -750,11 +750,11 @@ contains
   end subroutine vecmult_cuda
 
   subroutine compute_vorticity_cuda( &
-    self, vort, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    self, field_out, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
     implicit none
 
     class(cuda_backend_t) :: self
-    class(field_t), intent(inout) :: vort
+    class(field_t), intent(inout) :: field_out
     class(field_t), intent(in) :: dudx, dudy, dudz
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
@@ -764,7 +764,7 @@ contains
     type(dim3) :: blocks, threads
     integer :: n
 
-    call resolve_field_t(vort_d, vort)
+    call resolve_field_t(vort_d, field_out)
     call resolve_field_t(dudy_d, dudy)
     call resolve_field_t(dudz_d, dudz)
     call resolve_field_t(dvdx_d, dvdx)
@@ -781,11 +781,11 @@ contains
   end subroutine compute_vorticity_cuda
 
   subroutine compute_qcriterion_cuda( &
-    self, qcrit, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    self, field_out, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
     implicit none
 
     class(cuda_backend_t) :: self
-    class(field_t), intent(inout) :: qcrit
+    class(field_t), intent(inout) :: field_out
     class(field_t), intent(in) :: dudx, dudy, dudz
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
@@ -796,7 +796,7 @@ contains
     type(dim3) :: blocks, threads
     integer :: n
 
-    call resolve_field_t(qcrit_d, qcrit)
+    call resolve_field_t(qcrit_d, field_out)
     call resolve_field_t(dudx_d, dudx)
     call resolve_field_t(dudy_d, dudy)
     call resolve_field_t(dudz_d, dudz)

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -27,7 +27,9 @@ module m_cuda_backend
                                      field_set_x_face, &
                                      field_set_x_face_from_field, &
                                      field_set_y_face_from_field, &
-                                     pwmul, volume_integral
+                                     pwmul, volume_integral, &
+                                     vorticity_from_gradients, &
+                                     qcriterion_from_gradients
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c, &
@@ -67,6 +69,8 @@ module m_cuda_backend
     procedure :: field_shift => field_shift_cuda
     procedure :: field_set_face => field_set_face_cuda
     procedure :: field_set_face_from_field => field_set_face_from_field_cuda
+    procedure :: compute_vorticity => compute_vorticity_cuda
+    procedure :: compute_qcriterion => compute_qcriterion_cuda
     procedure :: field_volume_integral => field_volume_integral_cuda
     procedure :: copy_data_to_f => copy_data_to_f_cuda
     procedure :: copy_f_to_data => copy_f_to_data_cuda
@@ -744,6 +748,73 @@ contains
     call pwmul<<<blocks, threads>>>(y_d, x_d, n) !&
 
   end subroutine vecmult_cuda
+
+  subroutine compute_vorticity_cuda( &
+    self, vort, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(inout) :: vort
+    class(field_t), intent(in) :: dudx, dudy, dudz
+    class(field_t), intent(in) :: dvdx, dvdy, dvdz
+    class(field_t), intent(in) :: dwdx, dwdy, dwdz
+
+    real(dp), device, pointer, dimension(:, :, :) :: &
+      vort_d, dudy_d, dudz_d, dvdx_d, dvdz_d, dwdx_d, dwdy_d
+    type(dim3) :: blocks, threads
+    integer :: n
+
+    call resolve_field_t(vort_d, vort)
+    call resolve_field_t(dudy_d, dudy)
+    call resolve_field_t(dudz_d, dudz)
+    call resolve_field_t(dvdx_d, dvdx)
+    call resolve_field_t(dvdz_d, dvdz)
+    call resolve_field_t(dwdx_d, dwdx)
+    call resolve_field_t(dwdy_d, dwdy)
+
+    n = size(vort_d, dim=2)
+    blocks = dim3(size(vort_d, dim=3), 1, 1)
+    threads = dim3(SZ, 1, 1)
+    call vorticity_from_gradients<<<blocks, threads>>>( &
+      vort_d, dudy_d, dudz_d, dvdx_d, dvdz_d, dwdx_d, dwdy_d, n) !&
+
+  end subroutine compute_vorticity_cuda
+
+  subroutine compute_qcriterion_cuda( &
+    self, qcrit, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(inout) :: qcrit
+    class(field_t), intent(in) :: dudx, dudy, dudz
+    class(field_t), intent(in) :: dvdx, dvdy, dvdz
+    class(field_t), intent(in) :: dwdx, dwdy, dwdz
+
+    real(dp), device, pointer, dimension(:, :, :) :: &
+      qcrit_d, dudx_d, dudy_d, dudz_d, dvdx_d, dvdy_d, dvdz_d, dwdx_d, &
+      dwdy_d, dwdz_d
+    type(dim3) :: blocks, threads
+    integer :: n
+
+    call resolve_field_t(qcrit_d, qcrit)
+    call resolve_field_t(dudx_d, dudx)
+    call resolve_field_t(dudy_d, dudy)
+    call resolve_field_t(dudz_d, dudz)
+    call resolve_field_t(dvdx_d, dvdx)
+    call resolve_field_t(dvdy_d, dvdy)
+    call resolve_field_t(dvdz_d, dvdz)
+    call resolve_field_t(dwdx_d, dwdx)
+    call resolve_field_t(dwdy_d, dwdy)
+    call resolve_field_t(dwdz_d, dwdz)
+
+    n = size(qcrit_d, dim=2)
+    blocks = dim3(size(qcrit_d, dim=3), 1, 1)
+    threads = dim3(SZ, 1, 1)
+    call qcriterion_from_gradients<<<blocks, threads>>>( &
+      qcrit_d, dudx_d, dudy_d, dudz_d, dvdx_d, dvdy_d, dvdz_d, dwdx_d, &
+      dwdy_d, dwdz_d, n) !&
+
+  end subroutine compute_qcriterion_cuda
 
   real(dp) function scalar_product_cuda(self, x, y) result(s)
     !! [[m_base_backend(module):scalar_product(interface)]]

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -156,8 +156,9 @@ contains
     b = blockIdx%x
 
     do j = 1, n
-      qcrit(i, j, b) = -0.5_dp*(dudx(i, j, b)**2 + dvdy(i, j, b)**2 + &
-                                dwdz(i, j, b)**2) - &
+      qcrit(i, j, b) = -0.5_dp*(dudx(i, j, b)*dudx(i, j, b) + &
+                                dvdy(i, j, b)*dvdy(i, j, b) + &
+                                dwdz(i, j, b)*dwdz(i, j, b)) - &
                        dudy(i, j, b)*dvdx(i, j, b) - &
                        dudz(i, j, b)*dwdx(i, j, b) - &
                        dvdz(i, j, b)*dwdy(i, j, b)

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -116,6 +116,55 @@ contains
 
   end subroutine field_shift
 
+  attributes(global) subroutine vorticity_from_gradients( &
+    vort, dudy, dudz, dvdx, dvdz, dwdx, dwdy, n)
+    implicit none
+
+    real(dp), device, intent(inout), dimension(:, :, :) :: vort
+    real(dp), device, intent(in), dimension(:, :, :) :: &
+      dudy, dudz, dvdx, dvdz, dwdx, dwdy
+    integer, value, intent(in) :: n
+
+    integer :: i, j, b
+    real(dp) :: wx, wy, wz
+
+    i = threadIdx%x
+    b = blockIdx%x
+
+    do j = 1, n
+      wx = dwdy(i, j, b) - dvdz(i, j, b)
+      wy = dudz(i, j, b) - dwdx(i, j, b)
+      wz = dvdx(i, j, b) - dudy(i, j, b)
+      vort(i, j, b) = sqrt(wx*wx + wy*wy + wz*wz)
+    end do
+
+  end subroutine vorticity_from_gradients
+
+  attributes(global) subroutine qcriterion_from_gradients( &
+    qcrit, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz, n)
+    implicit none
+
+    real(dp), device, intent(inout), dimension(:, :, :) :: qcrit
+    real(dp), device, intent(in), dimension(:, :, :) :: dudx, dudy, dudz
+    real(dp), device, intent(in), dimension(:, :, :) :: dvdx, dvdy, dvdz
+    real(dp), device, intent(in), dimension(:, :, :) :: dwdx, dwdy, dwdz
+    integer, value, intent(in) :: n
+
+    integer :: i, j, b
+
+    i = threadIdx%x
+    b = blockIdx%x
+
+    do j = 1, n
+      qcrit(i, j, b) = -0.5_dp*(dudx(i, j, b)**2 + dvdy(i, j, b)**2 + &
+                dwdz(i, j, b)**2) - &
+                       dudy(i, j, b)*dvdx(i, j, b) - &
+                       dudz(i, j, b)*dwdx(i, j, b) - &
+                       dvdz(i, j, b)*dwdy(i, j, b)
+    end do
+
+  end subroutine qcriterion_from_gradients
+
   attributes(global) subroutine scalar_product(s, x, y, n, n_i_pad, n_j)
     implicit none
 

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -157,7 +157,7 @@ contains
 
     do j = 1, n
       qcrit(i, j, b) = -0.5_dp*(dudx(i, j, b)**2 + dvdy(i, j, b)**2 + &
-                dwdz(i, j, b)**2) - &
+                                dwdz(i, j, b)**2) - &
                        dudy(i, j, b)*dvdx(i, j, b) - &
                        dudz(i, j, b)*dwdx(i, j, b) - &
                        dvdz(i, j, b)*dwdy(i, j, b)

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -573,9 +573,12 @@ contains
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
 
-    field_out%data = sqrt((dwdy%data - dvdz%data)**2 + &
-                          (dudz%data - dwdx%data)**2 + &
-                          (dvdx%data - dudy%data)**2)
+    real(dp) :: wx, wy, wz
+
+    wx = dwdy%data - dvdz%data
+    wy = dudz%data - dwdx%data
+    wz = dvdx%data - dudy%data
+    field_out%data = sqrt(wx*wx + wy*wy + wz*wz)
 
   end subroutine compute_vorticity_omp
 
@@ -589,7 +592,9 @@ contains
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
 
-    field_out%data = -0.5_dp*(dudx%data**2 + dvdy%data**2 + dwdz%data**2) - &
+    field_out%data = -0.5_dp*(dudx%data*dudx%data + &
+                              dvdy%data*dvdy%data + &
+                              dwdz%data*dwdz%data) - &
                      dudy%data*dvdx%data - &
                      dudz%data*dwdx%data - &
                      dvdz%data*dwdy%data

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -48,6 +48,8 @@ module m_omp_backend
     procedure :: field_shift => field_shift_omp
     procedure :: field_set_face => field_set_face_omp
     procedure :: field_set_face_from_field => field_set_face_from_field_omp
+    procedure :: compute_vorticity => compute_vorticity_omp
+    procedure :: compute_qcriterion => compute_qcriterion_omp
     procedure :: field_volume_integral => field_volume_integral_omp
     procedure :: copy_data_to_f => copy_data_to_f_omp
     procedure :: copy_f_to_data => copy_f_to_data_omp
@@ -560,6 +562,39 @@ contains
     !$omp end parallel do
 
   end subroutine vecmult_omp
+
+  subroutine compute_vorticity_omp( &
+    self, vort, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(inout) :: vort
+    class(field_t), intent(in) :: dudx, dudy, dudz
+    class(field_t), intent(in) :: dvdx, dvdy, dvdz
+    class(field_t), intent(in) :: dwdx, dwdy, dwdz
+
+    vort%data = sqrt((dwdy%data - dvdz%data)**2 + &
+                     (dudz%data - dwdx%data)**2 + &
+                     (dvdx%data - dudy%data)**2)
+
+  end subroutine compute_vorticity_omp
+
+  subroutine compute_qcriterion_omp( &
+    self, qcrit, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(inout) :: qcrit
+    class(field_t), intent(in) :: dudx, dudy, dudz
+    class(field_t), intent(in) :: dvdx, dvdy, dvdz
+    class(field_t), intent(in) :: dwdx, dwdy, dwdz
+
+    qcrit%data = -0.5_dp*(dudx%data**2 + dvdy%data**2 + dwdz%data**2) - &
+                 dudy%data*dvdx%data - &
+                 dudz%data*dwdx%data - &
+                 dvdz%data*dwdy%data
+
+  end subroutine compute_qcriterion_omp
 
   real(dp) function scalar_product_omp(self, x, y) result(s)
     !! [[m_base_backend(module):scalar_product(interface)]]

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -573,12 +573,9 @@ contains
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
 
-    real(dp) :: wx, wy, wz
-
-    wx = dwdy%data - dvdz%data
-    wy = dudz%data - dwdx%data
-    wz = dvdx%data - dudy%data
-    field_out%data = sqrt(wx*wx + wy*wy + wz*wz)
+    field_out%data = sqrt((dwdy%data - dvdz%data)*(dwdy%data - dvdz%data) + &
+                          (dudz%data - dwdx%data)*(dudz%data - dwdx%data) + &
+                          (dvdx%data - dudy%data)*(dvdx%data - dudy%data))
 
   end subroutine compute_vorticity_omp
 

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -564,35 +564,35 @@ contains
   end subroutine vecmult_omp
 
   subroutine compute_vorticity_omp( &
-    self, vort, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    self, field_out, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
     implicit none
 
     class(omp_backend_t) :: self
-    class(field_t), intent(inout) :: vort
+    class(field_t), intent(inout) :: field_out
     class(field_t), intent(in) :: dudx, dudy, dudz
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
 
-    vort%data = sqrt((dwdy%data - dvdz%data)**2 + &
-                     (dudz%data - dwdx%data)**2 + &
-                     (dvdx%data - dudy%data)**2)
+    field_out%data = sqrt((dwdy%data - dvdz%data)**2 + &
+                          (dudz%data - dwdx%data)**2 + &
+                          (dvdx%data - dudy%data)**2)
 
   end subroutine compute_vorticity_omp
 
   subroutine compute_qcriterion_omp( &
-    self, qcrit, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    self, field_out, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
     implicit none
 
     class(omp_backend_t) :: self
-    class(field_t), intent(inout) :: qcrit
+    class(field_t), intent(inout) :: field_out
     class(field_t), intent(in) :: dudx, dudy, dudz
     class(field_t), intent(in) :: dvdx, dvdy, dvdz
     class(field_t), intent(in) :: dwdx, dwdy, dwdz
 
-    qcrit%data = -0.5_dp*(dudx%data**2 + dvdy%data**2 + dwdz%data**2) - &
-                 dudy%data*dvdx%data - &
-                 dudz%data*dwdx%data - &
-                 dvdz%data*dwdy%data
+    field_out%data = -0.5_dp*(dudx%data**2 + dvdy%data**2 + dwdz%data**2) - &
+                     dudy%data*dvdx%data - &
+                     dudz%data*dwdx%data - &
+                     dvdz%data*dwdy%data
 
   end subroutine compute_qcriterion_omp
 

--- a/src/postprocess/postprocess.f90
+++ b/src/postprocess/postprocess.f90
@@ -6,7 +6,7 @@ module m_postprocess
   !! and visualisation (e.g. pressure on the vertex grid, vorticity
   !! magnitude, Q-criterion).
 
-  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, VERT, &
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Z2X
   use m_field, only: field_t
   use m_solver, only: solver_t
@@ -38,6 +38,11 @@ contains
       u_y, dudy_y, u_z, dudz_z, &
       v_y, dvdy_y, v_z, dvdz_z, &
       w_y, dwdy_y, w_z, dwdz_z
+    class(field_t), pointer :: &
+      dudx_h, dudy_h, dudz_h, &
+      dvdx_h, dvdy_h, dvdz_h, &
+      dwdx_h, dwdy_h, dwdz_h, &
+      vort_h, qcrit_h
 
     ! Allocate output fields on first use
     if (output_vorticity .and. .not. associated(solver%vort)) &
@@ -132,30 +137,66 @@ contains
     ! dvdx, dvdy_x, dvdz_x
     ! dwdx, dwdy_x, dwdz_x
 
+    dudx_h => solver%host_allocator%get_block(DIR_C, dudx%data_loc)
+    dudy_h => solver%host_allocator%get_block(DIR_C, dudy_x%data_loc)
+    dudz_h => solver%host_allocator%get_block(DIR_C, dudz_x%data_loc)
+    dvdx_h => solver%host_allocator%get_block(DIR_C, dvdx%data_loc)
+    dvdy_h => solver%host_allocator%get_block(DIR_C, dvdy_x%data_loc)
+    dvdz_h => solver%host_allocator%get_block(DIR_C, dvdz_x%data_loc)
+    dwdx_h => solver%host_allocator%get_block(DIR_C, dwdx%data_loc)
+    dwdy_h => solver%host_allocator%get_block(DIR_C, dwdy_x%data_loc)
+    dwdz_h => solver%host_allocator%get_block(DIR_C, dwdz_x%data_loc)
+
+    call solver%backend%get_field_data(dudx_h%data, dudx, DIR_C)
+    call solver%backend%get_field_data(dudy_h%data, dudy_x, DIR_C)
+    call solver%backend%get_field_data(dudz_h%data, dudz_x, DIR_C)
+    call solver%backend%get_field_data(dvdx_h%data, dvdx, DIR_C)
+    call solver%backend%get_field_data(dvdy_h%data, dvdy_x, DIR_C)
+    call solver%backend%get_field_data(dvdz_h%data, dvdz_x, DIR_C)
+    call solver%backend%get_field_data(dwdx_h%data, dwdx, DIR_C)
+    call solver%backend%get_field_data(dwdy_h%data, dwdy_x, DIR_C)
+    call solver%backend%get_field_data(dwdz_h%data, dwdz_x, DIR_C)
+
     !! Vorticity magnitude:
     !! \( |\boldsymbol{\omega}| = \sqrt{(\partial w/\partial y - \partial v/\partial z)^2
     !! + (\partial u/\partial z - \partial w/\partial x)^2
     !! + (\partial v/\partial x - \partial u/\partial y)^2} \)
     if (output_vorticity) then
-      solver%vort%data = sqrt( &
-                         (dwdy_x%data - dvdz_x%data)**2 + &
-                         (dudz_x%data - dwdx%data)**2 + &
-                         (dvdx%data - dudy_x%data)**2 &
-                         )
+      vort_h => solver%host_allocator%get_block(DIR_C, solver%vort%data_loc)
+      vort_h%data = sqrt( &
+                     (dwdy_h%data - dvdz_h%data)**2 + &
+                     (dudz_h%data - dwdx_h%data)**2 + &
+                     (dvdx_h%data - dudy_h%data)**2 &
+                     )
+      call solver%backend%set_field_data(solver%vort, vort_h%data, DIR_C)
+      call solver%host_allocator%release_block(vort_h)
     end if
 
     !! Q-criterion:
     !! \( Q = -\frac{1}{2}(u_{x}^2 + v_{y}^2 + w_{z}^2)
     !! - u_{y}v_{x} - u_{z}w_{x} - v_{z}w_{y} \)
     if (output_qcriterion) then
-      solver%qcrit%data = &
-        -0.5_dp*(dudx%data**2 &
-                 + dvdy_x%data**2 &
-                 + dwdz_x%data**2) &
-        - dudy_x%data*dvdx%data &
-        - dudz_x%data*dwdx%data &
-        - dvdz_x%data*dwdy_x%data
+      qcrit_h => solver%host_allocator%get_block(DIR_C, solver%qcrit%data_loc)
+      qcrit_h%data = &
+        -0.5_dp*(dudx_h%data**2 &
+                 + dvdy_h%data**2 &
+                 + dwdz_h%data**2) &
+        - dudy_h%data*dvdx_h%data &
+        - dudz_h%data*dwdx_h%data &
+        - dvdz_h%data*dwdy_h%data
+      call solver%backend%set_field_data(solver%qcrit, qcrit_h%data, DIR_C)
+      call solver%host_allocator%release_block(qcrit_h)
     end if
+
+    call solver%host_allocator%release_block(dudx_h)
+    call solver%host_allocator%release_block(dudy_h)
+    call solver%host_allocator%release_block(dudz_h)
+    call solver%host_allocator%release_block(dvdx_h)
+    call solver%host_allocator%release_block(dvdy_h)
+    call solver%host_allocator%release_block(dvdz_h)
+    call solver%host_allocator%release_block(dwdx_h)
+    call solver%host_allocator%release_block(dwdy_h)
+    call solver%host_allocator%release_block(dwdz_h)
 
     ! Release all gradient fields
     call solver%backend%allocator%release_block(dudx)

--- a/src/postprocess/postprocess.f90
+++ b/src/postprocess/postprocess.f90
@@ -164,10 +164,10 @@ contains
     if (output_vorticity) then
       vort_h => solver%host_allocator%get_block(DIR_C, solver%vort%data_loc)
       vort_h%data = sqrt( &
-                     (dwdy_h%data - dvdz_h%data)**2 + &
-                     (dudz_h%data - dwdx_h%data)**2 + &
-                     (dvdx_h%data - dudy_h%data)**2 &
-                     )
+                    (dwdy_h%data - dvdz_h%data)**2 + &
+                    (dudz_h%data - dwdx_h%data)**2 + &
+                    (dvdx_h%data - dudy_h%data)**2 &
+                    )
       call solver%backend%set_field_data(solver%vort, vort_h%data, DIR_C)
       call solver%host_allocator%release_block(vort_h)
     end if

--- a/src/postprocess/postprocess.f90
+++ b/src/postprocess/postprocess.f90
@@ -6,7 +6,7 @@ module m_postprocess
   !! and visualisation (e.g. pressure on the vertex grid, vorticity
   !! magnitude, Q-criterion).
 
-  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, &
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, VERT, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Z2X
   use m_field, only: field_t
   use m_solver, only: solver_t
@@ -38,12 +38,6 @@ contains
       u_y, dudy_y, u_z, dudz_z, &
       v_y, dvdy_y, v_z, dvdz_z, &
       w_y, dwdy_y, w_z, dwdz_z
-    class(field_t), pointer :: &
-      dudx_h, dudy_h, dudz_h, &
-      dvdx_h, dvdy_h, dvdz_h, &
-      dwdx_h, dwdy_h, dwdz_h, &
-      vort_h, qcrit_h
-
     ! Allocate output fields on first use
     if (output_vorticity .and. .not. associated(solver%vort)) &
       solver%vort => solver%backend%allocator%get_block(DIR_X, VERT)
@@ -137,66 +131,24 @@ contains
     ! dvdx, dvdy_x, dvdz_x
     ! dwdx, dwdy_x, dwdz_x
 
-    dudx_h => solver%host_allocator%get_block(DIR_C, dudx%data_loc)
-    dudy_h => solver%host_allocator%get_block(DIR_C, dudy_x%data_loc)
-    dudz_h => solver%host_allocator%get_block(DIR_C, dudz_x%data_loc)
-    dvdx_h => solver%host_allocator%get_block(DIR_C, dvdx%data_loc)
-    dvdy_h => solver%host_allocator%get_block(DIR_C, dvdy_x%data_loc)
-    dvdz_h => solver%host_allocator%get_block(DIR_C, dvdz_x%data_loc)
-    dwdx_h => solver%host_allocator%get_block(DIR_C, dwdx%data_loc)
-    dwdy_h => solver%host_allocator%get_block(DIR_C, dwdy_x%data_loc)
-    dwdz_h => solver%host_allocator%get_block(DIR_C, dwdz_x%data_loc)
-
-    call solver%backend%get_field_data(dudx_h%data, dudx, DIR_C)
-    call solver%backend%get_field_data(dudy_h%data, dudy_x, DIR_C)
-    call solver%backend%get_field_data(dudz_h%data, dudz_x, DIR_C)
-    call solver%backend%get_field_data(dvdx_h%data, dvdx, DIR_C)
-    call solver%backend%get_field_data(dvdy_h%data, dvdy_x, DIR_C)
-    call solver%backend%get_field_data(dvdz_h%data, dvdz_x, DIR_C)
-    call solver%backend%get_field_data(dwdx_h%data, dwdx, DIR_C)
-    call solver%backend%get_field_data(dwdy_h%data, dwdy_x, DIR_C)
-    call solver%backend%get_field_data(dwdz_h%data, dwdz_x, DIR_C)
-
     !! Vorticity magnitude:
     !! \( |\boldsymbol{\omega}| = \sqrt{(\partial w/\partial y - \partial v/\partial z)^2
     !! + (\partial u/\partial z - \partial w/\partial x)^2
     !! + (\partial v/\partial x - \partial u/\partial y)^2} \)
     if (output_vorticity) then
-      vort_h => solver%host_allocator%get_block(DIR_C, solver%vort%data_loc)
-      vort_h%data = sqrt( &
-                    (dwdy_h%data - dvdz_h%data)**2 + &
-                    (dudz_h%data - dwdx_h%data)**2 + &
-                    (dvdx_h%data - dudy_h%data)**2 &
-                    )
-      call solver%backend%set_field_data(solver%vort, vort_h%data, DIR_C)
-      call solver%host_allocator%release_block(vort_h)
+      call solver%backend%compute_vorticity( &
+        solver%vort, dudx, dudy_x, dudz_x, dvdx, dvdy_x, dvdz_x, &
+        dwdx, dwdy_x, dwdz_x)
     end if
 
     !! Q-criterion:
     !! \( Q = -\frac{1}{2}(u_{x}^2 + v_{y}^2 + w_{z}^2)
     !! - u_{y}v_{x} - u_{z}w_{x} - v_{z}w_{y} \)
     if (output_qcriterion) then
-      qcrit_h => solver%host_allocator%get_block(DIR_C, solver%qcrit%data_loc)
-      qcrit_h%data = &
-        -0.5_dp*(dudx_h%data**2 &
-                 + dvdy_h%data**2 &
-                 + dwdz_h%data**2) &
-        - dudy_h%data*dvdx_h%data &
-        - dudz_h%data*dwdx_h%data &
-        - dvdz_h%data*dwdy_h%data
-      call solver%backend%set_field_data(solver%qcrit, qcrit_h%data, DIR_C)
-      call solver%host_allocator%release_block(qcrit_h)
+      call solver%backend%compute_qcriterion( &
+        solver%qcrit, dudx, dudy_x, dudz_x, dvdx, dvdy_x, dvdz_x, &
+        dwdx, dwdy_x, dwdz_x)
     end if
-
-    call solver%host_allocator%release_block(dudx_h)
-    call solver%host_allocator%release_block(dudy_h)
-    call solver%host_allocator%release_block(dudz_h)
-    call solver%host_allocator%release_block(dvdx_h)
-    call solver%host_allocator%release_block(dvdy_h)
-    call solver%host_allocator%release_block(dvdz_h)
-    call solver%host_allocator%release_block(dwdx_h)
-    call solver%host_allocator%release_block(dwdy_h)
-    call solver%host_allocator%release_block(dwdz_h)
 
     ! Release all gradient fields
     call solver%backend%allocator%release_block(dudx)


### PR DESCRIPTION

This PR fixes a bug where qcrit/vort fields did not change with time (i.e. remained frozen). Fixes #327 

- In `postprocess.f90` vorticity and q-criterion were computed from gradient fields without explicitly transfering it from CUDA backend
- As a result, these derived fields written to snapshots  were unchanged over time 


#### Changes
- Add host fields for all 9 velocity gradient components
- Uses `get_field_data` to copy/reorder gradients from backend fields into host fields
- Computed vorticity/q-criterion on host data
- Uses `set_field_data` to write computed vort/qcrit back to backend fields
- Releases all temporary host blocks and backend gradient blocks
- The OMP behaviour is correct

#### Future considerations
- Additional transfer of data from device to host - need to be optimised via kernels for larger simulations. Alternatively, we create a python module that does it after the simulation (similar to Incompact3d)

#### Testing 
Cylinder case at two different time-steps showing qcrit (coloured with u-velocity)

<img width="738" height="721" alt="Screenshot from 2026-06-20 00-25-37" src="https://github.com/user-attachments/assets/54cb4131-93c3-4070-9e40-9f0adde7e7fd" />
<img width="738" height="721" alt="Screenshot from 2026-06-20 00-25-27" src="https://github.com/user-attachments/assets/3a549fc1-78f4-4059-9b0d-c98921e065c4" />