### PR TITLE
Add static Smagorinsky LES model

### DIFF
--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -1,6 +1,71 @@
 Input Parameters
 ----------------
 
+LES Parameters
+~~~~~~~~~~~~~~
+
+The explicit large-eddy simulation (LES) parameters are specified in the
+``les_params`` namelist block. The current implementation provides the shared
+Smagorinsky and wall-damping relations; computation of the field and its
+coupling to the momentum equations are under development. Until that coupling
+is complete, selecting ``'smagorinsky'`` does not alter a simulation.
+
+.. code-block:: fortran
+
+   &les_params
+     model = 'none'
+     smagorinsky_constant = 0.14
+     wall_damping = .false.
+     wall_damping_n = 3.0
+     von_karman_constant = 0.4
+     roughness_length = 0.0
+   /
+
+``model``: Explicit SGS model selector. Supported values are ``'none'`` and
+``'smagorinsky'``.
+  **Default:** ``'none'``
+
+``smagorinsky_constant``: Smagorinsky coefficient :math:`C_s`. Without wall
+damping, the mixing length is :math:`\ell_s=C_s\Delta`, where the local filter
+width is :math:`\Delta=(\Delta x\,\Delta y\,\Delta z)^{1/3}`. The eddy viscosity
+is
+
+.. math::
+
+   \nu_t = \ell_s^2 |S|, \qquad
+   |S| = \sqrt{2 S_{ij}S_{ij}}, \qquad
+   S_{ij} = \frac{1}{2}\left(
+     \frac{\partial u_i}{\partial x_j} +
+     \frac{\partial u_j}{\partial x_i}\right).
+
+  **Default:** ``0.14``
+
+``wall_damping``: Enables the Mason--Thomson mixing-length blend used by
+Incompact3d. For wall distance :math:`y` and roughness length :math:`z_0`,
+
+.. math::
+
+   \ell_s = \Delta\left[C_s^{-n} +
+   \left(\frac{\kappa(y+z_0)}{\Delta}\right)^{-n}\right]^{-1/n}.
+
+For a smooth wall (``roughness_length = 0``), this makes ``nut`` tend to zero
+at the wall and approach the undamped Smagorinsky value away from it.
+  **Default:** ``.false.``
+
+``wall_damping_n``: Exponent :math:`n` in the Mason--Thomson blend.
+  **Default:** ``3.0``
+
+``von_karman_constant``: von Karman constant :math:`\kappa` used by the
+wall-damping length scale.
+  **Default:** ``0.4``
+
+``roughness_length``: Aerodynamic roughness length :math:`z_0` in the same
+units as the mesh coordinates. Use ``0.0`` for a smooth wall.
+  **Default:** ``0.0``
+
+The Smagorinsky, wall-damping, and von Karman constants must be positive;
+``roughness_length`` must be non-negative.
+
 Checkpoint Parameters
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -5,10 +5,10 @@ LES Parameters
 ~~~~~~~~~~~~~~
 
 The explicit large-eddy simulation (LES) parameters are specified in the
-``les_params`` namelist block. The current implementation provides the shared
-Smagorinsky and wall-damping relations; computation of the field and its
-coupling to the momentum equations are under development. Until that coupling
-is complete, selecting ``'smagorinsky'`` does not alter a simulation.
+``les_params`` namelist block. The current implementation computes the
+Smagorinsky eddy-viscosity field on the OpenMP and CUDA backends. Coupling its
+stress divergence to the momentum equations is under development; until that
+coupling is complete, selecting ``'smagorinsky'`` does not alter a simulation.
 
 .. code-block:: fortran
 

--- a/docs/source/user/input_file.rst
+++ b/docs/source/user/input_file.rst
@@ -5,10 +5,11 @@ LES Parameters
 ~~~~~~~~~~~~~~
 
 The explicit large-eddy simulation (LES) parameters are specified in the
-``les_params`` namelist block. The current implementation computes the
-Smagorinsky eddy-viscosity field on the OpenMP and CUDA backends. Coupling its
-stress divergence to the momentum equations is under development; until that
-coupling is complete, selecting ``'smagorinsky'`` does not alter a simulation.
+optional ``les_params`` namelist block. Selecting ``'smagorinsky'`` computes
+the eddy-viscosity field and adds the SGS stress divergence to the momentum
+right-hand side at every Runge--Kutta stage or Adams--Bashforth step. This is
+supported on the OpenMP and CUDA backends. If the block is omitted, LES
+defaults to ``model = 'none'`` and the momentum equations are unchanged.
 
 .. code-block:: fortran
 

--- a/docs/source/user/post-processing/monitoring.rst
+++ b/docs/source/user/post-processing/monitoring.rst
@@ -13,7 +13,7 @@ The file is a comma-separated CSV with a header line:
 
 .. code-block:: text
 
-   # time, enstrophy, div_u_max, div_u_mean
+   # time, kinetic_energy, enstrophy, div_u_max, div_u_mean
 
 Each subsequent row contains one record per output step.
 
@@ -30,6 +30,9 @@ Quantities
    * - ``time``
      - Simulation time
      - :math:`t`
+   * - ``kinetic_energy``
+     - Spatially-averaged kinetic energy
+     - :math:`E_k = \frac{1}{2N} \sum |\mathbf{u}|^2`
    * - ``enstrophy``
      - Spatially-averaged enstrophy
      - :math:`\mathcal{E} = \frac{1}{2N} \sum |\nabla \times \mathbf{u}|^2`
@@ -39,6 +42,15 @@ Quantities
    * - ``div_u_mean``
      - Mean of :math:`|\nabla \cdot \mathbf{u}|`
      - Divergence-free check
+
+.. note::
+
+   For a freely decaying periodic flow such as Taylor--Green vortex, the
+   kinetic-energy decay rate is
+   :math:`\varepsilon = -\mathrm{d}E_k/\mathrm{d}t`.  In LES this includes
+   the effects of molecular, subgrid-scale, and any numerical dissipation,
+   whereas an estimate based only on enstrophy does not include the
+   subgrid-scale contribution.
 
 .. note::
 
@@ -58,19 +70,23 @@ Example: plotting with Python
    import pandas as pd
    import matplotlib.pyplot as plt
 
-   columns = ["time", "enstrophy", "div_u_max", "div_u_mean"]
+   columns = ["time", "kinetic_energy", "enstrophy",
+              "div_u_max", "div_u_mean"]
    df = pd.read_csv("monitoring.csv", comment="#", names=columns)
 
-   fig, axes = plt.subplots(3, 1, figsize=(8, 8), sharex=True)
+   fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
 
-   axes[0].plot(df["time"], df["enstrophy"])
-   axes[0].set_ylabel("Enstrophy")
+   axes[0].plot(df["time"], df["kinetic_energy"])
+   axes[0].set_ylabel("Kinetic energy")
 
-   axes[1].plot(df["time"], df["div_u_max"])
-   axes[1].set_ylabel("div(u) max")
+   axes[1].plot(df["time"], df["enstrophy"])
+   axes[1].set_ylabel("Enstrophy")
 
-   axes[2].plot(df["time"], df["div_u_mean"])
-   axes[2].set_ylabel("div(u) mean")
+   axes[2].plot(df["time"], df["div_u_max"])
+   axes[2].set_ylabel("div(u) max")
+
+   axes[3].plot(df["time"], df["div_u_mean"])
+   axes[3].set_ylabel("div(u) mean")
 
    axes[-1].set_xlabel("Time")
 

--- a/examples/TGV/input_static_smagorinsky.x3d
+++ b/examples/TGV/input_static_smagorinsky.x3d
@@ -6,10 +6,10 @@ flow_case_name = 'tgv'
 L_global = 6.283185307179586d0, 6.283185307179586d0, 6.283185307179586d0
 
 ! Global number of cells in each direction
-dims_global = 256, 256, 256
+dims_global = 160, 160, 160
 
 ! Domain decomposition in each direction
-nproc_dir = 1, 1, 2
+nproc_dir = 1, 1, 1
 
 ! BC options are 'periodic' | 'neumann' | 'dirichlet'
 BC_x = 'periodic', 'periodic'
@@ -18,14 +18,23 @@ BC_z = 'periodic', 'periodic'
 /End
 
 &solver_params
-Re = 1600d0
-time_intg = 'AB3' ! 'AB[1-4]' | 'RK[1-4]'
-dt = 0.001d0
-n_iters = 20000
-n_output = 100
+Re = 5000d0
+time_intg = 'RK3' ! 'AB[1-4]' | 'RK[1-4]'
+dt = 0.0025d0
+n_iters = 8000
+
+! Write monitoring every 0.02 time units, matching the DNS reference data.
+n_output = 8
+
 poisson_solver_type = 'FFT' ! 'FFT' | 'CG'
 der1st_scheme = 'compact6'
 der2nd_scheme = 'compact6' ! 'compact6' | 'compact6-hyperviscous'
-interpl_scheme = 'classic' ! 'classic' | 'optimised' | 'aggressive'
+interpl_scheme = 'aggressive' ! 'classic' | 'optimised' | 'aggressive'
 stagder_scheme = 'compact6'
+/End
+
+&les_params
+model = 'smagorinsky'
+smagorinsky_constant = 0.1d0
+wall_damping = .false.
 /End

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC
   ordering.f90
   poisson_fft.f90
   solver.f90
+  les/les.f90
   postprocess/postprocess.f90
   postprocess/monitoring.f90
   postprocess/scalar_series.f90

--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -230,7 +230,8 @@ module m_base_backend
   end interface
 
   abstract interface
-    real(dp) function vector_norm_squared_op(self, a, b, c) result(norm_squared)
+    real(dp) function vector_norm_squared_op(self, a, b, c) &
+      result(norm_squared)
       !! Computes the global discrete squared norm of a three-component field.
       import :: base_backend_t
       import :: dp

--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -43,6 +43,7 @@ module m_base_backend
     procedure(vecadd), deferred :: vecadd
     procedure(vecmult), deferred :: vecmult
     procedure(scalar_product), deferred :: scalar_product
+    procedure(vector_norm_squared_op), deferred :: vector_norm_squared
     procedure(field_max_mean), deferred :: field_max_mean
     procedure(slice_max_sum), deferred :: slice_max_sum
     procedure(field_ops), deferred :: field_scale
@@ -226,6 +227,19 @@ module m_base_backend
       class(base_backend_t) :: self
       class(field_t), intent(in) :: x, y
     end function scalar_product
+  end interface
+
+  abstract interface
+    real(dp) function vector_norm_squared_op(self, a, b, c) result(norm_squared)
+      !! Computes the global discrete squared norm of a three-component field.
+      import :: base_backend_t
+      import :: dp
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(in) :: a, b, c
+    end function vector_norm_squared_op
   end interface
 
   abstract interface

--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -53,6 +53,7 @@ module m_base_backend
     procedure(derive_field_from_gradients), deferred :: compute_vorticity
     procedure(derive_field_from_gradients), deferred :: compute_qcriterion
     procedure(smagorinsky_from_gradients), deferred :: compute_smagorinsky_nut
+    procedure(sgs_stress_from_gradients), deferred :: compute_sgs_stress
     procedure(copy_data_to_f), deferred :: copy_data_to_f
     procedure(copy_f_to_data), deferred :: copy_f_to_data
     procedure(alloc_tdsops), deferred :: alloc_tdsops
@@ -81,6 +82,22 @@ module m_base_backend
       real(dp), intent(in) :: nu
       type(dirps_t), intent(in) :: dirps
     end subroutine transeq_ders
+  end interface
+
+  abstract interface
+    subroutine sgs_stress_from_gradients( &
+      self, stress, nut, gradient_a, gradient_b, scale_a, scale_b)
+      !! Forms nut*(scale_a*gradient_a + scale_b*gradient_b).
+      import :: base_backend_t
+      import :: dp
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(inout) :: stress
+      class(field_t), intent(in) :: nut, gradient_a, gradient_b
+      real(dp), intent(in) :: scale_a, scale_b
+    end subroutine sgs_stress_from_gradients
   end interface
 
   abstract interface

--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -52,6 +52,7 @@ module m_base_backend
     procedure(field_set_face_from_field), deferred :: field_set_face_from_field
     procedure(derive_field_from_gradients), deferred :: compute_vorticity
     procedure(derive_field_from_gradients), deferred :: compute_qcriterion
+    procedure(smagorinsky_from_gradients), deferred :: compute_smagorinsky_nut
     procedure(copy_data_to_f), deferred :: copy_data_to_f
     procedure(copy_f_to_data), deferred :: copy_f_to_data
     procedure(alloc_tdsops), deferred :: alloc_tdsops
