### PR TITLE
Update 2DECOMP-FFT to v2.0.3.2

### DIFF
--- a/cmake/decomp2d/Finddecomp2d.cmake
+++ b/cmake/decomp2d/Finddecomp2d.cmake
@@ -1,5 +1,5 @@
 # - Find the 2decomp-fft library
-set(decomp2d_git_tag "v2.0.3.1")
+set(decomp2d_git_tag "v2.0.3.2")
 string(REPLACE "/" "-" decomp2d_git_tag_dir "${decomp2d_git_tag}")
 
 if(SINGLE_PREC)


### PR DESCRIPTION
Update the 2DECOMP-FFT dependency from `v2.0.3.1` to `v2.0.3.2`, which includes the fix for the non-portable -`march=native` flag in NVHPC builds.

This restores compatibility with non-x86 platforms and older NVIDIA HPC SDK versions.

Validation:
- CUDA configure and build passed.
- FFT and Poisson tests passed.