### PR TITLE
Fix single-precision test failures and spectral Poisson thresholds

### DIFF
--- a/src/backend/cuda/kernels/spectral_processing.f90
+++ b/src/backend/cuda/kernels/spectral_processing.f90
@@ -5,6 +5,12 @@ module m_cuda_spectral
 
   implicit none
 
+  ! Threshold below which a spectral coefficient is treated as zero. Must
+  ! scale with the working precision: single-precision roundoff leaves
+  ! ~1e-13 noise in wave numbers that should vanish (e.g. Nyquist modes),
+  ! and dividing by that noise corrupts the pressure field.
+  real(dp), parameter :: eps_wave = epsilon(1._dp)
+
 contains
 
   attributes(global) subroutine memcpy3D(dst, src, nx, ny, nz)
@@ -186,7 +192,7 @@ contains
         ! Solve Poisson
         tmp_r = real(waves(i, j, k), kind=dp)
         tmp_c = aimag(waves(i, j, k))
-        if ((tmp_r < 1.e-16_dp) .or. (tmp_c < 1.e-16_dp)) then
+        if ((tmp_r < eps_wave) .or. (tmp_c < eps_wave)) then
           div_r = 0._dp; div_c = 0._dp
         else
           div_r = -div_r/tmp_r
@@ -311,12 +317,12 @@ contains
 
         tmp_r = real(waves(i, j, k), kind=dp)
         tmp_c = aimag(waves(i, j, k))
-        if (abs(tmp_r) < 1.e-16_dp) then
+        if (abs(tmp_r) < eps_wave) then
           div_r = 0._dp
         else
           div_r = -div_r/tmp_r
         end if
-        if (abs(tmp_c) < 1.e-16_dp) then
+        if (abs(tmp_c) < eps_wave) then
           div_c = 0._dp
         else
           div_c = -div_c/tmp_c
@@ -480,12 +486,11 @@ contains
     integer, value, intent(in) :: nx_spec, n, nx, ny, nz
 
     integer :: i, j, k, jm, nm
-    real(dp) :: tmp_r, tmp_c, div_r, div_c, epsilon
+    real(dp) :: tmp_r, tmp_c, div_r, div_c
 
     i = threadIdx%x + (blockIdx%x - 1)*blockDim%x
     k = blockIdx%y ! nz_spec
 
-    epsilon = 1.e-16_dp
 
     ! Solve Poisson
     if (i <= nx_spec) then
@@ -498,11 +503,11 @@ contains
         jm = inc*j + off - inc/2
         ! eliminate diag-1
         tmp_r = 0._dp
-        if (abs(a_re(i, j, k, 3)) > epsilon) then
+        if (abs(a_re(i, j, k, 3)) > eps_wave) then
           tmp_r = a_re(i, j + 1, k, 2)/a_re(i, j, k, 3)
         end if
         tmp_c = 0._dp
-        if (abs(a_im(i, j, k, 3)) > epsilon) then
+        if (abs(a_im(i, j, k, 3)) > eps_wave) then
           tmp_c = a_im(i, j + 1, k, 2)/a_im(i, j, k, 3)
         end if
         div_r = real(div_u(i, jm + inc, k) - tmp_r*div_u(i, jm, k), kind=dp)
@@ -516,11 +521,11 @@ contains
 
         ! eliminate diag-2
         tmp_r = 0._dp
-        if (abs(a_re(i, j, k, 3)) > epsilon) then
+        if (abs(a_re(i, j, k, 3)) > eps_wave) then
           tmp_r = a_re(i, j + 2, k, 1)/a_re(i, j, k, 3)
         end if
         tmp_c = 0._dp
-        if (abs(a_im(i, j, k, 3)) > epsilon) then
+        if (abs(a_im(i, j, k, 3)) > eps_wave) then
           tmp_c = a_im(i, j + 2, k, 1)/a_im(i, j, k, 3)
         end if
         div_r = real(div_u(i, jm + 2*inc, k) - tmp_r*div_u(i, jm, k), kind=dp)