@@ -322,6 +323,24 @@ module m_base_backend
       class(field_t), intent(in) :: dvdx, dvdy, dvdz
       class(field_t), intent(in) :: dwdx, dwdy, dwdz
     end subroutine derive_field_from_gradients
+  end interface
+
+  abstract interface
+    subroutine smagorinsky_from_gradients( &
+      self, nut, mixing_length_sq, dudx, dudy, dudz, dvdx, dvdy, dvdz, &
+      dwdx, dwdy, dwdz)
+      !! Computes nut=l_s^2*sqrt(2*S_ij*S_ij) from velocity gradients.
+      import :: base_backend_t
+      import :: field_t
+      implicit none
+
+      class(base_backend_t) :: self
+      class(field_t), intent(inout) :: nut
+      class(field_t), intent(in) :: mixing_length_sq
+      class(field_t), intent(in) :: dudx, dudy, dudz
+      class(field_t), intent(in) :: dvdx, dvdy, dvdz
+      class(field_t), intent(in) :: dwdx, dwdy, dwdz
+    end subroutine smagorinsky_from_gradients
   end interface
 
   abstract interface

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -23,6 +23,7 @@ module m_cuda_backend
   use m_cuda_kernels_dist, only: transeq_3fused_dist, transeq_3fused_subs
   use m_cuda_kernels_fieldops, only: axpby, buffer_copy, field_scale, &
                                      field_shift, scalar_product, &
+                                     vector_norm_squared, &
                                      field_max_sum, field_set_y_face, &
                                      field_set_x_face, &
                                      field_set_x_face_from_field, &
@@ -65,6 +66,7 @@ module m_cuda_backend
     procedure :: vecadd => vecadd_cuda
     procedure :: vecmult => vecmult_cuda
     procedure :: scalar_product => scalar_product_cuda
+    procedure :: vector_norm_squared => vector_norm_squared_cuda
     procedure :: field_max_mean => field_max_mean_cuda
     procedure :: slice_max_sum => slice_max_sum_cuda
     procedure :: field_scale => field_scale_cuda
@@ -935,6 +937,50 @@ contains
                        MPI_COMM_WORLD, ierr)
 
   end function scalar_product_cuda
+
+  real(dp) function vector_norm_squared_cuda(self, a, b, c) &
+    result(norm_squared)
+    !! Global sum of a**2 + b**2 + c**2, with one MPI reduction.
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(in) :: a, b, c
+
+    real(dp), device, pointer, dimension(:, :, :) :: a_d, b_d, c_d
+    real(dp), device, allocatable :: norm_squared_d
+    real(dp) :: local_sum
+    integer :: dims(3), dims_padded(3), ierr
+    type(dim3) :: blocks, threads
+
+    if (a%data_loc == NULL_LOC .or. b%data_loc == NULL_LOC .or. &
+        c%data_loc == NULL_LOC) then
+      error stop 'You must set data_loc before computing a vector norm.'
+    end if
+    if (a%data_loc /= b%data_loc .or. a%data_loc /= c%data_loc) then
+      error stop 'Vector-norm fields must use the same data location.'
+    end if
+    if (a%dir /= DIR_X .or. b%dir /= DIR_X .or. c%dir /= DIR_X) then
+      error stop 'Vector-norm fields must use DIR_X layout.'
+    end if
+
+    call resolve_field_t(a_d, a)
+    call resolve_field_t(b_d, b)
+    call resolve_field_t(c_d, c)
+
+    allocate (norm_squared_d)
+    norm_squared_d = 0._dp
+    dims = self%mesh%get_dims(a%data_loc)
+    dims_padded = self%allocator%get_padded_dims(DIR_C)
+
+    blocks = dim3(dims(3), (dims(2) - 1)/SZ + 1, 1)
+    threads = dim3(SZ, 1, 1)
+    call vector_norm_squared<<<blocks, threads>>>( & !&
+      norm_squared_d, a_d, b_d, c_d, dims(1), dims_padded(3), dims(2))
+
+    local_sum = norm_squared_d
+    call MPI_Allreduce(local_sum, norm_squared, 1, MPI_X3D2_DP, MPI_SUM, &
+                       MPI_COMM_WORLD, ierr)
+  end function vector_norm_squared_cuda
 
   subroutine copy_into_buffers(u_send_s_dev, u_send_e_dev, u_dev, n)
     implicit none

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -29,7 +29,8 @@ module m_cuda_backend
                                      field_set_y_face_from_field, &
                                      pwmul, volume_integral, &
                                      vorticity_from_gradients, &
-                                     qcriterion_from_gradients
+                                     qcriterion_from_gradients, &
+                                     smagorinsky_from_gradients
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c, &
@@ -71,6 +72,7 @@ module m_cuda_backend
     procedure :: field_set_face_from_field => field_set_face_from_field_cuda
     procedure :: compute_vorticity => compute_vorticity_cuda
     procedure :: compute_qcriterion => compute_qcriterion_cuda
+    procedure :: compute_smagorinsky_nut => compute_smagorinsky_nut_cuda
     procedure :: field_volume_integral => field_volume_integral_cuda
     procedure :: copy_data_to_f => copy_data_to_f_cuda
     procedure :: copy_f_to_data => copy_f_to_data_cuda
@@ -815,6 +817,45 @@ contains
       dwdy_d, dwdz_d, n) !&
 
   end subroutine compute_qcriterion_cuda
+
+  subroutine compute_smagorinsky_nut_cuda( &
+    self, nut, mixing_length_sq, dudx, dudy, dudz, dvdx, dvdy, dvdz, &
+    dwdx, dwdy, dwdz)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(inout) :: nut
+    class(field_t), intent(in) :: mixing_length_sq
+    class(field_t), intent(in) :: dudx, dudy, dudz
+    class(field_t), intent(in) :: dvdx, dvdy, dvdz
+    class(field_t), intent(in) :: dwdx, dwdy, dwdz
+
+    real(dp), device, pointer, dimension(:, :, :) :: &
+      nut_d, mixing_length_sq_d, dudx_d, dudy_d, dudz_d, &
+      dvdx_d, dvdy_d, dvdz_d, dwdx_d, dwdy_d, dwdz_d
+    type(dim3) :: blocks, threads
+    integer :: n
+
+    call resolve_field_t(nut_d, nut)
+    call resolve_field_t(mixing_length_sq_d, mixing_length_sq)
+    call resolve_field_t(dudx_d, dudx)
+    call resolve_field_t(dudy_d, dudy)
+    call resolve_field_t(dudz_d, dudz)
+    call resolve_field_t(dvdx_d, dvdx)
+    call resolve_field_t(dvdy_d, dvdy)
+    call resolve_field_t(dvdz_d, dvdz)
+    call resolve_field_t(dwdx_d, dwdx)
+    call resolve_field_t(dwdy_d, dwdy)
+    call resolve_field_t(dwdz_d, dwdz)
+
+    n = size(nut_d, dim=2)
+    blocks = dim3(size(nut_d, dim=3), 1, 1)
+    threads = dim3(SZ, 1, 1)
+    call smagorinsky_from_gradients<<<blocks, threads>>>( &
+      nut_d, mixing_length_sq_d, dudx_d, dudy_d, dudz_d, &
+      dvdx_d, dvdy_d, dvdz_d, dwdx_d, dwdy_d, dwdz_d, n) !&
+
+  end subroutine compute_smagorinsky_nut_cuda
 
   real(dp) function scalar_product_cuda(self, x, y) result(s)
     !! [[m_base_backend(module):scalar_product(interface)]]

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -30,7 +30,8 @@ module m_cuda_backend
                                      pwmul, volume_integral, &
                                      vorticity_from_gradients, &
                                      qcriterion_from_gradients, &
-                                     smagorinsky_from_gradients
+                                     smagorinsky_from_gradients, &
+                                     sgs_stress_from_gradients
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c, &
@@ -73,6 +74,7 @@ module m_cuda_backend
     procedure :: compute_vorticity => compute_vorticity_cuda
     procedure :: compute_qcriterion => compute_qcriterion_cuda
     procedure :: compute_smagorinsky_nut => compute_smagorinsky_nut_cuda
+    procedure :: compute_sgs_stress => compute_sgs_stress_cuda
     procedure :: field_volume_integral => field_volume_integral_cuda
     procedure :: copy_data_to_f => copy_data_to_f_cuda
     procedure :: copy_f_to_data => copy_f_to_data_cuda
@@ -856,6 +858,33 @@ contains
       dvdx_d, dvdy_d, dvdz_d, dwdx_d, dwdy_d, dwdz_d, n) !&
 
   end subroutine compute_smagorinsky_nut_cuda
+
+  subroutine compute_sgs_stress_cuda( &
+    self, stress, nut, gradient_a, gradient_b, scale_a, scale_b)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(inout) :: stress
+    class(field_t), intent(in) :: nut, gradient_a, gradient_b
+    real(dp), intent(in) :: scale_a, scale_b
+
+    real(dp), device, pointer, dimension(:, :, :) :: &
+      stress_d, nut_d, gradient_a_d, gradient_b_d
+    type(dim3) :: blocks, threads
+    integer :: n
+
+    call resolve_field_t(stress_d, stress)
+    call resolve_field_t(nut_d, nut)
+    call resolve_field_t(gradient_a_d, gradient_a)
+    call resolve_field_t(gradient_b_d, gradient_b)
+
+    n = size(stress_d, dim=2)
+    blocks = dim3(size(stress_d, dim=3), 1, 1)
+    threads = dim3(SZ, 1, 1)
+    call sgs_stress_from_gradients<<<blocks, threads>>>( &
+      stress_d, nut_d, gradient_a_d, gradient_b_d, &
+      scale_a, scale_b, n) !&
+  end subroutine compute_sgs_stress_cuda
 
   real(dp) function scalar_product_cuda(self, x, y) result(s)
     !! [[m_base_backend(module):scalar_product(interface)]]

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -216,8 +216,9 @@ contains
 
     do j = 1, n
       if (nut(i, j, b) > 0._dp) then
-        stress(i, j, b) = nut(i, j, b)*( &
-          scale_a*gradient_a(i, j, b) + scale_b*gradient_b(i, j, b))
+        stress(i, j, b) = nut(i, j, b)* &
+                          (scale_a*gradient_a(i, j, b) &
+                           + scale_b*gradient_b(i, j, b))
       else
         stress(i, j, b) = 0._dp
       end if

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -249,6 +249,32 @@ contains
 
   end subroutine scalar_product
 
+  attributes(global) subroutine vector_norm_squared(s, a, b, c, &
+                                                    n, n_i_pad, n_j)
+    implicit none
+
+    real(dp), device, intent(inout) :: s
+    real(dp), device, intent(in), dimension(:, :, :) :: a, b, c
+    integer, value, intent(in) :: n, n_i_pad, n_j
+
+    real(dp) :: pencil_sum
+    integer :: i, j, pencil, block_i, block_j, ierr
+
+    i = threadIdx%x
+    block_i = blockIdx%x
+    block_j = blockIdx%y
+    pencil = block_i + (block_j - 1)*n_i_pad
+
+    pencil_sum = 0._dp
+    if (i + (block_j - 1)*blockDim%x <= n_j) then
+      do j = 1, n
+        pencil_sum = pencil_sum + a(i, j, pencil)**2 + &
+                     b(i, j, pencil)**2 + c(i, j, pencil)**2
+      end do
+    end if
+    ierr = atomicadd(s, pencil_sum)
+  end subroutine vector_norm_squared
+
   attributes(global) subroutine field_max_sum(max_f, sum_f, f, n, n_i_pad, n_j)
     implicit none
 

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -199,6 +199,31 @@ contains
 
   end subroutine smagorinsky_from_gradients
 
+  attributes(global) subroutine sgs_stress_from_gradients( &
+    stress, nut, gradient_a, gradient_b, scale_a, scale_b, n)
+    implicit none
+
+    real(dp), device, intent(out), dimension(:, :, :) :: stress
+    real(dp), device, intent(in), dimension(:, :, :) :: &
+      nut, gradient_a, gradient_b
+    real(dp), value, intent(in) :: scale_a, scale_b
+    integer, value, intent(in) :: n
+
+    integer :: i, j, b
+
+    i = threadIdx%x
+    b = blockIdx%x
+
+    do j = 1, n
+      if (nut(i, j, b) > 0._dp) then
+        stress(i, j, b) = nut(i, j, b)*( &
+          scale_a*gradient_a(i, j, b) + scale_b*gradient_b(i, j, b))
+      else
+        stress(i, j, b) = 0._dp
+      end if
+    end do
+  end subroutine sgs_stress_from_gradients
+
   attributes(global) subroutine scalar_product(s, x, y, n, n_i_pad, n_j)
     implicit none
 

