### PR TITLE
Import DECOMP_2D_COMM_CART_X from decomp_2d_mpi

### DIFF
--- a/src/decomp/decomp_2decompfft.f90
+++ b/src/decomp/decomp_2decompfft.f90
@@ -15,8 +15,8 @@ contains
   subroutine decomposition_2decomp(grid, par)
     !! Performs 2D mesh decomposition using 2decomp&fft
     use m_mesh_content, only: par_t, grid_t
-    use decomp_2d, only: decomp_2d_init, DECOMP_2D_COMM_CART_X, xsize, xstart
-    use decomp_2d_mpi, only: nrank, nproc
+    use decomp_2d, only: decomp_2d_init, xsize, xstart
+    use decomp_2d_mpi, only: nrank, nproc, DECOMP_2D_COMM_CART_X
 
     class(grid_t), intent(inout) :: grid
     class(par_t), intent(inout) :: par


### PR DESCRIPTION
Import `DECOMP_2D_COMM_CART_X` from `decomp_2d_mpi`, where it is defined, instead of re-exporting it through `decomp_2d` in `decomp_2decompfft.f90`.

This makes the code more robust - some 2decomp&fft builds/environments do not re-export `DECOMP_2D_COMM_CART_X` via `decomp_2d`, causing a build failure.