@@ -534,12 +539,12 @@ contains
       end do
 
       ! handle the last row
-      if (abs(a_re(i, n - 1, k, 3)) > epsilon) then
+      if (abs(a_re(i, n - 1, k, 3)) > eps_wave) then
         tmp_r = a_re(i, n, k, 2)/a_re(i, n - 1, k, 3)
       else
         tmp_r = 0._dp
       end if
-      if (abs(a_im(i, n - 1, k, 3)) > epsilon) then
+      if (abs(a_im(i, n - 1, k, 3)) > eps_wave) then
         tmp_c = a_im(i, n, k, 2)/a_im(i, n - 1, k, 3)
       else
         tmp_c = 0._dp
@@ -549,7 +554,7 @@ contains
 
       ! j mapping based on odd/even for last point j=n
       nm = inc*n + off - inc/2
-      if (abs(div_r) > epsilon) then
+      if (abs(div_r) > eps_wave) then
         tmp_r = tmp_r/div_r
         div_r = real(div_u(i, nm, k), kind=dp)/div_r &
                 - tmp_r*real(div_u(i, nm - inc, k), kind=dp)
@@ -557,7 +562,7 @@ contains
         tmp_r = 0._dp
         div_r = 0._dp
       end if
-      if (abs(div_c) > epsilon) then
+      if (abs(div_c) > eps_wave) then
         tmp_c = tmp_c/div_c
         div_c = aimag(div_u(i, nm, k))/div_c &
                 - tmp_c*aimag(div_u(i, nm - inc, k))
@@ -567,12 +572,12 @@ contains
       end if
       div_u(i, nm, k) = cmplx(div_r, div_c, kind=dp)
 
-      if (abs(a_re(i, n - 1, k, 3)) > epsilon) then
+      if (abs(a_re(i, n - 1, k, 3)) > eps_wave) then
         tmp_r = 1._dp/a_re(i, n - 1, k, 3)
       else
         tmp_r = 0._dp
       end if
-      if (abs(a_im(i, n - 1, k, 3)) > epsilon) then
+      if (abs(a_im(i, n - 1, k, 3)) > eps_wave) then
         tmp_c = 1._dp/a_im(i, n - 1, k, 3)
       else
         tmp_c = 0._dp
@@ -596,12 +601,12 @@ contains
       do j = n - 2, 1, -1
         ! j mapping based on odd/even
         jm = inc*j + off - inc/2
-        if (abs(a_re(i, j, k, 3)) > epsilon) then
+        if (abs(a_re(i, j, k, 3)) > eps_wave) then
           tmp_r = 1._dp/a_re(i, j, k, 3)
         else
           tmp_r = 0._dp
         end if
-        if (abs(a_im(i, j, k, 3)) > epsilon) then
+        if (abs(a_im(i, j, k, 3)) > eps_wave) then
           tmp_c = 1._dp/a_im(i, j, k, 3)
         else
           tmp_c = 0._dp
@@ -869,12 +874,12 @@ contains
 
         tmp_r = real(waves(j, i, k), kind=dp)
         tmp_c = aimag(waves(j, i, k))
-        if (abs(tmp_r) < 1.e-16_dp) then
+        if (abs(tmp_r) < eps_wave) then
           div_r = 0._dp
         else
           div_r = -div_r/tmp_r
         end if
-        if (abs(tmp_c) < 1.e-16_dp) then
+        if (abs(tmp_c) < eps_wave) then
           div_c = 0._dp
         else
           div_c = -div_c/tmp_c

--- a/src/backend/cuda/kernels/spectral_processing.f90
+++ b/src/backend/cuda/kernels/spectral_processing.f90
@@ -491,7 +491,6 @@ contains
     i = threadIdx%x + (blockIdx%x - 1)*blockDim%x
     k = blockIdx%y ! nz_spec
 
-
     ! Solve Poisson
     if (i <= nx_spec) then
       ! Forward pass for the pentadiagonal matrix