--- a/src/backend/cuda/kernels/fieldops.f90
+++ b/src/backend/cuda/kernels/fieldops.f90
@@ -166,6 +166,39 @@ contains
 
   end subroutine qcriterion_from_gradients
 
+  attributes(global) subroutine smagorinsky_from_gradients( &
+    nut, mixing_length_sq, dudx, dudy, dudz, dvdx, dvdy, dvdz, &
+    dwdx, dwdy, dwdz, n)
+    implicit none
+
+    real(dp), device, intent(out), dimension(:, :, :) :: nut
+    real(dp), device, intent(in), dimension(:, :, :) :: mixing_length_sq
+    real(dp), device, intent(in), dimension(:, :, :) :: dudx, dudy, dudz
+    real(dp), device, intent(in), dimension(:, :, :) :: dvdx, dvdy, dvdz
+    real(dp), device, intent(in), dimension(:, :, :) :: dwdx, dwdy, dwdz
+    integer, value, intent(in) :: n
+
+    real(dp) :: sij_sq
+    integer :: i, j, b
+
+    i = threadIdx%x
+    b = blockIdx%x
+
+    do j = 1, n
+      if (mixing_length_sq(i, j, b) > 0._dp) then
+        sij_sq = dudx(i, j, b)**2 + dvdy(i, j, b)**2 + &
+                 dwdz(i, j, b)**2 + &
+                 0.5_dp*(dudy(i, j, b) + dvdx(i, j, b))**2 + &
+                 0.5_dp*(dudz(i, j, b) + dwdx(i, j, b))**2 + &
+                 0.5_dp*(dvdz(i, j, b) + dwdy(i, j, b))**2
+        nut(i, j, b) = mixing_length_sq(i, j, b)*sqrt(2._dp*sij_sq)
+      else
+        nut(i, j, b) = 0._dp
+      end if
+    end do
+
+  end subroutine smagorinsky_from_gradients
+
   attributes(global) subroutine scalar_product(s, x, y, n, n_i_pad, n_j)
     implicit none
 

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -50,6 +50,7 @@ module m_omp_backend
     procedure :: field_set_face_from_field => field_set_face_from_field_omp
     procedure :: compute_vorticity => compute_vorticity_omp
     procedure :: compute_qcriterion => compute_qcriterion_omp
+    procedure :: compute_smagorinsky_nut => compute_smagorinsky_nut_omp
     procedure :: field_volume_integral => field_volume_integral_omp
     procedure :: copy_data_to_f => copy_data_to_f_omp
     procedure :: copy_f_to_data => copy_f_to_data_omp
@@ -648,6 +649,49 @@ contains
 
   end subroutine compute_qcriterion_omp
 
+  subroutine compute_smagorinsky_nut_omp( &
+    self, nut, mixing_length_sq, dudx, dudy, dudz, dvdx, dvdy, dvdz, &
+    dwdx, dwdy, dwdz)
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(inout) :: nut
+    class(field_t), intent(in) :: mixing_length_sq
+    class(field_t), intent(in) :: dudx, dudy, dudz
+    class(field_t), intent(in) :: dvdx, dvdy, dvdz
+    class(field_t), intent(in) :: dwdx, dwdy, dwdz
+
+    real(dp) :: sij_sq
+    integer :: i, j, k
+
+    !$omp parallel do private(sij_sq) collapse(2)
+    do k = 1, size(nut%data, 3)
+      do j = 1, size(nut%data, 2)
+        !$omp simd private(sij_sq)
+        do i = 1, size(nut%data, 1)
+          if (mixing_length_sq%data(i, j, k) > 0._dp) then
+            sij_sq = dudx%data(i, j, k)**2 + &
+                     dvdy%data(i, j, k)**2 + &
+                     dwdz%data(i, j, k)**2 + &
+                     0.5_dp*(dudy%data(i, j, k) + &
+                             dvdx%data(i, j, k))**2 + &
+                     0.5_dp*(dudz%data(i, j, k) + &
+                             dwdx%data(i, j, k))**2 + &
+                     0.5_dp*(dvdz%data(i, j, k) + &
+                             dwdy%data(i, j, k))**2
+            nut%data(i, j, k) = mixing_length_sq%data(i, j, k)* &
+                                 sqrt(2._dp*sij_sq)
+          else
+            nut%data(i, j, k) = 0._dp
+          end if
+        end do
+        !$omp end simd
+      end do
+    end do
+    !$omp end parallel do
+
+  end subroutine compute_smagorinsky_nut_omp
+
   real(dp) function scalar_product_omp(self, x, y) result(s)
     !! [[m_base_backend(module):scalar_product(interface)]]
     implicit none
@@ -1108,4 +1152,3 @@ contains
   end subroutine init_omp_poisson_fft
 
 end module m_omp_backend
-

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -51,6 +51,7 @@ module m_omp_backend
     procedure :: compute_vorticity => compute_vorticity_omp
     procedure :: compute_qcriterion => compute_qcriterion_omp
     procedure :: compute_smagorinsky_nut => compute_smagorinsky_nut_omp
+    procedure :: compute_sgs_stress => compute_sgs_stress_omp
     procedure :: field_volume_integral => field_volume_integral_omp
     procedure :: copy_data_to_f => copy_data_to_f_omp
     procedure :: copy_f_to_data => copy_f_to_data_omp
@@ -691,6 +692,35 @@ contains
     !$omp end parallel do
 
   end subroutine compute_smagorinsky_nut_omp
+
+  subroutine compute_sgs_stress_omp( &
+    self, stress, nut, gradient_a, gradient_b, scale_a, scale_b)
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(inout) :: stress
+    class(field_t), intent(in) :: nut, gradient_a, gradient_b
+    real(dp), intent(in) :: scale_a, scale_b
+    integer :: i, j, k
+
+    !$omp parallel do collapse(2)
+    do k = 1, size(stress%data, 3)
+      do j = 1, size(stress%data, 2)
+        !$omp simd
+        do i = 1, size(stress%data, 1)
+          if (nut%data(i, j, k) > 0._dp) then
+            stress%data(i, j, k) = nut%data(i, j, k)*( &
+              scale_a*gradient_a%data(i, j, k) + &
+              scale_b*gradient_b%data(i, j, k))
+          else
+            stress%data(i, j, k) = 0._dp
+          end if
+        end do
+        !$omp end simd
+      end do
+    end do
+    !$omp end parallel do
+  end subroutine compute_sgs_stress_omp
 
   real(dp) function scalar_product_omp(self, x, y) result(s)
     !! [[m_base_backend(module):scalar_product(interface)]]

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -42,6 +42,7 @@ module m_omp_backend
     procedure :: vecadd => vecadd_omp
     procedure :: vecmult => vecmult_omp
     procedure :: scalar_product => scalar_product_omp
+    procedure :: vector_norm_squared => vector_norm_squared_omp
     procedure :: field_max_mean => field_max_mean_omp
     procedure :: slice_max_sum => slice_max_sum_omp
     procedure :: field_scale => field_scale_omp
@@ -784,6 +785,55 @@ contains
                        ierr)
 
   end function scalar_product_omp
+
+  real(dp) function vector_norm_squared_omp(self, a, b, c) &
+    result(norm_squared)
+    !! Global sum of a**2 + b**2 + c**2, with one MPI reduction.
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(in) :: a, b, c
+
+    real(dp) :: local_sum, pencil_sum
+    integer :: dims(3), stacked
+    integer :: i, j, k, k_i, k_j, ierr
+
+    if (a%data_loc == NULL_LOC .or. b%data_loc == NULL_LOC .or. &
+        c%data_loc == NULL_LOC) then
+      error stop 'You must set data_loc before computing a vector norm.'
+    end if
+    if (a%data_loc /= b%data_loc .or. a%data_loc /= c%data_loc) then
+      error stop 'Vector-norm fields must use the same data location.'
+    end if
+    if (a%dir /= DIR_X .or. b%dir /= DIR_X .or. c%dir /= DIR_X) then
+      error stop 'Vector-norm fields must use DIR_X layout.'
+    end if
+
+    dims = self%mesh%get_dims(a%data_loc)
+    stacked = (dims(2) - 1)/SZ + 1
+
+    local_sum = 0._dp
+    !$omp parallel do collapse(2) reduction(+:local_sum) private(k, pencil_sum)
+    do k_j = 1, stacked
+      do k_i = 1, dims(3)
+        k = k_j + (k_i - 1)*stacked
+        pencil_sum = 0._dp
+        do j = 1, dims(1)
+          !$omp simd reduction(+:pencil_sum)
+          do i = 1, min(SZ, dims(2) - (k_j - 1)*SZ)
+            pencil_sum = pencil_sum + a%data(i, j, k)**2 + &
+                         b%data(i, j, k)**2 + c%data(i, j, k)**2
+          end do
+          !$omp end simd
+        end do
+        local_sum = local_sum + pencil_sum
+      end do
+    end do
+    !$omp end parallel do
+
+    call MPI_Allreduce(local_sum, norm_squared, 1, MPI_X3D2_DP, MPI_SUM, &
+                       MPI_COMM_WORLD, ierr)
+  end function vector_norm_squared_omp
 
   subroutine copy_into_buffers(u_send_s, u_send_e, u, n, n_groups)
     implicit none

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -682,7 +682,7 @@ contains
                      0.5_dp*(dvdz%data(i, j, k) + &
                              dwdy%data(i, j, k))**2
             nut%data(i, j, k) = mixing_length_sq%data(i, j, k)* &
-                                 sqrt(2._dp*sij_sq)
+                                sqrt(2._dp*sij_sq)
           else
             nut%data(i, j, k) = 0._dp
           end if
@@ -711,8 +711,8 @@ contains
         do i = 1, size(stress%data, 1)
           if (nut%data(i, j, k) > 0._dp) then
             stress%data(i, j, k) = nut%data(i, j, k)*( &
-              scale_a*gradient_a%data(i, j, k) + &
-              scale_b*gradient_b%data(i, j, k))
+                                   scale_a*gradient_a%data(i, j, k) + &
+                                   scale_b*gradient_b%data(i, j, k))
           else
             stress%data(i, j, k) = 0._dp
           end if

--- a/src/case/base_case.f90
+++ b/src/case/base_case.f90
@@ -137,6 +137,7 @@ contains
 
     call self%monitoring%finalise()
     call self%io_mgr%finalise()
+    call self%solver%finalise()
   end subroutine case_finalise
 
   subroutine set_init(self, field, field_func)

--- a/src/case/cylinder.f90
+++ b/src/case/cylinder.f90
@@ -253,7 +253,7 @@ contains
   end subroutine forcings_cylinder
 
   ! ==========================================================================
-  ! Post-processing: report enstrophy and divergence
+  ! Post-processing: report global monitoring quantities
   ! ==========================================================================
   subroutine postprocess_cylinder(self, iter, t)
     implicit none

--- a/src/config.f90
+++ b/src/config.f90
@@ -238,7 +238,8 @@ contains
     roughness_length = self%roughness_length
 
     if (present(nml_file) .and. present(nml_string)) then
-      error stop 'Reading LES config failed! Provide only a file name or source.'
+      error stop 'Reading LES config failed! &
+                 & Provide only a file name or source.'
     else if (present(nml_file)) then
       open (newunit=unit, file=nml_file, iostat=ierr)
       if (ierr /= 0) error stop 'Opening LES config file failed.'

--- a/src/config.f90
+++ b/src/config.f90
@@ -221,7 +221,7 @@ contains
     character(*), optional, intent(in) :: nml_file
     character(*), optional, intent(in) :: nml_string
 
-    integer :: unit
+    integer :: unit, ierr
     character(len=20) :: model
     real(dp) :: smagorinsky_constant, wall_damping_n, von_karman_constant
     real(dp) :: roughness_length
@@ -240,9 +240,13 @@ contains
     if (present(nml_file) .and. present(nml_string)) then
       error stop 'Reading LES config failed! Provide only a file name or source.'
     else if (present(nml_file)) then
