### PR TITLE
fix nvlink cudadevrt ordering error on NVHPC GPU builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,5 +42,21 @@ if (${OMP_TGT} AND NOT
 endif()
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include)
+
+# Resolve OpenMP once here so src/ and tests/ share a single import target.
+find_package(OpenMP REQUIRED)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" OR
+   CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
+  # FindOpenMP probing nvfortran with -cuda pulls the CUDA runtime into the OpenMP
+  # target with cudadevrt not last -> nvlink "unexpected object after cudadevrt".
+  # Drop them; the per-target -cuda link option relinks them with cudadevrt last.
+  get_target_property(_omp_fortran_libs OpenMP::OpenMP_Fortran INTERFACE_LINK_LIBRARIES)
+  if(_omp_fortran_libs)
+    list(FILTER _omp_fortran_libs EXCLUDE REGEX "cuda")
+    set_target_properties(OpenMP::OpenMP_Fortran PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${_omp_fortran_libs}")
+  endif()
+endif()
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,7 +163,7 @@ if(WITH_2DECOMPFFT)
   target_compile_options(x3d2_backends PRIVATE "-DWITH_2DECOMPFFT")
 endif()
 
-find_package(OpenMP REQUIRED)
+# OpenMP is resolved once at the top level (see the root CMakeLists.txt).
 target_link_libraries(x3d2 PRIVATE OpenMP::OpenMP_Fortran)
 target_link_libraries(x3d2_backends PRIVATE OpenMP::OpenMP_Fortran)
 target_link_libraries(xcompact PRIVATE OpenMP::OpenMP_Fortran)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ function(define_test testfile np backend)
         set(CMAKE_Fortran_FLAGS_DEBUG "-g -Wall -Wno-ambiguous-structure-constructor -Werror")
       endif()
     endif()
-    find_package(OpenMP REQUIRED)
+    # OpenMP is resolved once at the top level (see the root CMakeLists.txt).
     target_link_libraries(${test_name} PRIVATE OpenMP::OpenMP_Fortran)
 
     if(${backend} STREQUAL omp_tgt)


### PR DESCRIPTION
This problem was produced on NVHPC 23.1 and CMake 3.26.5, however, it is a real issue that might cause issues even with later versions of NVHPC. 

The code was calling `find_package(OpenMP)` in `src/CMakeLists.txt` after `-cuda` is added to `CMAKE_Fortran_FLAGS`. Because `-cuda` was active `FindOpenMP` tested the compiler with it and picked up NVHPC's CUDA runtime libaries (`cudafor_120;cudafor;acchost;cudadevrt;cudart;cudafor2`) as part of OpenMP. These then landed on every link line with `libcudadevrt.a` not last. `nvlink` needs `cudadevrt` to come last, so the link failed with: `nvlink fatal: unexpected object after cudadevrt`

#### Fix
- Find OpenMP just once, at the top level, so `src/` and `tests/` share one target. This also removes the duplicate `find_package(OpenMP)` calls that kept overwriting it.
- For NVHPC/PGI, remove the `cuda*` libraries from the OpenMP target. Each target already passes `-cuda`, which links the CUDA runtime itself with `cudadevrt` in the right place (last).

The cleanup runs on the finished target, so it works whether or not `-cuda` was active when OpenMP was found. Only the host OpenMP library (`libacchost.so`) is kept, and `-mp` still comes from the compile flags - so OpenMP still works, and
non-NVHPC/PGI compilers are untouched.