--- a/src/backend/omp/kernels/spectral_processing.f90
+++ b/src/backend/omp/kernels/spectral_processing.f90
@@ -2,6 +2,12 @@ module m_omp_spectral
   use m_common, only: dp
   implicit none
 
+  ! Threshold below which a spectral coefficient is treated as zero. Must
+  ! scale with the working precision: single-precision roundoff leaves
+  ! ~1e-13 noise in wave numbers that should vanish (e.g. Nyquist modes),
+  ! and dividing by that noise corrupts the pressure field.
+  real(dp), parameter :: eps_wave = epsilon(1._dp)
+
 contains
 
   subroutine process_spectral_000( &
@@ -66,7 +72,7 @@ contains
           ! Solve Poisson
           tmp_r = real(waves(i, j, k), kind=dp)
           tmp_c = aimag(waves(i, j, k))
-          if ((tmp_r < 1.e-16_dp) .or. (tmp_c < 1.e-16_dp)) then
+          if ((tmp_r < eps_wave) .or. (tmp_c < eps_wave)) then
             div_r = 0._dp; div_c = 0._dp
           else
             div_r = -div_r/tmp_r
@@ -200,12 +206,12 @@ contains
 
           tmp_r = real(waves(i, j, k), kind=dp)
           tmp_c = aimag(waves(i, j, k))
-          if (abs(tmp_r) < 1.e-16_dp) then
+          if (abs(tmp_r) < eps_wave) then
             div_r = 0._dp
           else
             div_r = -div_r/tmp_r
           end if
-          if (abs(tmp_c) < 1.e-16_dp) then
+          if (abs(tmp_c) < eps_wave) then
             div_c = 0._dp
           else
             div_c = -div_c/tmp_c

--- a/tests/unit/test_mesh.f90
+++ b/tests/unit/test_mesh.f90
@@ -20,7 +20,9 @@ program test_mesh
   integer, dimension(3) :: dims_check
   integer :: ierr, nrank, nproc
   integer :: n_cell, n_vert, n_x_face
-  real(dp), parameter :: eps = 1e-8
+  ! -ffast-math reciprocal division can be ~1 ulp off even for exactly
+  ! representable results, so the tolerance must scale with the precision
+  real(dp), parameter :: eps = 1000*epsilon(1._dp)
 
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)

--- a/tests/unit/test_statistics.f90
+++ b/tests/unit/test_statistics.f90
@@ -29,7 +29,7 @@ contains
     real(dp) :: umean(1, 1, 1), uumean(1, 1, 1), val(1, 1, 1)
     real(dp) :: uprime, stat_inc
     integer :: n
-    real(dp), parameter :: tol = 1.0e-12_dp
+    real(dp), parameter :: tol = 1.0e4_dp*epsilon(1.0_dp)
 
     umean = 0.0_dp; uumean = 0.0_dp
 
@@ -60,7 +60,7 @@ contains
     real(dp) :: umean(1, 1, 1), val(1, 1, 1)
     real(dp) :: stat_inc, expected
     integer :: n
-    real(dp), parameter :: tol = 1.0e-12_dp
+    real(dp), parameter :: tol = 1.0e4_dp*epsilon(1.0_dp)
 
     umean = 0.0_dp
     expected = (n_samples + 1)/2.0_dp
@@ -84,7 +84,7 @@ contains
     real(dp) :: umean(1, 1, 1), uumean(1, 1, 1), val(1, 1, 1)
     real(dp) :: uprime, stat_inc
     integer :: n
-    real(dp), parameter :: tol = 1.0e-10_dp
+    real(dp), parameter :: tol = 1.0e4_dp*epsilon(1.0_dp)
 
     umean = 0.0_dp; uumean = 0.0_dp
 
@@ -118,7 +118,7 @@ contains
     real(dp) :: val(1, 1, 1), stat_inc
     real(dp) :: uprime2, reynolds_stress
     integer :: n