-      open (newunit=unit, file=nml_file)
-      read (unit, nml=les_params)
+      open (newunit=unit, file=nml_file, iostat=ierr)
+      if (ierr /= 0) error stop 'Opening LES config file failed.'
+      read (unit, nml=les_params, iostat=ierr)
       close (unit)
+      ! Existing input files may omit this optional namelist. End-of-file
+      ! therefore selects the defaults, while a malformed block remains fatal.
+      if (ierr > 0) error stop 'Reading LES config failed.'
     else if (present(nml_string)) then
       read (nml_string, nml=les_params)
     else

--- a/src/config.f90
+++ b/src/config.f90
@@ -43,6 +43,18 @@ module m_config
     procedure :: read => read_solver_nml
   end type solver_config_t
 
+  type, extends(base_config_t) :: les_config_t
+    !! Configuration for explicit sub-grid-scale modelling.
+    character(len=20) :: model = 'none'
+    real(dp) :: smagorinsky_constant = 0.14_dp
+    logical :: wall_damping = .false.
+    real(dp) :: wall_damping_n = 3._dp
+    real(dp) :: von_karman_constant = 0.4_dp
+    real(dp) :: roughness_length = 0._dp
+  contains
+    procedure :: read => read_les_nml
+  end type les_config_t
+
   type, extends(base_config_t) :: channel_config_t
     real(dp) :: omega_rot
     real(dp) :: init_noise(3)
@@ -203,6 +215,59 @@ contains
     self%stagder_scheme = stagder_scheme
 
   end subroutine read_solver_nml
+
+  subroutine read_les_nml(self, nml_file, nml_string)
+    class(les_config_t) :: self
+    character(*), optional, intent(in) :: nml_file
+    character(*), optional, intent(in) :: nml_string
+
+    integer :: unit
+    character(len=20) :: model
+    real(dp) :: smagorinsky_constant, wall_damping_n, von_karman_constant
+    real(dp) :: roughness_length
+    logical :: wall_damping
+
+    namelist /les_params/ model, smagorinsky_constant, wall_damping, &
+      wall_damping_n, von_karman_constant, roughness_length
+
+    model = self%model
+    smagorinsky_constant = self%smagorinsky_constant
+    wall_damping = self%wall_damping
+    wall_damping_n = self%wall_damping_n
+    von_karman_constant = self%von_karman_constant
+    roughness_length = self%roughness_length
+
+    if (present(nml_file) .and. present(nml_string)) then
+      error stop 'Reading LES config failed! Provide only a file name or source.'
+    else if (present(nml_file)) then
+      open (newunit=unit, file=nml_file)
+      read (unit, nml=les_params)
+      close (unit)
+    else if (present(nml_string)) then
+      read (nml_string, nml=les_params)
+    else
+      error stop 'Reading LES config failed! Provide a file name or source.'
+    end if
+
+    select case (trim(model))
+    case ('none', 'smagorinsky')
+    case default
+      error stop 'Unknown LES model. Use "none" or "smagorinsky".'
+    end select
+    if (smagorinsky_constant <= 0._dp) &
+      error stop 'smagorinsky_constant must be positive.'
+    if (von_karman_constant <= 0._dp .or. wall_damping_n <= 0._dp) &
+      error stop 'LES wall-damping constants must be positive.'
+    if (roughness_length < 0._dp) &
+      error stop 'roughness_length must not be negative.'
+
+    self%model = trim(model)
+    self%smagorinsky_constant = smagorinsky_constant
+    self%wall_damping = wall_damping
+    self%wall_damping_n = wall_damping_n
+    self%von_karman_constant = von_karman_constant
+    self%roughness_length = roughness_length
+  end subroutine read_les_nml
 
   subroutine read_channel_nml(self, nml_file, nml_string)
     implicit none

--- a/src/les/les.f90
+++ b/src/les/les.f90
@@ -27,6 +27,7 @@ module m_les
     class(field_t), pointer :: nut => null()
     class(field_t), pointer :: mixing_length_sq => null()
   contains
+    procedure :: mixing_length
     procedure :: nut_from_gradient
     procedure :: compute_nut
     procedure :: apply_sgs_stress
@@ -98,30 +99,29 @@ contains
   end function wall_damped_mixing_length
 
   pure real(dp) function smagorinsky_nut( &
-    velocity_gradient, mixing_length) result(nut)
+    velocity_gradient, length) result(nut)
     real(dp), intent(in) :: velocity_gradient(3, 3)
-    real(dp), intent(in) :: mixing_length
+    real(dp), intent(in) :: length
 
-    nut = mixing_length**2*strain_rate_magnitude(velocity_gradient)
+    nut = length**2*strain_rate_magnitude(velocity_gradient)
   end function smagorinsky_nut
 
-  pure real(dp) function nut_from_gradient( &
-    self, velocity_gradient, spacing, wall_distance) result(nut)
+  pure real(dp) function mixing_length( &
+    self, spacing, wall_distance) result(length)
+    !! Smagorinsky mixing length, optionally Mason-Thomson wall-damped.
+    !!
+    !! Returns zero when wall damping is requested without a wall distance,
+    !! which in turn zeroes the eddy viscosity built from it.
     class(les_t), intent(in) :: self
-    real(dp), intent(in) :: velocity_gradient(3, 3), spacing(3)
+    real(dp), intent(in) :: spacing(3)
     real(dp), optional, intent(in) :: wall_distance
-    real(dp) :: delta, length
-
-    if (trim(self%model) == 'none') then
-      nut = 0._dp
-      return
-    end if
+    real(dp) :: delta
 
     delta = filter_width(spacing)
     length = self%smagorinsky_constant*delta
     if (self%wall_damping) then
       if (.not. present(wall_distance)) then
-        nut = 0._dp
+        length = 0._dp
         return
       end if
       length = wall_damped_mixing_length( &
@@ -130,7 +130,21 @@ contains
                self%wall_damping_n, self%roughness_length &
                )
     end if
-    nut = smagorinsky_nut(velocity_gradient, length)
+  end function mixing_length
+
+  pure real(dp) function nut_from_gradient( &
+    self, velocity_gradient, spacing, wall_distance) result(nut)
+    class(les_t), intent(in) :: self
+    real(dp), intent(in) :: velocity_gradient(3, 3), spacing(3)
+    real(dp), optional, intent(in) :: wall_distance
+
+    if (trim(self%model) == 'none') then
+      nut = 0._dp
+      return
+    end if
+
+    nut = smagorinsky_nut(velocity_gradient, &
+                          self%mixing_length(spacing, wall_distance))
   end function nut_from_gradient
 
   subroutine compute_nut(self, backend, mesh, u, v, w, &
@@ -357,7 +371,7 @@ contains
     type(mesh_t), intent(in) :: mesh
 
     real(dp), allocatable :: mixing_data(:, :, :)
-    real(dp) :: delta, length, spacing(3), wall_distance, y_lower
+    real(dp) :: spacing(3), wall_distance, y_lower
     integer :: dims(3), dims_padded(3), i, j, k
 
     dims = mesh%get_dims(VERT)
@@ -376,15 +390,7 @@ contains
         wall_distance = max(mesh%geo%vert_coords(j, 2) - y_lower, 0._dp)
         do i = 1, dims(1)
           spacing(1) = spacing_at_vertex(mesh, i, 1, dims(1))
-          delta = filter_width(spacing)
-          length = self%smagorinsky_constant*delta
-          if (self%wall_damping) then
-            length = wall_damped_mixing_length( &
-                     delta, wall_distance, self%smagorinsky_constant, &
-                     self%von_karman_constant, self%wall_damping_n, &
-                     self%roughness_length)
-          end if
-          mixing_data(i, j, k) = length**2
+          mixing_data(i, j, k) = self%mixing_length(spacing, wall_distance)**2
         end do
       end do
     end do

--- a/src/les/les.f90
+++ b/src/les/les.f90
@@ -1,0 +1,125 @@
+module m_les
+  !! Shared physics for explicit eddy-viscosity LES models.
+  !!
+  !! The field-level implementation will use backend derivative and pointwise
+  !! operations.  Keeping these scalar relations here gives both backends one
+  !! definition of the model and makes the closure independently testable.
+  use m_common, only: dp
+  use m_config, only: les_config_t
+
+  implicit none
+
+  private
+  public :: les_t, smagorinsky_nut, strain_rate_magnitude, &
+            filter_width, wall_damped_mixing_length
+
+  type :: les_t
+    character(len=20) :: model = 'none'
+    real(dp) :: smagorinsky_constant = 0.14_dp
+    logical :: wall_damping = .false.
+    real(dp) :: wall_damping_n = 3._dp
+    real(dp) :: von_karman_constant = 0.4_dp
+    real(dp) :: roughness_length = 0._dp
+  contains
+    procedure :: nut_from_gradient
+  end type les_t
+
+  interface les_t
+    module procedure les_init
+  end interface les_t
+
+contains
+
+  pure function les_init(config) result(les)
+    type(les_config_t), intent(in) :: config
+    type(les_t) :: les
+
+    les%model = config%model
+    les%smagorinsky_constant = config%smagorinsky_constant
+    les%wall_damping = config%wall_damping
+    les%wall_damping_n = config%wall_damping_n
+    les%von_karman_constant = config%von_karman_constant
+    les%roughness_length = config%roughness_length
+  end function les_init
+
+  pure real(dp) function filter_width(spacing) result(delta)
+    !! Volume-equivalent grid-filter width, Delta=(dx*dy*dz)^(1/3).
+    real(dp), intent(in) :: spacing(3)
+
+    if (any(spacing <= 0._dp)) then
+      delta = 0._dp
+    else
+      delta = product(spacing)**(1._dp/3._dp)
+    end if
+  end function filter_width
+
+  pure real(dp) function strain_rate_magnitude(velocity_gradient) result(smag)
+    !! |S|=sqrt(2 S_ij S_ij), where S_ij=(du_i/dx_j+du_j/dx_i)/2.
+    real(dp), intent(in) :: velocity_gradient(3, 3)
+    real(dp) :: sij_sq
+
+    sij_sq = velocity_gradient(1, 1)**2 + &
+             velocity_gradient(2, 2)**2 + &
+             velocity_gradient(3, 3)**2 + &
+             0.5_dp*(velocity_gradient(1, 2) + &
+                     velocity_gradient(2, 1))**2 + &
+             0.5_dp*(velocity_gradient(1, 3) + &
+                     velocity_gradient(3, 1))**2 + &
+             0.5_dp*(velocity_gradient(2, 3) + &
+                     velocity_gradient(3, 2))**2
+    smag = sqrt(2._dp*sij_sq)
+  end function strain_rate_magnitude
+
+  pure real(dp) function wall_damped_mixing_length( &
+    delta, wall_distance, smagorinsky_constant, von_karman_constant, exponent, &
+    roughness_length) result(length)
+    !! Mason-Thomson blend used by Incompact3d's ABL Smagorinsky path.
+    real(dp), intent(in) :: delta, wall_distance, smagorinsky_constant
+    real(dp), intent(in) :: von_karman_constant, exponent, roughness_length
+    real(dp) :: wall_scale
+
+    if (delta <= 0._dp .or. wall_distance + roughness_length <= 0._dp) then
+      length = 0._dp
+      return
+    end if
+
+    wall_scale = von_karman_constant*(wall_distance + roughness_length)/delta
+    length = delta*(smagorinsky_constant**(-exponent) + &
+                    wall_scale**(-exponent))**(-1._dp/exponent)
+  end function wall_damped_mixing_length
+
+  pure real(dp) function smagorinsky_nut( &
+    velocity_gradient, mixing_length) result(nut)
+    real(dp), intent(in) :: velocity_gradient(3, 3)
+    real(dp), intent(in) :: mixing_length
+
+    nut = mixing_length**2*strain_rate_magnitude(velocity_gradient)
+  end function smagorinsky_nut
+
+  pure real(dp) function nut_from_gradient( &
+    self, velocity_gradient, spacing, wall_distance) result(nut)
+    class(les_t), intent(in) :: self
+    real(dp), intent(in) :: velocity_gradient(3, 3), spacing(3)
+    real(dp), optional, intent(in) :: wall_distance
+    real(dp) :: delta, length
+
+    if (trim(self%model) == 'none') then
+      nut = 0._dp
+      return
+    end if
+
+    delta = filter_width(spacing)
+    length = self%smagorinsky_constant*delta
+    if (self%wall_damping) then
+      if (.not. present(wall_distance)) then
+        nut = 0._dp
+        return
+      end if
+      length = wall_damped_mixing_length(delta, wall_distance, &
+        self%smagorinsky_constant, self%von_karman_constant, &
+        self%wall_damping_n, self%roughness_length)
+    end if
+    nut = smagorinsky_nut(velocity_gradient, length)
+  end function nut_from_gradient
+
+end module m_les

--- a/src/les/les.f90
+++ b/src/les/les.f90
@@ -80,8 +80,8 @@ contains
   end function strain_rate_magnitude
 
   pure real(dp) function wall_damped_mixing_length( &
-    delta, wall_distance, smagorinsky_constant, von_karman_constant, exponent, &
-    roughness_length) result(length)
+    delta, wall_distance, smagorinsky_constant, von_karman_constant, &
+    exponent, roughness_length) result(length)
     !! Mason-Thomson blend used by Incompact3d's ABL Smagorinsky path.
     real(dp), intent(in) :: delta, wall_distance, smagorinsky_constant
     real(dp), intent(in) :: von_karman_constant, exponent, roughness_length
