### PR TITLE
Prevent NVHPC OpenMP-target build from picking up CUDA tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,9 +150,12 @@ define_performance_test(performance/perf_thom.f90 1 omp)
 define_performance_test(performance/perf_omp_tridiag.f90 ${CMAKE_CTEST_NPROCS} omp)
 
 # CUDA backend tests
-if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
-   ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC" AND
-   NOT ${OMP_TGT})
+# Parenthesise the compiler-ID check so NOT OMP_TGT gates both PGI and NVHPC;
+# without it CMake precedence (NOT > AND > OR) leaves an OpenMP-target build
+# able to pick up CUDA tests.
+if((${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
+    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "NVHPC") AND
+   NOT OMP_TGT)
 
   # CUDA unit tests
   define_test(unit/test_reordering.f90 1 cuda)


### PR DESCRIPTION
Fixes #331

The CUDA test guard relied on `PGI OR NVHPC AND NOT OMP_TGT`. CMake operator precedence (`NOT` > `AND` > `OR`) grouped this as `PGI OR (NVHPC AND NOT OMP_TGT)`, so `NOT OMP_TGT` only gated the NVHPC term and left the guard fragile - an OpenMP-target build could still register CUDA tests.

This parenthesises the compiler-ID check so NOT OMP_TGT gates the whole condition:

```cmake
if((CMAKE_Fortran_COMPILER_ID STREQUAL "PGI" OR
    CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") AND
   NOT OMP_TGT)
```


#### Testing
Verified with the real NVHPC toolchain via `ctest -N`:

| Scenario | CUDA tests | omp_tgt tests |
|---|---|---|
| NVHPC, `OMP_TGT=OFF` | 19 | 0 |
| NVHPC, `OMP_TGT=ON` | 0 | 4 |