-    real(dp), parameter :: tol = 1.0e-10_dp
+    real(dp), parameter :: tol = 1.0e4_dp*epsilon(1.0_dp)
 
     ! Perfectly correlated: u == v
     umean = 0.0_dp; vmean = 0.0_dp

--- a/tests/verification/test_cuda_penta.f90
+++ b/tests/verification/test_cuda_penta.f90
@@ -394,7 +394,8 @@ contains
         if (isize == 1) then
           print '(i6, es16.4, a10)', n_glob, l2_err, '   ---'
         else
-          if (l2_prev > 0._dp .and. l2_err > 0._dp) then
+          if (l2_prev > converged_tol(n_glob) &
+              .and. l2_err > converged_tol(n_glob)) then
             block
               real(dp) :: rate
               rate = log(l2_prev/l2_err)/log(2.0_dp)
@@ -427,7 +428,7 @@ contains
     if (nrank /= 0) return
     if (isize == 1) then
       print '(i6, es16.4, a10)', n_glob, l2_err, '   ---'
-    else if (l2_err < 1e-12_dp) then
+    else if (l2_err < converged_tol(n_glob)) then
       print '(i6, es16.4, a10)', n_glob, l2_err, '  <eps'
     else
       rate = log(l2_prev/l2_err)/log(2.0_dp)
@@ -440,6 +441,16 @@ contains
       end if
     end if
   end subroutine report_rate
+
+  real(dp) pure function converged_tol(n_glob)
+    !! Error level below which the truncation error is hidden by roundoff
+    !! and a convergence rate can no longer be measured.  The roundoff
+    !! floor of a first-derivative L2 error at resolution n is ~eps*n
+    !! (roundoff eps amplified by 1/dx = n), with a 20x safety margin.
+    integer, intent(in) :: n_glob
+    converged_tol = max(1e-12_dp, &
+                        20._dp*epsilon(1._dp)*real(n_glob, dp))
+  end function converged_tol
 
   subroutine finalise()
     if (allpass) then

--- a/tests/verification/test_cuda_transeq.f90
+++ b/tests/verification/test_cuda_transeq.f90
@@ -32,7 +32,13 @@ program test_cuda_transeq
   integer :: ierr, ndevs, devnum
 
   type(dim3) :: blocks, threads
+  ! The diffusion term's roundoff floor is ~eps/dx^2: at n=512 this is
+  ! ~8e-4 in single precision, so the tolerance must account for it.
+#ifdef SINGLE_PREC
+  real(dp), parameter :: residual_tol = 2.0e-2_dp
+#else
   real(dp), parameter :: residual_tol = 1.0e-8_dp
+#endif
   real(dp) :: dx_per, nu, norm_du
 
   call initialise_mpi()

--- a/tests/verification/test_cuda_tridiag.f90
+++ b/tests/verification/test_cuda_tridiag.f90
@@ -27,7 +27,14 @@ program test_cuda_tridiag
   integer :: ierr, ndevs, devnum
 
   type(dim3) :: blocks, threads
+  ! The second-derivative roundoff floor is ~eps/dx^2: at n=1024 this is
+  ! ~3e-3 in single precision (~6e-12 in double), so the tolerance must
+  ! account for it.
+#ifdef SINGLE_PREC
+  real(dp), parameter :: residual_tol = 2.0e-2_dp
+#else
   real(dp), parameter :: residual_tol = 1.0e-8_dp
+#endif
   real(dp) :: dx_per, norm_du
 
   call initialise_mpi()

--- a/tests/verification/test_omp_dist_transeq.f90
+++ b/tests/verification/test_omp_dist_transeq.f90
@@ -28,7 +28,14 @@ program test_transeq
   integer :: nrank, nproc, pprev, pnext
   integer :: ierr
 