@@ -124,9 +124,11 @@ contains
         nut = 0._dp
         return
       end if
-      length = wall_damped_mixing_length(delta, wall_distance, &
-        self%smagorinsky_constant, self%von_karman_constant, &
-        self%wall_damping_n, self%roughness_length)
+      length = wall_damped_mixing_length( &
+               delta, wall_distance, &
+               self%smagorinsky_constant, self%von_karman_constant, &
+               self%wall_damping_n, self%roughness_length &
+               )
     end if
     nut = smagorinsky_nut(velocity_gradient, length)
   end function nut_from_gradient
@@ -285,7 +287,9 @@ contains
   end subroutine add_normal_stress
 
   subroutine add_shear_stress( &
-    backend, rhs_a, direction_a, rhs_b, direction_b, nut, gradient_a, gradient_b)
+    backend, rhs_a, direction_a, rhs_b, &
+    direction_b, nut, gradient_a, gradient_b &
+    )
     class(base_backend_t), intent(inout) :: backend
     class(field_t), intent(inout) :: rhs_a, rhs_b
     type(dirps_t), intent(in) :: direction_a, direction_b
@@ -376,9 +380,9 @@ contains
           length = self%smagorinsky_constant*delta
           if (self%wall_damping) then
             length = wall_damped_mixing_length( &
-              delta, wall_distance, self%smagorinsky_constant, &
-              self%von_karman_constant, self%wall_damping_n, &
-              self%roughness_length)
+                     delta, wall_distance, self%smagorinsky_constant, &
+                     self%von_karman_constant, self%wall_damping_n, &
+                     self%roughness_length)
           end if
           mixing_data(i, j, k) = length**2
         end do

--- a/src/les/les.f90
+++ b/src/les/les.f90
@@ -1,11 +1,15 @@
 module m_les
   !! Shared physics for explicit eddy-viscosity LES models.
   !!
-  !! The field-level implementation will use backend derivative and pointwise
-  !! operations.  Keeping these scalar relations here gives both backends one
-  !! definition of the model and makes the closure independently testable.
-  use m_common, only: dp
+  !! Derivatives and data movement are orchestrated here, while pointwise
+  !! operations are dispatched to the selected computational backend.
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, &
+                      RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Z2X
   use m_config, only: les_config_t
+  use m_field, only: field_t
+  use m_mesh, only: mesh_t
+  use m_tdsops, only: dirps_t
 
   implicit none
 
@@ -20,8 +24,12 @@ module m_les
     real(dp) :: wall_damping_n = 3._dp
     real(dp) :: von_karman_constant = 0.4_dp
     real(dp) :: roughness_length = 0._dp
+    class(field_t), pointer :: nut => null()
+    class(field_t), pointer :: mixing_length_sq => null()
   contains
     procedure :: nut_from_gradient
+    procedure :: compute_nut
+    procedure :: finalise
   end type les_t
 
   interface les_t
@@ -121,5 +129,170 @@ contains
     end if
     nut = smagorinsky_nut(velocity_gradient, length)
   end function nut_from_gradient
