### PR TITLE
Upgrade ADIOS2 to v2.12.1 and forward CUDA architecture

### DIFF
--- a/cmake/adios2/FindADIOS2.cmake
+++ b/cmake/adios2/FindADIOS2.cmake
@@ -18,7 +18,9 @@
 #   ADIOS2_ROOT_DIR - Directory where ADIOS2 is installed (when USE_SYSTEM_ADIOS2=ON)
 option(USE_SYSTEM_ADIOS2 "Use system-installed ADIOS2" OFF)
 set(ADIOS2_ROOT_DIR "" CACHE PATH "Directory where ADIOS2 is installed (optional)")
-set(adios2_git_tag "v2.10.2")
+set(CUDA_ARCH "" CACHE STRING
+  "CUDA architecture(s) for the ADIOS2 build (e.g. 80). Empty selects native detection.")
+set(adios2_git_tag "v2.12.1")
 string(REPLACE "/" "-" adios2_git_tag_dir "${adios2_git_tag}")
 
 if(NOT USE_SYSTEM_ADIOS2 AND ADIOS2_ROOT_DIR)
@@ -75,6 +77,20 @@ else()
 
     # ensure that the build directory for the external project exists
     file(MAKE_DIRECTORY "${adios2_driver_dir}")
+
+    # ADIOS2 defaults CMAKE_CUDA_ARCHITECTURES to 52 (Maxwell) when unset, which
+    # CUDA >= 13 no longer supports. Forward an explicit architecture so ADIOS2's
+    # CUDA sources build for the target GPU. CUDA_ARCH may be set to a specific
+    # value (e.g. 80); otherwise fall back to native detection.
+    if(X3D2_ADIOS2_CUDA)
+      if(CUDA_ARCH)
+        set(x3d2_adios2_cuda_arch "${CUDA_ARCH}")
+      else()
+        set(x3d2_adios2_cuda_arch "native")
+      endif()
+    else()
+      set(x3d2_adios2_cuda_arch "")
+    endif()
 
     # copy the external project script into a subdirectory of the build tree
     configure_file(

--- a/cmake/adios2/downloadBuildAdios2.cmake.in
+++ b/cmake/adios2/downloadBuildAdios2.cmake.in
@@ -15,4 +15,5 @@ ExternalProject_Add(downloadBuildAdios2
       -DADIOS2_BUILD_TESTING=OFF
       -DADIOS2_USE_Fortran=ON
       -DADIOS2_USE_CUDA=@X3D2_ADIOS2_CUDA@
+      -DCMAKE_CUDA_ARCHITECTURES=@x3d2_adios2_cuda_arch@
 )

--- a/docs/source/user/advanced_build.rst
+++ b/docs/source/user/advanced_build.rst
@@ -56,6 +56,20 @@ To use the built-in ADIOS2 (default behavior):
 
    -DWITH_ADIOS2=ON
 
+CUDA Architecture for the ADIOS2 Build
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When x3d2 is built with the NVHPC compiler, the built-in ADIOS2 is compiled with 
+CUDA support. By default its CUDA sources are built for the architecture of the 
+GPU present at configure time (``native`` detection). If you are building on a 
+node without a visible GPU (for example a GPU-less login or build node), ``native`` 
+cannot probe the hardware, so set the target architecture explicitly with 
+the ``CUDA_ARCH`` CMake option:
+
+.. code-block:: bash
+
+   -DCUDA_ARCH=80
+
 Library Path Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -174,3 +188,20 @@ Available combinations:
 
 - Double precision simulation (default): checkpoints in double precision, snapshots configurable via ``snapshot_sp``
 - Single precision simulation (``-DSINGLE_PREC=ON``): all I/O in single precision, ``snapshot_sp`` ignored
+
+Debugging the CUDA Backend
+--------------------------
+
+FP Exception Trapping
+~~~~~~~~~~~~~~~~~~~~~~
+
+The NVHPC debug build omits ``-Ktrap=fp`` by default. Because it traps floating-point exceptions 
+process-wide, benign FP operations inside linked libraries (for example cuFFTMp's PTX-JIT during 
+Poisson plan creation, or HPC-X/UCX in ``ucp_worker_iface_open`` during ``MPI_Init``) can raise 
+a fatal ``SIGFPE`` that is unrelated to x3d2. To enable trapping when hunting a genuine FP bug 
+in x3d2's own kernels, use the ``CUDA_DEBUG_FP_TRAP`` CMake option:
+
+.. code-block:: bash
+
+   -DCUDA_DEBUG_FP_TRAP=ON
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,10 +122,13 @@ target_link_libraries(xcompact PRIVATE x3d2)
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC")
   set(CMAKE_Fortran_FLAGS "-cpp -cuda")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -traceback -Mbounds -Mchkptr -Ktrap=fp")
-  # Note: -Ktrap=fp traps FP exceptions process-wide. On some NVIDIA GPUs (for example RTX A4000)
-  # it was giving a divide-by-zero inside cuFFTMp's PTX-JIT compiler during Poisson FFT plan creation
-  # This is a JIT quirk (not an issue with cuFFTMp or bug in x3d2). Remove this flag if you encounter this error
+  set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0 -traceback -Mbounds -Mchkptr")
+  # Opt-in: -Ktrap=fp traps FP exceptions process-wide, turning benign FP ops in
+  # linked libs (cuFFTMp PTX-JIT, HPC-X/UCX at MPI_Init) into fatal SIGFPEs.
+  option(CUDA_DEBUG_FP_TRAP "Trap FP exceptions in the CUDA debug build (-Ktrap=fp)" OFF)
+  if(CUDA_DEBUG_FP_TRAP)
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -Ktrap=fp")
+  endif()
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fast")
   target_link_options(x3d2 INTERFACE "-cuda")
   target_link_options(x3d2 INTERFACE "-cudalib=cufftmp")


### PR DESCRIPTION
Closes #334 

This PR fixes the following issues when building ADIOS2 with NVHPC 26.5 / CUDA 13.2:

1. CUDA 13.x's CCCL (Thrust/CUB/libcu++) requires C++17, but ADIOS2 v2.10.2 pins C++11. Bumping the version to v2.12.1 raises `ADIOS2_REQUIRED_CXX_STANDARD` to 17
2.  ADIOS2 defaults `CMAKE_CUDA_ARCHITECTURES` to `52` (Maxwell), when unset, which CUDA >=13 no longer supports. x3d2 wasn't forwarding any value

#### Changes
- `cmake/adios2/FindADIOS2.cmake`: bump `adios2_git_tag` to `v2.12.1` and add `CUDA_ARCH` cache variable and compute the architecture forwarded to the ADIOS2 build (uses `CUDA_ARCH` if set, otherwise `native` detection), only for the CUDA build
- foward `-DCMAKE_CUDA_ARCHITECTURES` to the ADIOS2 ExternalProject
- `-Ktrap=fp` made opt-in. It traps floating point exceptions process-wide, turning benign FP ops inside linked libraries inot fatal `SIGFPE`s unrelated to x3d2. It is now dropped from the default NVHPC debug flags and gated behind a new `CUDA_DEBUG_FP_TRAP` option (default is OFF)
- Updated docs

#### Testing
- Build x3d2 on Kolmogorov with NHVPC 26.5 / CUDA 13.2. Note that I had to upgrade Kolmogorov's NVIDIA driver to 580 (it was 560)