-  real(dp) :: dx_per, nu, norm_du, tol = 1d-8
+  real(dp) :: dx_per, nu, norm_du
+  ! Roundoff floor of the second-derivative term is ~eps/dx^2, which at
+  ! 96^3 cells is ~1e-4 in single precision.
+#ifdef SINGLE_PREC
+  real(dp) :: tol = 5e-3
+#else
+  real(dp) :: tol = 1d-8
+#endif
 
   call initialise_mpi()
   call setup_geometry()

--- a/tests/verification/test_omp_penta.f90
+++ b/tests/verification/test_omp_penta.f90
@@ -400,6 +400,8 @@ contains
       if (nrank == 0) then
         if (isize == 1) then
           print '(i6, es16.4, a10)', n_glob, l2_err, '   ---'
+        else if (l2_err < converged_tol(n_glob)) then
+          print '(i6, es16.4, a10)', n_glob, l2_err, '  <eps'
         else
           rate = log(l2_prev/l2_err)/log(2.0_dp)
           print '(i6, es16.4, f10.2)', n_glob, l2_err, rate
@@ -427,7 +429,7 @@ contains
     if (nrank /= 0) return
     if (isize == 1) then
       print '(i6, es16.4, a10)', n_glob, l2_err, '   ---'
-    else if (l2_err < 1e-12_dp) then
+    else if (l2_err < converged_tol(n_glob)) then
       print '(i6, es16.4, a10)', n_glob, l2_err, '  <eps'
     else
       rate = log(l2_prev/l2_err)/log(2.0_dp)
@@ -440,5 +442,15 @@ contains
       end if
     end if
   end subroutine report_rate
+
+  real(dp) pure function converged_tol(n_glob)
+    !! Error level below which the truncation error is hidden by roundoff
+    !! and a convergence rate can no longer be measured.  The roundoff
+    !! floor of a first-derivative L2 error at resolution n is ~eps*n
+    !! (roundoff eps amplified by 1/dx = n), with a 20x safety margin.
+    integer, intent(in) :: n_glob
+    converged_tol = max(1e-12_dp, &
+                        20._dp*epsilon(1._dp)*real(n_glob, dp))
+  end function converged_tol
 
 end program test_omp_penta

--- a/tests/verification/test_omp_transeq.f90
+++ b/tests/verification/test_omp_transeq.f90
@@ -23,7 +23,14 @@ program test_omp_transeq
   integer :: ierr
   integer, dimension(3) :: dims_global
 
-  real(dp) :: dx_per, nu, norm_du, tol = 1d-8
+  real(dp) :: dx_per, nu, norm_du
+  ! Roundoff floor of the second-derivative term is ~eps/dx^2, which at
+  ! 96^3 cells is ~1e-4 in single precision.
+#ifdef SINGLE_PREC
+  real(dp) :: tol = 5e-3
+#else
+  real(dp) :: tol = 1d-8
+#endif
 
   class(allocator_t), pointer :: allocator
 

--- a/tests/verification/test_omp_transeq_species.f90
+++ b/tests/verification/test_omp_transeq_species.f90
@@ -23,7 +23,14 @@ program test_omp_transeq_species
   integer :: nrank, nproc
   integer :: ierr
 
-  real(dp) :: dx_per, nu, norm_du, tol = 1d-8
+  real(dp) :: dx_per, nu, norm_du
+  ! Roundoff floor of the second-derivative term is ~eps/dx^2, which at
+  ! 96^3 cells is ~1e-4 in single precision.
+#ifdef SINGLE_PREC
+  real(dp) :: tol = 5e-3
+#else
+  real(dp) :: tol = 1d-8
+#endif
 
   class(allocator_t), pointer :: allocator
 

--- a/tests/verification/test_omp_tridiag.f90
+++ b/tests/verification/test_omp_tridiag.f90
@@ -35,7 +35,15 @@ program test_omp_tridiag
   integer :: nrank, nproc, pprev, pnext
   integer :: ierr
 