+
+  subroutine compute_nut(self, backend, mesh, u, v, w, &
+                         xdirps, ydirps, zdirps)
+    !! Compute the Smagorinsky eddy-viscosity field in DIR_X layout.
+    class(les_t), intent(inout) :: self
+    class(base_backend_t), intent(inout) :: backend
+    type(mesh_t), intent(in) :: mesh
+    class(field_t), intent(in) :: u, v, w
+    type(dirps_t), intent(in) :: xdirps, ydirps, zdirps
+
+    class(field_t), pointer :: dudx, dudy, dudz
+    class(field_t), pointer :: dvdx, dvdy, dvdz
+    class(field_t), pointer :: dwdx, dwdy, dwdz
+
+    if (u%dir /= DIR_X .or. v%dir /= DIR_X .or. w%dir /= DIR_X) then
+      error stop 'LES velocity fields must use DIR_X layout.'
+    end if
+
+    if (.not. associated(self%nut)) then
+      self%nut => backend%allocator%get_block(DIR_X, VERT)
+    end if
+
+    select case (trim(self%model))
+    case ('none')
+      call self%nut%fill(0._dp)
+      return
+    case ('smagorinsky')
+    case default
+      error stop 'Unsupported LES model in compute_nut.'
+    end select
+
+    if (.not. associated(self%mixing_length_sq)) then
+      self%mixing_length_sq => backend%allocator%get_block(DIR_X, VERT)
+      call initialise_mixing_length(self, backend, mesh)
+    end if
+
+    call derivative_to_x(backend, dudx, u, xdirps)
+    call derivative_to_x(backend, dvdx, v, xdirps)
+    call derivative_to_x(backend, dwdx, w, xdirps)
+    call derivative_to_x(backend, dudy, u, ydirps)
+    call derivative_to_x(backend, dvdy, v, ydirps)
+    call derivative_to_x(backend, dwdy, w, ydirps)
+    call derivative_to_x(backend, dudz, u, zdirps)
+    call derivative_to_x(backend, dvdz, v, zdirps)
+    call derivative_to_x(backend, dwdz, w, zdirps)
+
+    call backend%compute_smagorinsky_nut( &
+      self%nut, self%mixing_length_sq, &
+      dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+
+    call backend%allocator%release_block(dudx)
+    call backend%allocator%release_block(dudy)
+    call backend%allocator%release_block(dudz)
+    call backend%allocator%release_block(dvdx)
+    call backend%allocator%release_block(dvdy)
+    call backend%allocator%release_block(dvdz)
+    call backend%allocator%release_block(dwdx)
+    call backend%allocator%release_block(dwdy)
+    call backend%allocator%release_block(dwdz)
+  end subroutine compute_nut
+
+  subroutine derivative_to_x(backend, derivative, velocity, dirps)
+    class(base_backend_t), intent(inout) :: backend
+    class(field_t), pointer, intent(out) :: derivative
+    class(field_t), intent(in) :: velocity
+    type(dirps_t), intent(in) :: dirps
+
+    class(field_t), pointer :: velocity_dir, derivative_dir
+
+    derivative => backend%allocator%get_block(DIR_X)
+    select case (dirps%dir)
+    case (DIR_X)
+      call backend%tds_solve(derivative, velocity, dirps%der1st)
+    case (DIR_Y)
+      velocity_dir => backend%allocator%get_block(DIR_Y)
+      derivative_dir => backend%allocator%get_block(DIR_Y)
+      call backend%reorder(velocity_dir, velocity, RDR_X2Y)
+      call backend%tds_solve(derivative_dir, velocity_dir, dirps%der1st)
+      call backend%reorder(derivative, derivative_dir, RDR_Y2X)
+      call backend%allocator%release_block(velocity_dir)
+      call backend%allocator%release_block(derivative_dir)
+    case (DIR_Z)
+      velocity_dir => backend%allocator%get_block(DIR_Z)
+      derivative_dir => backend%allocator%get_block(DIR_Z)
+      call backend%reorder(velocity_dir, velocity, RDR_X2Z)
+      call backend%tds_solve(derivative_dir, velocity_dir, dirps%der1st)
+      call backend%reorder(derivative, derivative_dir, RDR_Z2X)
+      call backend%allocator%release_block(velocity_dir)
+      call backend%allocator%release_block(derivative_dir)
+    case default
+      error stop 'Invalid derivative direction in LES.'
+    end select
+  end subroutine derivative_to_x
+
+  subroutine initialise_mixing_length(self, backend, mesh)
+    class(les_t), intent(in) :: self
+    class(base_backend_t), intent(inout) :: backend
+    type(mesh_t), intent(in) :: mesh
+
+    real(dp), allocatable :: mixing_data(:, :, :)
+    real(dp) :: delta, length, spacing(3), wall_distance, y_lower
+    integer :: dims(3), dims_padded(3), i, j, k
+
+    dims = mesh%get_dims(VERT)
+    dims_padded = backend%allocator%get_padded_dims(DIR_C)
+    allocate (mixing_data(dims_padded(1), dims_padded(2), dims_padded(3)))
+    mixing_data = 0._dp
+
+    y_lower = 0._dp
+    if (trim(mesh%geo%stretching(2)) == 'centred') &
+      y_lower = -0.5_dp*mesh%geo%L(2)
+
+    do k = 1, dims(3)
+      spacing(3) = spacing_at_vertex(mesh, k, 3, dims(3))
+      do j = 1, dims(2)
+        spacing(2) = spacing_at_vertex(mesh, j, 2, dims(2))
+        wall_distance = max(mesh%geo%vert_coords(j, 2) - y_lower, 0._dp)
+        do i = 1, dims(1)
+          spacing(1) = spacing_at_vertex(mesh, i, 1, dims(1))
+          delta = filter_width(spacing)
+          length = self%smagorinsky_constant*delta
+          if (self%wall_damping) then
+            length = wall_damped_mixing_length( &
+              delta, wall_distance, self%smagorinsky_constant, &
+              self%von_karman_constant, self%wall_damping_n, &
+              self%roughness_length)
+          end if
+          mixing_data(i, j, k) = length**2
+        end do
+      end do
+    end do
+
+    call backend%set_field_data(self%mixing_length_sq, mixing_data)
+    deallocate (mixing_data)
+  end subroutine initialise_mixing_length
+
+  pure real(dp) function spacing_at_vertex(mesh, index, direction, n) &
+    result(spacing)
+    type(mesh_t), intent(in) :: mesh
+    integer, intent(in) :: index, direction, n
+
+    if (.not. mesh%geo%stretched(direction) .or. n == 1) then
+      spacing = mesh%geo%d(direction)
+    else if (index < n) then
+      spacing = abs(mesh%geo%vert_coords(index + 1, direction) - &
+                    mesh%geo%vert_coords(index, direction))
+    else
+      spacing = abs(mesh%geo%vert_coords(index, direction) - &
+                    mesh%geo%vert_coords(index - 1, direction))
+    end if
+  end function spacing_at_vertex
+
+  subroutine finalise(self, backend)
+    class(les_t), intent(inout) :: self
+    class(base_backend_t), intent(inout) :: backend
+
+    if (associated(self%nut)) then
+      call backend%allocator%release_block(self%nut)
+      nullify (self%nut)
+    end if
+    if (associated(self%mixing_length_sq)) then
+      call backend%allocator%release_block(self%mixing_length_sq)
+      nullify (self%mixing_length_sq)
+    end if
+  end subroutine finalise
 
 end module m_les

--- a/src/les/les.f90
+++ b/src/les/les.f90
@@ -29,6 +29,7 @@ module m_les
   contains
     procedure :: nut_from_gradient
     procedure :: compute_nut
+    procedure :: apply_sgs_stress
     procedure :: finalise
   end type les_t
 
@@ -165,6 +166,80 @@ contains
       call initialise_mixing_length(self, backend, mesh)
     end if
 
+    call compute_velocity_gradients( &
+      backend, u, v, w, xdirps, ydirps, zdirps, &
+      dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+
+    call backend%compute_smagorinsky_nut( &
+      self%nut, self%mixing_length_sq, &
+      dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+
+    call release_velocity_gradients( &
+      backend, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+  end subroutine compute_nut
+
+  subroutine apply_sgs_stress(self, backend, mesh, du, dv, dw, u, v, w, &
+                              xdirps, ydirps, zdirps)
+    !! Add div(2*nut*S_ij) to the momentum right-hand-side fields.
+    class(les_t), intent(inout) :: self
+    class(base_backend_t), intent(inout) :: backend
+    type(mesh_t), intent(in) :: mesh
+    class(field_t), intent(inout) :: du, dv, dw
+    class(field_t), intent(in) :: u, v, w
+    type(dirps_t), intent(in) :: xdirps, ydirps, zdirps
+
+    class(field_t), pointer :: dudx, dudy, dudz
+    class(field_t), pointer :: dvdx, dvdy, dvdz
+    class(field_t), pointer :: dwdx, dwdy, dwdz
+
+    if (trim(self%model) == 'none') return
+    if (trim(self%model) /= 'smagorinsky') &
+      error stop 'Unsupported LES model in apply_sgs_stress.'
+    if (du%dir /= DIR_X .or. dv%dir /= DIR_X .or. dw%dir /= DIR_X) then
+      error stop 'LES momentum RHS fields must use DIR_X layout.'
+    end if
+    if (u%dir /= DIR_X .or. v%dir /= DIR_X .or. w%dir /= DIR_X) then
+      error stop 'LES velocity fields must use DIR_X layout.'
+    end if
+
+    if (.not. associated(self%nut)) &
+      self%nut => backend%allocator%get_block(DIR_X, VERT)
+    if (.not. associated(self%mixing_length_sq)) then
+      self%mixing_length_sq => backend%allocator%get_block(DIR_X, VERT)
+      call initialise_mixing_length(self, backend, mesh)
+    end if
+
+    call compute_velocity_gradients( &
+      backend, u, v, w, xdirps, ydirps, zdirps, &
+      dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    call backend%compute_smagorinsky_nut( &
+      self%nut, self%mixing_length_sq, &
+      dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+
+    call add_normal_stress(backend, du, self%nut, dudx, xdirps)
+    call add_normal_stress(backend, dv, self%nut, dvdy, ydirps)
+    call add_normal_stress(backend, dw, self%nut, dwdz, zdirps)
+    call add_shear_stress( &
+      backend, du, ydirps, dv, xdirps, self%nut, dudy, dvdx)
+    call add_shear_stress( &
+      backend, du, zdirps, dw, xdirps, self%nut, dudz, dwdx)
+    call add_shear_stress( &
+      backend, dv, zdirps, dw, ydirps, self%nut, dvdz, dwdy)
+
+    call release_velocity_gradients( &
+      backend, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+  end subroutine apply_sgs_stress
+
+  subroutine compute_velocity_gradients( &
+    backend, u, v, w, xdirps, ydirps, zdirps, &
+    dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    class(base_backend_t), intent(inout) :: backend
+    class(field_t), intent(in) :: u, v, w
+    type(dirps_t), intent(in) :: xdirps, ydirps, zdirps
+    class(field_t), pointer, intent(out) :: dudx, dudy, dudz
+    class(field_t), pointer, intent(out) :: dvdx, dvdy, dvdz
+    class(field_t), pointer, intent(out) :: dwdx, dwdy, dwdz
+
     call derivative_to_x(backend, dudx, u, xdirps)
     call derivative_to_x(backend, dvdx, v, xdirps)
     call derivative_to_x(backend, dwdx, w, xdirps)
@@ -174,10 +249,14 @@ contains
     call derivative_to_x(backend, dudz, u, zdirps)
     call derivative_to_x(backend, dvdz, v, zdirps)
     call derivative_to_x(backend, dwdz, w, zdirps)
+  end subroutine compute_velocity_gradients
 
-    call backend%compute_smagorinsky_nut( &
-      self%nut, self%mixing_length_sq, &
-      dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+  subroutine release_velocity_gradients( &
+    backend, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz)
+    class(base_backend_t), intent(inout) :: backend
+    class(field_t), pointer, intent(inout) :: dudx, dudy, dudz
+    class(field_t), pointer, intent(inout) :: dvdx, dvdy, dvdz
+    class(field_t), pointer, intent(inout) :: dwdx, dwdy, dwdz
 
     call backend%allocator%release_block(dudx)
     call backend%allocator%release_block(dudy)
@@ -188,7 +267,52 @@ contains
     call backend%allocator%release_block(dwdx)
     call backend%allocator%release_block(dwdy)
     call backend%allocator%release_block(dwdz)
-  end subroutine compute_nut
+  end subroutine release_velocity_gradients
+
+  subroutine add_normal_stress(backend, rhs, nut, gradient, direction)
+    class(base_backend_t), intent(inout) :: backend
+    class(field_t), intent(inout) :: rhs
+    class(field_t), intent(in) :: nut, gradient
+    type(dirps_t), intent(in) :: direction
+
+    class(field_t), pointer :: stress
+
+    stress => backend%allocator%get_block(DIR_X, VERT)
+    call backend%compute_sgs_stress( &
+      stress, nut, gradient, gradient, 2._dp, 0._dp)
+    call add_stress_derivative(backend, rhs, stress, direction)
+    call backend%allocator%release_block(stress)
+  end subroutine add_normal_stress
+
+  subroutine add_shear_stress( &
+    backend, rhs_a, direction_a, rhs_b, direction_b, nut, gradient_a, gradient_b)
+    class(base_backend_t), intent(inout) :: backend
+    class(field_t), intent(inout) :: rhs_a, rhs_b
+    type(dirps_t), intent(in) :: direction_a, direction_b
+    class(field_t), intent(in) :: nut, gradient_a, gradient_b
+
+    class(field_t), pointer :: stress
+
+    stress => backend%allocator%get_block(DIR_X, VERT)
+    call backend%compute_sgs_stress( &
+      stress, nut, gradient_a, gradient_b, 1._dp, 1._dp)
+    call add_stress_derivative(backend, rhs_a, stress, direction_a)
+    call add_stress_derivative(backend, rhs_b, stress, direction_b)
+    call backend%allocator%release_block(stress)
+  end subroutine add_shear_stress
+
+  subroutine add_stress_derivative(backend, rhs, stress, direction)
+    class(base_backend_t), intent(inout) :: backend
+    class(field_t), intent(inout) :: rhs
+    class(field_t), intent(in) :: stress
+    type(dirps_t), intent(in) :: direction
+
+    class(field_t), pointer :: derivative
+
+    call derivative_to_x(backend, derivative, stress, direction)
+    call backend%vecadd(1._dp, derivative, 1._dp, rhs)
+    call backend%allocator%release_block(derivative)
+  end subroutine add_stress_derivative
 
   subroutine derivative_to_x(backend, derivative, velocity, dirps)
     class(base_backend_t), intent(inout) :: backend

--- a/src/postprocess/monitoring.f90
+++ b/src/postprocess/monitoring.f90
@@ -3,6 +3,7 @@ module m_monitoring
   !!
   !! Tracks the following quantities:
   !!
+  !! - Kinetic energy: \( E_k = \frac{1}{2N} \sum |\mathbf{u}|^2 \)
   !! - Enstrophy: \( \mathcal{E} = \frac{1}{2N} \sum |\nabla \times \mathbf{u}|^2 \)
   !! - Divergence: \( \max |\nabla \cdot \mathbf{u}| \) and mean (divergence-free check)
 
@@ -30,8 +31,9 @@ contains
     logical, intent(in), optional :: append
 
     logical :: append_output
-    character(len=16), parameter :: columns(3) = &
-                                    ['enstrophy      ', &
+    character(len=16), parameter :: columns(4) = &
+                                    ['kinetic_energy ', &
+                                     'enstrophy      ', &
                                      'div_u_max      ', &
                                      'div_u_mean     ']
 
@@ -52,7 +54,11 @@ contains
     class(field_t), intent(in) :: u, v, w
 
     class(field_t), pointer :: du, dv, dw, div_u
-    real(dp) :: enstrophy, div_u_max, div_u_mean
+    real(dp) :: kinetic_energy, enstrophy, div_u_max, div_u_mean
+
+    !! Kinetic energy: \( E_k = \frac{1}{2N} \sum |\mathbf{u}|^2 \)
+    kinetic_energy = 0.5_dp*solver%backend%vector_norm_squared(u, v, w) &
+                     /solver%ngrid
 
     !! Enstrophy: \( \mathcal{E} = \frac{1}{2N} \sum |\nabla \times \mathbf{u}|^2 \)
     du => solver%backend%allocator%get_block(DIR_X, VERT)
@@ -61,9 +67,7 @@ contains
 
     call solver%curl(du, dv, dw, u, v, w)
 
-    enstrophy = 0.5_dp*(solver%backend%scalar_product(du, du) &
-                        + solver%backend%scalar_product(dv, dv) &
-                        + solver%backend%scalar_product(dw, dw)) &
+    enstrophy = 0.5_dp*solver%backend%vector_norm_squared(du, dv, dw) &
                 /solver%ngrid
 
     call solver%backend%allocator%release_block(du)
@@ -81,10 +85,13 @@ contains
 
     ! Print to stdout and write to file (root only)
     if (self%is_root) then
+      print *, 'kinetic energy:', kinetic_energy
       print *, 'enstrophy:', enstrophy
       print *, 'div u max mean:', div_u_max, div_u_mean
 
-      call self%series%write_step(t, [enstrophy, div_u_max, div_u_mean])
+      call self%series%write_step(t, &
+                                  [kinetic_energy, enstrophy, &
+                                   div_u_max, div_u_mean])
     end if
 
   end subroutine write_step

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -9,9 +9,10 @@ module m_solver
                       RDR_Z2C, RDR_C2Z, &
                       DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, CELL, &
                       BC_NEUMANN, BC_DIRICHLET
-  use m_config, only: solver_config_t
+  use m_config, only: solver_config_t, les_config_t
   use m_field, only: field_t, flist_t
   use m_ibm, only: ibm_t
+  use m_les, only: les_t
   use m_mesh, only: mesh_t
   use m_tdsops, only: dirps_t
   use m_time_integrator, only: time_intg_t
@@ -70,11 +71,14 @@ module m_solver
     type(dirps_t), pointer :: xdirps, ydirps, zdirps
     type(vector_calculus_t) :: vector_calculus
     type(ibm_t) :: ibm
+    type(les_t) :: les
     logical :: ibm_on
     procedure(poisson_solver), pointer :: poisson => null()
     procedure(transport_equation), pointer :: transeq => null()
   contains
     procedure :: transeq_species
+    procedure :: apply_les
+    procedure :: finalise
     procedure :: pressure_correction
     procedure :: divergence_v2p
     procedure :: gradient_p2v
@@ -117,6 +121,7 @@ contains
     type(solver_t) :: solver
 
     type(solver_config_t) :: solver_cfg
+    type(les_config_t) :: les_cfg
     integer :: i
 
     solver%backend => backend
@@ -135,6 +140,10 @@ contains
     solver%w => solver%backend%allocator%get_block(DIR_X)
 
     call solver_cfg%read(nml_file=get_argument(1))
+    call les_cfg%read(nml_file=get_argument(1))
+    solver%les = les_t(les_cfg)
+    if (solver%mesh%par%is_root()) &
+      print *, 'LES model: ', trim(solver%les%model)
 
     ! Add transported species
     solver%nspecies = solver_cfg%n_species
@@ -381,6 +390,8 @@ contains
     call self%backend%allocator%release_block(dv_z)
     call self%backend%allocator%release_block(dw_z)
 
+    call self%apply_les(rhs, variables)
+
     ! Convection-diffusion for species
     if (self%nspecies > 0) then
       call self%transeq_species(rhs(4:), variables)
@@ -497,12 +508,34 @@ contains
     self%v => v
     self%w => w
 
+    call self%apply_les(rhs, variables)
+
     ! Convection-diffusion for species
     if (self%nspecies > 0) then
       call self%transeq_species(rhs(4:), variables)
     end if
 
   end subroutine transeq_lowmem
+
+  subroutine apply_les(self, rhs, variables)
+    !! Add the configured explicit SGS closure to the momentum RHS.
+    class(solver_t), intent(inout) :: self
+    type(flist_t), intent(inout) :: rhs(:)
+    type(flist_t), intent(in) :: variables(:)
+
+    call self%les%apply_sgs_stress( &
+      self%backend, self%mesh, &
+      rhs(1)%ptr, rhs(2)%ptr, rhs(3)%ptr, &
+      variables(1)%ptr, variables(2)%ptr, variables(3)%ptr, &
+      self%xdirps, self%ydirps, self%zdirps)
+  end subroutine apply_les
+
+  subroutine finalise(self)
+    !! Release resources owned by the solver and its runtime models.
+    class(solver_t), intent(inout) :: self
+
+    call self%les%finalise(self%backend)
+  end subroutine finalise
 
   subroutine transeq_species(self, rhs, variables)
     !! Skew-symmetric form of convection-diffusion terms in the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ define_verification_test(verification/test_omp_transeq.f90 ${CMAKE_CTEST_NPROCS}
 define_verification_test(verification/test_omp_transeq_species.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_verification_test(verification/test_omp_dist_transeq.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_verification_test(verification/test_time_integrator.f90 1 omp)
+define_verification_test(verification/test_les_field.f90 1 omp)
 if(WITH_2DECOMPFFT)
   define_verification_test(verification/test_fft.f90 4 omp)
 endif()
@@ -169,6 +170,7 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
   define_verification_test(verification/test_cuda_tridiag.f90 ${CMAKE_CTEST_NPROCS} cuda)
   define_verification_test(verification/test_cuda_penta.f90 ${CMAKE_CTEST_NPROCS} cuda)
   define_verification_test(verification/test_cuda_transeq.f90 ${CMAKE_CTEST_NPROCS} cuda)
+  define_verification_test(verification/test_les_field.f90 1 cuda)
 
   # CUDA performance tests
   define_performance_test(performance/perf_thom.f90 1 cuda)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ define_test(unit/test_setget_field.f90 1 omp)
 define_test(unit/test_snapshot_species_fields.f90 1 omp)
 define_test(unit/test_statistics.f90 1 omp)
 define_test(unit/test_output_scalars.f90 1 omp)
+define_test(unit/test_les.f90 1 omp)
 
 if(WITH_ADIOS2)
   define_test(unit/test_adios2_read_write.f90 4 omp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ define_test(unit/test_mesh.f90 4 omp)
 define_test(unit/test_reorder_map.f90 1 omp)
 define_test(unit/test_vecadd.f90 1 omp)
 define_test(unit/test_scalar_product.f90 ${CMAKE_CTEST_NPROCS} omp)
+define_test(unit/test_kinetic_energy.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(unit/test_sum_intox.f90 ${CMAKE_CTEST_NPROCS} omp)
 define_test(unit/test_setget_field.f90 1 omp)
 define_test(unit/test_snapshot_species_fields.f90 1 omp)
@@ -159,6 +160,7 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
   # CUDA unit tests
   define_test(unit/test_reordering.f90 1 cuda)
   define_test(unit/test_vecadd.f90 1 cuda)
+  define_test(unit/test_kinetic_energy.f90 1 cuda)
   define_test(unit/test_cuda_allocator.f90 1 cuda)
   define_test(unit/test_cuda_reorder.f90 1 cuda)
 

--- a/tests/unit/test_kinetic_energy.f90
+++ b/tests/unit/test_kinetic_energy.f90
@@ -1,0 +1,101 @@
+program test_kinetic_energy
+  !! Verifies the one-pass global squared norm used for kinetic energy.
+
+  use mpi
+
+  use m_allocator, only: allocator_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, DIR_X, VERT
+  use m_field, only: field_t
+  use m_mesh, only: mesh_t
+
+#ifdef CUDA
+  use m_cuda_allocator, only: cuda_allocator_t
+  use m_cuda_backend, only: cuda_backend_t
+  use m_cuda_common, only: SZ
+#else
+  use m_omp_backend, only: omp_backend_t
+  use m_omp_common, only: SZ
+#endif
+
+  implicit none
+
+  type(mesh_t), target :: mesh
+  class(allocator_t), pointer :: allocator
+  class(base_backend_t), pointer :: backend
+#ifdef CUDA
+  type(cuda_allocator_t), target :: cuda_allocator
+  type(cuda_backend_t), target :: cuda_backend
+#else
+  type(allocator_t), target :: omp_allocator
+  type(omp_backend_t), target :: omp_backend
+#endif
+  class(field_t), pointer :: u, v, w
+
+  integer :: dims_global(3), nproc_dir(3)
+  integer :: ierr, nrank, nproc
+  real(dp) :: energy, norm_squared, expected_norm_squared
+  real(dp), parameter :: expected_energy = 7._dp
+  real(dp), parameter :: lengths(3) = [1._dp, 1._dp, 1._dp]
+  real(dp), parameter :: tolerance = 100._dp*epsilon(1._dp)
+  character(len=8), parameter :: periodic(2) = &
+    ['periodic', 'periodic']
+  logical :: test_pass
+
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+
+  ! ny is not a multiple of SZ, so each field contains padding that the
+  ! reduction must exclude.  Keep twenty physical z points on every rank.
+  dims_global = [17, 18, 20*nproc]
+  nproc_dir = [1, 1, nproc]
+  mesh = mesh_t(dims_global, nproc_dir, lengths, &
+                periodic, periodic, periodic)
+
+#ifdef CUDA
+  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
+  allocator => cuda_allocator
+  cuda_backend = cuda_backend_t(mesh, allocator)
+  backend => cuda_backend
+#else
+  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
+  allocator => omp_allocator
+  omp_backend = omp_backend_t(mesh, allocator)
+  backend => omp_backend
+#endif
+
+  u => allocator%get_block(DIR_X, VERT)
+  v => allocator%get_block(DIR_X, VERT)
+  w => allocator%get_block(DIR_X, VERT)
+  call u%fill(1._dp)
+  call v%fill(2._dp)
+  call w%fill(-3._dp)
+
+  norm_squared = backend%vector_norm_squared(u, v, w)
+  expected_norm_squared = 14._dp*real(product(dims_global), dp)
+  energy = 0.5_dp*norm_squared/real(product(dims_global), dp)
+  test_pass = abs(norm_squared - expected_norm_squared) &
+              <= tolerance*expected_norm_squared
+  test_pass = test_pass .and. abs(energy - expected_energy) <= tolerance
+  call MPI_Allreduce(MPI_IN_PLACE, test_pass, 1, MPI_LOGICAL, MPI_LAND, &
+                     MPI_COMM_WORLD, ierr)
+
+  if (nrank == 0) then
+    print *, 'kinetic energy:', energy
+    print *, 'expected:', expected_energy
+    if (test_pass) then
+      print *, 'PASS'
+    else
+      print *, 'FAIL'
+    end if
+  end if
+
+  call allocator%release_block(u)
+  call allocator%release_block(v)
+  call allocator%release_block(w)
+  call MPI_Finalize(ierr)
+
+  if (.not. test_pass) error stop 'Kinetic-energy test failed.'
+
+end program test_kinetic_energy

--- a/tests/unit/test_les.f90
+++ b/tests/unit/test_les.f90
@@ -1,0 +1,65 @@
+program test_les
+  use m_common, only: dp
+  use m_config, only: les_config_t
+  use m_les, only: les_t, filter_width, strain_rate_magnitude, &
+                   wall_damped_mixing_length
+
+  implicit none
+
+  type(les_config_t) :: config
+  type(les_t) :: les
+  real(dp) :: gradient(3, 3), spacing(3), expected, actual, length
+  real(dp), parameter :: tol = 100._dp*epsilon(1._dp)
+  logical :: all_pass
+
+  all_pass = .true.
+  spacing = [0.5_dp, 0.25_dp, 0.125_dp]
+
+  call config%read(nml_string='&les_params model="smagorinsky", '// &
+    'smagorinsky_constant=0.2, wall_damping=.false. /')
+  les = les_t(config)
+
+  ! Simple shear u=gamma*y has |S|=|gamma|.
+  gradient = 0._dp
+  gradient(1, 2) = 4._dp
+  expected = (0.2_dp*filter_width(spacing))**2*4._dp
+  actual = les%nut_from_gradient(gradient, spacing)
+  call check_close('simple-shear nut', actual, expected, tol, all_pass)
+  call check_close('simple-shear strain', strain_rate_magnitude(gradient), &
+                   4._dp, tol, all_pass)
+
+  ! Solid-body rotation has an antisymmetric gradient and no strain.
+  gradient = 0._dp
+  gradient(1, 2) = -3._dp
+  gradient(2, 1) = 3._dp
+  actual = les%nut_from_gradient(gradient, spacing)
+  call check_close('solid-body rotation', actual, 0._dp, tol, all_pass)
+
+  ! Mason-Thomson damping reaches zero at a smooth wall and asymptotes to Cs*Delta.
+  length = wall_damped_mixing_length(1._dp, 0._dp, 0.2_dp, &
+                                      0.4_dp, 3._dp, 0._dp)
+  call check_close('wall damping at wall', length, 0._dp, tol, all_pass)
+  length = wall_damped_mixing_length(1._dp, 1.0e6_dp, 0.2_dp, &
+                                      0.4_dp, 3._dp, 0._dp)
+  call check_close('wall damping far from wall', length, 0.2_dp, &
+                   1.0e-14_dp, all_pass)
+
+  if (.not. all_pass) error stop 'FAIL'
+  print *, 'PASS'
+
+contains
+
+  subroutine check_close(label, value, reference, tolerance, pass)
+    character(*), intent(in) :: label
+    real(dp), intent(in) :: value, reference, tolerance
+    logical, intent(inout) :: pass
+
+    if (abs(value - reference) > tolerance) then
+      print *, 'FAIL: ', label, value, reference
+      pass = .false.
+    else
+      print *, 'PASS: ', label
+    end if
+  end subroutine check_close
+
+end program test_les

--- a/tests/verification/test_les_field.f90
+++ b/tests/verification/test_les_field.f90
@@ -35,12 +35,13 @@ program test_les_field
   type(dirps_t) :: xdirps, ydirps, zdirps
   type(les_config_t) :: config
   type(les_t) :: les, les_wall
-  class(field_t), pointer :: u, v, w
+  class(field_t), pointer :: u, v, w, rhs_u, rhs_v, rhs_w
 
   integer, parameter :: dims_global(3) = [32, 33, 32]
   integer, parameter :: nproc_dir(3) = [1, 1, 1]
   real(dp), parameter :: lengths(3) = [1._dp, 1._dp, 1._dp]
   real(dp), parameter :: shear = 2.5_dp
+  real(dp), parameter :: curvature = 1.75_dp
   character(len=9), parameter :: bc_periodic(2) = &
     ['periodic ', 'periodic ']
   character(len=9), parameter :: bc_wall(2) = &
@@ -138,11 +139,56 @@ program test_les_field
   call check_error('smooth-wall nut', abs(nut_data(1, 1, 1)), &
                    tolerance, all_pass)
 
+  ! For u=(a/2)y^2, div(2*nut*S)_x=2*(Cs*Delta)^2*a^2*y.
+  u_data = 0._dp
+  do k = 1, dims(3)
+    do j = 1, dims(2)
+      do i = 1, dims(1)
+        u_data(i, j, k) = &
+          0.5_dp*curvature*mesh%geo%vert_coords(j, 2)**2
+      end do
+    end do
+  end do
+  call backend%set_field_data(u, u_data)
+
+  rhs_u => allocator%get_block(DIR_X, VERT)
+  rhs_v => allocator%get_block(DIR_X, VERT)
+  rhs_w => allocator%get_block(DIR_X, VERT)
+  call rhs_u%fill(0._dp)
+  call rhs_v%fill(0._dp)
+  call rhs_w%fill(0._dp)
+  call les%apply_sgs_stress(backend, mesh, rhs_u, rhs_v, rhs_w, u, v, w, &
+                            xdirps, ydirps, zdirps)
+
+  call backend%get_field_data(nut_data, rhs_u)
+  max_error = 0._dp
+  do k = 1, dims(3)
+    do j = 1, dims(2)
+      expected = 2._dp*(config%smagorinsky_constant*delta)**2* &
+                 curvature**2*mesh%geo%vert_coords(j, 2)
+      do i = 1, dims(1)
+        max_error = max(max_error, abs(nut_data(i, j, k) - expected))
+      end do
+    end do
+  end do
+  call check_error('SGS stress divergence', max_error, &
+                   10._dp*tolerance, all_pass)
+
+  call backend%get_field_data(nut_data, rhs_v)
+  call check_error('SGS y-momentum cross-coupling', &
+                   maxval(abs(nut_data)), 10._dp*tolerance, all_pass)
+  call backend%get_field_data(nut_data, rhs_w)
+  call check_error('SGS z-momentum cross-coupling', &
+                   maxval(abs(nut_data)), 10._dp*tolerance, all_pass)
+
   call les%finalise(backend)
   call les_wall%finalise(backend)
   call allocator%release_block(u)
   call allocator%release_block(v)
   call allocator%release_block(w)
+  call allocator%release_block(rhs_u)
+  call allocator%release_block(rhs_v)
+  call allocator%release_block(rhs_w)
   deallocate (u_data, nut_data)
 
   if (.not. all_pass) error stop 'FAIL'

--- a/tests/verification/test_les_field.f90
+++ b/tests/verification/test_les_field.f90
@@ -5,10 +5,10 @@ program test_les_field
   use m_base_backend, only: base_backend_t
   use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
   use m_config, only: les_config_t
-  use m_field, only: field_t
+  use m_field, only: field_t, flist_t
   use m_les, only: les_t, filter_width, wall_damped_mixing_length
   use m_mesh, only: mesh_t
-  use m_solver, only: allocate_tdsops
+  use m_solver, only: solver_t, allocate_tdsops, transeq_default
   use m_tdsops, only: dirps_t
 
 #ifdef CUDA
@@ -32,9 +32,11 @@ program test_les_field
   type(allocator_t), target :: omp_allocator
   type(omp_backend_t), target :: omp_backend
 #endif
-  type(dirps_t) :: xdirps, ydirps, zdirps
+  type(dirps_t), target :: xdirps, ydirps, zdirps
   type(les_config_t) :: config
   type(les_t) :: les, les_wall
+  type(solver_t) :: solver
+  type(flist_t) :: rhs(3), variables(3)
   class(field_t), pointer :: u, v, w, rhs_u, rhs_v, rhs_w
 
   integer, parameter :: dims_global(3) = [32, 33, 32]
@@ -139,6 +141,15 @@ program test_les_field
   call check_error('smooth-wall nut', abs(nut_data(1, 1, 1)), &
                    tolerance, all_pass)
 
+  config%wall_damping = .false.
+  solver%backend => backend
+  solver%mesh => mesh
+  solver%xdirps => xdirps
+  solver%ydirps => ydirps
+  solver%zdirps => zdirps
+  solver%les = les_t(config)
+  solver%nu = 0._dp
+
   ! For u=(a/2)y^2, div(2*nut*S)_x=2*(Cs*Delta)^2*a^2*y.
   u_data = 0._dp
   do k = 1, dims(3)
@@ -157,8 +168,13 @@ program test_les_field
   call rhs_u%fill(0._dp)
   call rhs_v%fill(0._dp)
   call rhs_w%fill(0._dp)
-  call les%apply_sgs_stress(backend, mesh, rhs_u, rhs_v, rhs_w, u, v, w, &
-                            xdirps, ydirps, zdirps)
+  rhs(1)%ptr => rhs_u
+  rhs(2)%ptr => rhs_v
+  rhs(3)%ptr => rhs_w
+  variables(1)%ptr => u
+  variables(2)%ptr => v
+  variables(3)%ptr => w
+  call transeq_default(solver, rhs, variables)
 
   call backend%get_field_data(nut_data, rhs_u)
   max_error = 0._dp
@@ -171,18 +187,21 @@ program test_les_field
       end do
     end do
   end do
-  call check_error('SGS stress divergence', max_error, &
+  call check_error('solver-coupled SGS stress divergence', max_error, &
                    10._dp*tolerance, all_pass)
 
   call backend%get_field_data(nut_data, rhs_v)
   call check_error('SGS y-momentum cross-coupling', &
-                   maxval(abs(nut_data)), 10._dp*tolerance, all_pass)
+                   maxval(abs(nut_data(1:dims(1), 1:dims(2), 1:dims(3)))), &
+                   10._dp*tolerance, all_pass)
   call backend%get_field_data(nut_data, rhs_w)
   call check_error('SGS z-momentum cross-coupling', &
-                   maxval(abs(nut_data)), 10._dp*tolerance, all_pass)
+                   maxval(abs(nut_data(1:dims(1), 1:dims(2), 1:dims(3)))), &
+                   10._dp*tolerance, all_pass)
 
   call les%finalise(backend)
   call les_wall%finalise(backend)
+  call solver%finalise()
   call allocator%release_block(u)
   call allocator%release_block(v)
   call allocator%release_block(w)

--- a/tests/verification/test_les_field.f90
+++ b/tests/verification/test_les_field.f90
@@ -1,0 +1,167 @@
+program test_les_field
+  use mpi
+
+  use m_allocator, only: allocator_t
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
+  use m_config, only: les_config_t
+  use m_field, only: field_t
+  use m_les, only: les_t, filter_width, wall_damped_mixing_length
+  use m_mesh, only: mesh_t
+  use m_solver, only: allocate_tdsops
+  use m_tdsops, only: dirps_t
+
+#ifdef CUDA
+  use m_cuda_allocator, only: cuda_allocator_t
+  use m_cuda_backend, only: cuda_backend_t
+  use m_cuda_common, only: SZ
+#else
+  use m_omp_backend, only: omp_backend_t
+  use m_omp_common, only: SZ
+#endif
+
+  implicit none
+
+  type(mesh_t), target :: mesh
+  class(allocator_t), pointer :: allocator
+  class(base_backend_t), pointer :: backend
+#ifdef CUDA
+  type(cuda_allocator_t), target :: cuda_allocator
+  type(cuda_backend_t), target :: cuda_backend
+#else
+  type(allocator_t), target :: omp_allocator
+  type(omp_backend_t), target :: omp_backend
+#endif
+  type(dirps_t) :: xdirps, ydirps, zdirps
+  type(les_config_t) :: config
+  type(les_t) :: les, les_wall
+  class(field_t), pointer :: u, v, w
+
+  integer, parameter :: dims_global(3) = [32, 33, 32]
+  integer, parameter :: nproc_dir(3) = [1, 1, 1]
+  real(dp), parameter :: lengths(3) = [1._dp, 1._dp, 1._dp]
+  real(dp), parameter :: shear = 2.5_dp
+  character(len=9), parameter :: bc_periodic(2) = &
+    ['periodic ', 'periodic ']
+  character(len=9), parameter :: bc_wall(2) = &
+    ['dirichlet', 'dirichlet']
+
+  real(dp), allocatable :: u_data(:, :, :), nut_data(:, :, :)
+  real(dp) :: delta, expected, length, max_error, spacing(3), tolerance
+  integer :: dims(3), dims_padded(3), i, j, k, ierr
+  logical :: all_pass
+
+  call MPI_Init(ierr)
+  all_pass = .true.
+  tolerance = 2000._dp*epsilon(1._dp)
+
+  mesh = mesh_t(dims_global, nproc_dir, lengths, &
+                bc_periodic, bc_wall, bc_periodic)
+  dims = mesh%get_dims(VERT)
+
+#ifdef CUDA
+  cuda_allocator = cuda_allocator_t(dims, SZ)
+  allocator => cuda_allocator
+  cuda_backend = cuda_backend_t(mesh, allocator)
+  backend => cuda_backend
+#else
+  omp_allocator = allocator_t(dims, SZ)
+  allocator => omp_allocator
+  omp_backend = omp_backend_t(mesh, allocator)
+  backend => omp_backend
+#endif
+
+  xdirps%dir = DIR_X
+  ydirps%dir = DIR_Y
+  zdirps%dir = DIR_Z
+  call allocate_tdsops(xdirps, backend, mesh, &
+                       'compact6', 'compact6', 'classic', 'compact6')
+  call allocate_tdsops(ydirps, backend, mesh, &
+                       'compact6', 'compact6', 'classic', 'compact6')
+  call allocate_tdsops(zdirps, backend, mesh, &
+                       'compact6', 'compact6', 'classic', 'compact6')
+
+  u => allocator%get_block(DIR_X, VERT)
+  v => allocator%get_block(DIR_X, VERT)
+  w => allocator%get_block(DIR_X, VERT)
+  call v%fill(0._dp)
+  call w%fill(0._dp)
+
+  dims_padded = allocator%get_padded_dims(DIR_C)
+  allocate (u_data(dims_padded(1), dims_padded(2), dims_padded(3)))
+  allocate (nut_data(dims_padded(1), dims_padded(2), dims_padded(3)))
+  u_data = 0._dp
+  do k = 1, dims(3)
+    do j = 1, dims(2)
+      do i = 1, dims(1)
+        u_data(i, j, k) = shear*mesh%geo%vert_coords(j, 2)
+      end do
+    end do
+  end do
+  call backend%set_field_data(u, u_data)
+
+  config%model = 'smagorinsky'
+  config%smagorinsky_constant = 0.2_dp
+  les = les_t(config)
+  call les%compute_nut(backend, mesh, u, v, w, xdirps, ydirps, zdirps)
+  call backend%get_field_data(nut_data, les%nut)
+
+  spacing = mesh%geo%d
+  delta = filter_width(spacing)
+  expected = (config%smagorinsky_constant*delta)**2*abs(shear)
+  max_error = maxval(abs(nut_data(1:dims(1), 1:dims(2), 1:dims(3)) - &
+                         expected))
+  call check_error('constant-shear nut', max_error, tolerance, all_pass)
+
+  config%wall_damping = .true.
+  config%roughness_length = 0._dp
+  les_wall = les_t(config)
+  call les_wall%compute_nut(backend, mesh, u, v, w, &
+                            xdirps, ydirps, zdirps)
+  call backend%get_field_data(nut_data, les_wall%nut)
+
+  max_error = 0._dp
+  do k = 1, dims(3)
+    do j = 1, dims(2)
+      length = wall_damped_mixing_length( &
+        delta, mesh%geo%vert_coords(j, 2), &
+        config%smagorinsky_constant, config%von_karman_constant, &
+        config%wall_damping_n, config%roughness_length)
+      expected = length**2*abs(shear)
+      do i = 1, dims(1)
+        max_error = max(max_error, abs(nut_data(i, j, k) - expected))
+      end do
+    end do
+  end do
+  call check_error('wall-damped constant-shear nut', max_error, &
+                   tolerance, all_pass)
+  call check_error('smooth-wall nut', abs(nut_data(1, 1, 1)), &
+                   tolerance, all_pass)
+
+  call les%finalise(backend)
+  call les_wall%finalise(backend)
+  call allocator%release_block(u)
+  call allocator%release_block(v)
+  call allocator%release_block(w)
+  deallocate (u_data, nut_data)
+
+  if (.not. all_pass) error stop 'FAIL'
+  print *, 'PASS'
+  call MPI_Finalize(ierr)
+
+contains
+
+  subroutine check_error(label, error, tol, pass)
+    character(*), intent(in) :: label
+    real(dp), intent(in) :: error, tol
+    logical, intent(inout) :: pass
+
+    if (error > tol) then
+      print *, 'FAIL: ', label, ' error=', error, ' tolerance=', tol
+      pass = .false.
+    else
+      print *, 'PASS: ', label, ' error=', error
+    end if
+  end subroutine check_error
+
+end program test_les_field


### PR DESCRIPTION
#### Summary
- Add static Smagorinsky LES model with optional wall damping
- Couple the SGS stress divergence into the momentum RHS for OpenMP and CUDA
- Add kinetic-energy for monitoring and reduce the cost of kinetic energy and enstrophy calculations
- Add unit/verification tests and update the input-file documentation
- Add `input_static_smagorinsky.x3d` as an LES TGV example
- Closes #321 

#### Validation
Validated in double precision against the reference DNS data. The reference DNS is the $1280^3$, $Re=5000$ TGV calculation reported by Dairay et al.:

> T. Dairay, E. Lamballais, S. Laizet, and J. C. Vassilicos,
> “Numerical dissipation vs. subgrid-scale modelling for large eddy
> simulation,” *Journal of Computational Physics*, 337 (2017), 252–274.  
> https://doi.org/10.1016/j.jcp.2017.02.035

The reference data were taken from the corresponding Incompact3d [`TGV_Re5000.dat`](https://github.com/xcompact3d/Incompact3d/blob/abb010e615cff520f949a210278945346995966c/examples/TGV-Taylor-Green-vortex/TGV_Re5000.dat) dataset.

Against this reference DNS:

- Kinetic-energy relative L2 error: 3.59%
- Total-dissipation relative L2 error: 11.31%
- Dissipation-peak relative error: 3.16%
- Mean divergence remained approximately $10^{-14}$

The same static Smagorinsky case was compared with Incompact3d:

- Kinetic-energy relative L2 difference: $1.3\times10^{-6}$
- Total-dissipation relative L2 difference: $7.3\times10^{-5}$

The example uses `interpl_scheme = 'aggressive'`, corresponding to Incompact3d's `ipinter=3`, so both solvers use the same midpoint interpolation scheme.

<img width="1280" height="1280" alt="comparison" src="https://github.com/user-attachments/assets/da72890f-27fc-48ff-9605-b67f58891b40" />