-  real(dp) :: dx, dx_per, dx_pi, norm_du, tol = 1d-8
+  real(dp) :: dx, dx_per, dx_pi, norm_du
+  ! Single precision roundoff floors at n_glob=1024: ~eps/dx (~2e-5) for
+  ! first derivatives/interpolation, ~eps/dx^2 (~3e-3) for second
+  ! derivatives, and ~63x more for the hyperviscous operator (nu0_nu=63).
+#ifdef SINGLE_PREC
+  real(dp) :: tol = 1e-4, tol_2nd = 2e-2, tol_hyper = 2.0
+#else
+  real(dp) :: tol = 1d-8, tol_2nd = 1d-8, tol_hyper = 1d-8
+#endif
 
   call initialise_mpi()
   call setup_geometry()
@@ -124,7 +132,7 @@ contains
     if (nrank == 0) print *, 'error norm second-deriv periodic', norm_du
 
     if (nrank == 0) then
-      if (norm_du > tol) then
+      if (norm_du > tol_2nd) then
         allpass = .false.
         write (stderr, '(a)') 'Check 2nd derivatives, periodic BCs... failed'
       else
@@ -340,7 +348,7 @@ contains
     if (nrank == 0) print *, 'error norm hyperviscous', norm_du
 
     if (nrank == 0) then
-      if (norm_du > tol) then
+      if (norm_du > tol_hyper) then
         allpass = .false.
         write (stderr, '(a)') 'Check 2nd ders, hyperviscous, dir-neu... failed'
       else

--- a/tests/verification/test_poisson_bc.f90
+++ b/tests/verification/test_poisson_bc.f90
@@ -59,7 +59,15 @@ program test_poisson
   integer, parameter :: NUM_CONFIGS = 4
   integer, parameter :: TOTAL_TESTS = NUM_CONFIGS*NUM_TESTS
 
+  ! The single precision tolerance must sit between the roundoff floor of
+  ! the passing cases (~3e-7 in this normalised norm, norm2/N) and the
+  ! n=3 periodic aliasing error (~2.4e-6) that the XFAIL logic relies on
+  ! detecting; a looser tolerance turns XFAILs into unexpected passes.
+#ifdef SINGLE_PREC
+  real(dp), parameter :: ERROR_TOLERANCE = 1.0e-6_dp
+#else
   real(dp), parameter :: ERROR_TOLERANCE = 1.0e-11_dp
+#endif
 
   integer :: nrank, nproc, ierr
   integer :: ic, idx

--- a/tests/verification/test_thom.f90
+++ b/tests/verification/test_thom.f90
@@ -16,7 +16,14 @@ program test_thom
   use m_test_utils, only: checkerr
   implicit none
 
+  ! The second-derivative roundoff floor is ~eps/dx^2: at n=1024 this is
+  ! ~3e-3 in single precision (~6e-12 in double), so the tolerance must
+  ! account for it.
+#ifdef SINGLE_PREC
+  real(dp), parameter :: residual_tol = 5.0e-2_dp
+#else
   real(dp), parameter :: residual_tol = 1.0e-8_dp
+#endif
   logical :: allpass = .true.
 
 #ifdef CUDA


### PR DESCRIPTION
From issue #210 the following test cases were failing in single-precision:

```
OMP backend:

 5 - test_mesh_omp_4
12 - test_statistics_omp_1
17 - test_thom_omp_1
18 - test_omp_tridiag_omp_4
19 - test_omp_penta_omp_4
20 - test_omp_transeq_omp_4
21 - test_omp_transeq_species_omp_4
22 - test_omp_dist_transeq_omp_4

CUDA backend:

34 - test_poisson_bc_cuda_1     <----- exposed a real bug
35 - test_cuda_tridiag_cuda_4
36 - test_cuda_penta_cuda_4
37 - test_cuda_transeq_cuda_4
```

With the exception of `test_poisson_bc_cuda_1`, these failures were caused by test tolerances that were not suitable for single precision. Each failing case was compared with its theoretically expected single-precision roundoff floor, and the observed errors were consistent with floating-point roundoff rather than implementation errors.

Several tests used hardcoded tolerances such as `tol = 1e-8`, which are appropriate for double precision but can be below the achievable error floor in single precision. A derivative operator amplifies input roundoff by approximately `1/dx` for a first derivative and `1/dx^2` for a second derivative. At `n_glob = 1024`, single-precision epsilon (`eps_sp ~ 1.19e-7`) therefore produces an irreducible error floor of approximately `3e-3` for second derivatives.

The following table compares the observed errors with the expected single-precision roundoff floors:

| Test | Check | Observed error | Predicted floor | Amplification mechanism |
|---|---|---|---|---|
| test_thom (n_glob=1024) | 2nd deriv, periodic | 3.5e-3 | ~3.2e-3 | `eps/dx^2`, `dx = 2pi/1024` |
| test_thom (n_glob=1024) | 2nd deriv, Dirichlet | 8.6e-3 | ~3e-3 (+boundary rows) | `eps/dx^2` |
| test_omp_tridiag | 1st deriv | 1.0–1.3e-5 | ~2e-5 | `eps/dx` |
| test_omp_tridiag | 2nd deriv | 3.2e-3 | ~3.2e-3 | `eps/dx^2` |
| test_omp_tridiag | interpolation | 9.2e-8 | ~1.2e-7 | `eps` (no amplification) |
| test_omp_tridiag | staggered deriv | 2.4–2.7e-5 | ~2e-5 | `eps/dx` |
| test_omp_tridiag | hyperviscous 2nd deriv | 0.57 | ~0.2 | `eps/dx^2 x nu0_nu (=63)` |
| transeq family (96³) | conv + diff RHS | 1.1–6.0e-4 | ~3e-5 × O(10) coeffs | `eps/dx^2` |
| test_statistics | running mean, 200 samples | 2.8e-9 | <=2e-5 | accumulation roundoff |
| test_mesh | `geo%d(Y) - 0.25` | 1.5e-8 | 1 ulp of 0.25 | fast-math reciprocal |

#### Fast-math behaviour in `test_math`
One test case (`test_mesh_omp_4`) expected the exactly representable value `1/4 = 0.25`. In a `Release` build, however, `-ffast-math` allows GCC to vectorise divisions using hardware reciprocal approximations. The resulting value may differ by approximately one ulp. For example with `-ffast-math`, the runtime division can produce: `2.49999985E-01` instead of `2.50000000E-01`. This behaviour was only found to affect this particular test. The `-ffast-math` flag is retained for performance reasons, and the tolerance is now scaled with the working precision.

#### Spectral Poisson solver bug
A real bug was found in both backends’ spectral Poisson kernels. The kernels used a hardcoded threshold when testing modified wave numbers for zero.

These wave numbers include staggered-interpolation transfer functions that vanish identically at Nyquist-type modes. In double precision, the corresponding entries evaluate to approximately `1e-20` because of roundoff and are therefore below the existing `1e-16` guard. In single precision, however, the same expressions leave approximately `1e-13` of roundoff noise, which is above that guard.

As a result, the solver divided the FFT of the RHS by values of approximately `1e-13`. In `test_poisson_bc`, this produced normalised errors as large as `6.9e+3`.

The threshold now scales with the working precision using the module-level parameter: `eps_wave = epsilon(1._dp)`. This evaluates to approximately `1.2e-7` in single precision and `2.2e-16` in double precision. The hardcoded `1.e-16_dp` guards have been replaced with `eps_wave` in both backends. After this fix, the affected error drops from `6.9e+3` to `7.1e-6`.


#### `test_poisson_bc` tolerance
While retuning `test_poisson_bc`, a related constraint was identified: its tolerance must lie between the single-precision roundoff floor of passing cases -- approximately `3e-7` in the test’s normalised norm -- and the expected aliasing error of approximately `2.4e-6`. The tolerance is now `1e-6`. This leaves a margin of roughly three on either side. If the test becomes flaky in the future, this narrow separation should be revisited.

After these fixes, all tests pass in single precision with both the OMP and CUDA backends. Closes #210.