### PR TITLE
Refactor tests around shared MPI and backend helpers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,10 +109,16 @@ set(LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib")
 
 # Create the main library
 add_library(x3d2 STATIC ${SRC})
-target_include_directories(x3d2 INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+set_target_properties(x3d2 PROPERTIES
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/modules/x3d2")
+target_include_directories(x3d2 INTERFACE
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/x3d2)
 
 add_library(x3d2_backends STATIC ${BACKENDSRC})
-target_include_directories(x3d2_backends INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+set_target_properties(x3d2_backends PROPERTIES
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/modules/x3d2_backends")
+target_include_directories(x3d2_backends INTERFACE
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/x3d2_backends)
 target_link_libraries(x3d2_backends PRIVATE x3d2)
 
 add_executable(xcompact xcompact.f90)

--- a/src/backend/backend.f90
+++ b/src/backend/backend.f90
@@ -36,6 +36,7 @@ module m_base_backend
     procedure(transeq_ders), deferred :: transeq_z
     procedure(transeq_ders_spec), deferred :: transeq_species
     procedure(tds_solve), deferred :: tds_solve
+    procedure(tds_solve), deferred :: thom_solve
     procedure(reorder), deferred :: reorder
     procedure(sum_intox), deferred :: sum_yintox
     procedure(sum_intox), deferred :: sum_zintox
@@ -59,6 +60,8 @@ module m_base_backend
     procedure(copy_f_to_data), deferred :: copy_f_to_data
     procedure(alloc_tdsops), deferred :: alloc_tdsops
     procedure(init_poisson_fft), deferred :: init_poisson_fft
+    procedure(sync_backend), deferred :: sync
+    procedure(device_bw_info), deferred :: get_device_bw_info
     procedure :: base_init
     procedure :: get_field_data
     procedure :: set_field_data
@@ -140,6 +143,27 @@ module m_base_backend
       class(field_t), intent(in) :: u
       class(tdsops_t), intent(in) :: tdsops
     end subroutine tds_solve
+  end interface
+
+  abstract interface
+    subroutine sync_backend(self)
+      import :: base_backend_t
+      implicit none
+
+      class(base_backend_t) :: self
+    end subroutine sync_backend
+  end interface
+
+  abstract interface
+    subroutine device_bw_info(self, mem_clock_rt, mem_bus_width, available)
+      import :: base_backend_t
+      implicit none
+
+      class(base_backend_t) :: self
+      integer, intent(out) :: mem_clock_rt
+      integer, intent(out) :: mem_bus_width
+      logical, intent(out) :: available
+    end subroutine device_bw_info
   end interface
 
   abstract interface

--- a/src/backend/backend_runtime.f90
+++ b/src/backend/backend_runtime.f90
@@ -56,6 +56,27 @@ module m_backend_runtime
 
 contains
 
+#ifdef CUDA
+  subroutine select_cuda_device(nrank, devnum)
+    !! Select a CUDA device round-robin by MPI rank.  The optional result
+    !! returns the device that CUDA reports as current after selection.
+    integer, intent(in) :: nrank
+    integer, optional, intent(out) :: devnum
+
+    integer :: ierr, ndevs, selected_device
+
+    ierr = cudaGetDeviceCount(ndevs)
+    if (ndevs < 1) then
+      error stop 'select_cuda_device: no CUDA devices available'
+    end if
+
+    ierr = cudaSetDevice(mod(nrank, ndevs))
+    ierr = cudaGetDevice(selected_device)
+
+    if (present(devnum)) devnum = selected_device
+  end subroutine select_cuda_device
+#endif
+
   subroutine init(self, mesh, separate_host_allocator)
     class(backend_runtime_t), target, intent(inout) :: self
     type(mesh_t), target, intent(inout) :: mesh
@@ -67,7 +88,7 @@ contains
 #endif
 
 #ifdef CUDA
-    integer :: ierr, nrank, ndevs, devnum
+    integer :: ierr, nrank
 #endif
 
     dims = mesh%grid%vert_dims
@@ -80,12 +101,7 @@ contains
 
 #ifdef CUDA
     call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    ierr = cudaGetDeviceCount(ndevs)
-    if (ndevs < 1) then
-      error stop 'backend_runtime_t%init: no CUDA devices available'
-    end if
-    ierr = cudaSetDevice(mod(nrank, ndevs))
-    ierr = cudaGetDevice(devnum)
+    call select_cuda_device(nrank)
 
     self%backend_name = 'CUDA'
     self%cuda_allocator = cuda_allocator_t(dims, SZ)

--- a/src/backend/backend_runtime.f90
+++ b/src/backend/backend_runtime.f90
@@ -10,6 +10,10 @@ module m_backend_runtime
   use m_cuda_allocator, only: cuda_allocator_t
   use m_cuda_backend, only: cuda_backend_t
   use m_cuda_common, only: SZ
+#elif defined(OMP_TGT)
+  use m_omp_common, only: SZ
+  use m_omptgt_allocator, only: omptgt_allocator_t
+  use m_omptgt_backend, only: omptgt_backend_t
 #else
   use m_omp_backend, only: omp_backend_t
   use m_omp_common, only: SZ
@@ -38,6 +42,9 @@ module m_backend_runtime
 #ifdef CUDA
     type(cuda_backend_t) :: cuda_backend
     type(cuda_allocator_t) :: cuda_allocator
+#elif defined(OMP_TGT)
+    type(omptgt_backend_t) :: omptgt_backend
+    type(omptgt_allocator_t) :: omptgt_allocator
 #else
     type(omp_backend_t) :: omp_backend
     type(allocator_t) :: omp_allocator
@@ -55,17 +62,21 @@ contains
     logical, optional, intent(in) :: separate_host_allocator
 
     integer :: dims(3)
+#if !defined(CUDA) && !defined(OMP_TGT)
     logical :: need_separate_host_allocator
+#endif
 
 #ifdef CUDA
     integer :: ierr, nrank, ndevs, devnum
 #endif
 
     dims = mesh%grid%vert_dims
+#if !defined(CUDA) && !defined(OMP_TGT)
     need_separate_host_allocator = .false.
     if (present(separate_host_allocator)) then
       need_separate_host_allocator = separate_host_allocator
     end if
+#endif
 
 #ifdef CUDA
     call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
@@ -87,6 +98,17 @@ contains
     self%host_allocator => self%host_allocator_storage
     self%cuda_backend = cuda_backend_t(mesh, self%allocator)
     self%backend => self%cuda_backend
+#elif defined(OMP_TGT)
+    self%backend_name = 'OMP_TGT'
+    self%omptgt_allocator = omptgt_allocator_t(dims, SZ)
+    self%allocator => self%omptgt_allocator
+    ! omp_tgt manages offload memory, so always use a separate host
+    ! allocator (the omptgt allocator cannot be aliased by a plain
+    ! type(allocator_t) pointer).
+    self%host_allocator_storage = allocator_t(dims, SZ)
+    self%host_allocator => self%host_allocator_storage
+    self%omptgt_backend = omptgt_backend_t(mesh, self%allocator)
+    self%backend => self%omptgt_backend
 #else
     self%backend_name = 'OMP'
     self%omp_allocator = allocator_t(dims, SZ)

--- a/src/backend/backend_runtime.f90
+++ b/src/backend/backend_runtime.f90
@@ -1,0 +1,108 @@
+module m_backend_runtime
+  use mpi
+
+  use m_allocator, only: allocator_t
+  use m_base_backend, only: base_backend_t
+  use m_mesh, only: mesh_t
+
+#ifdef CUDA
+  use cudafor
+  use m_cuda_allocator, only: cuda_allocator_t
+  use m_cuda_backend, only: cuda_backend_t
+  use m_cuda_common, only: SZ
+#else
+  use m_omp_backend, only: omp_backend_t
+  use m_omp_common, only: SZ
+#endif
+
+  implicit none
+
+  integer, parameter :: backend_sz = SZ
+
+#ifdef CUDA
+  logical, parameter :: backend_is_cuda = .true.
+#else
+  logical, parameter :: backend_is_cuda = .false.
+#endif
+
+  type :: backend_runtime_t
+    !! Convenience wrapper that creates the correct backend and allocator
+    !! for the current build.  The pointer components (backend, allocator,
+    !! host_allocator) alias concrete members of this same object, so
+    !! instances must be declared with the TARGET attribute and must
+    !! never be copied or assigned - the pointers would dangle.
+    class(base_backend_t), pointer :: backend => null()
+    class(allocator_t), pointer :: allocator => null()
+    type(allocator_t), pointer :: host_allocator => null()
+    character(len=8) :: backend_name = ''
+#ifdef CUDA
+    type(cuda_backend_t) :: cuda_backend
+    type(cuda_allocator_t) :: cuda_allocator
+#else
+    type(omp_backend_t) :: omp_backend
+    type(allocator_t) :: omp_allocator
+#endif
+    type(allocator_t) :: host_allocator_storage
+  contains
+    procedure :: init
+  end type backend_runtime_t
+
+contains
+
+  subroutine init(self, mesh, separate_host_allocator)
+    class(backend_runtime_t), target, intent(inout) :: self
+    type(mesh_t), target, intent(inout) :: mesh
+    logical, optional, intent(in) :: separate_host_allocator
+
+    integer :: dims(3)
+    logical :: need_separate_host_allocator
+
+#ifdef CUDA
+    integer :: ierr, nrank, ndevs, devnum
+#endif
+
+    dims = mesh%grid%vert_dims
+    need_separate_host_allocator = .false.
+    if (present(separate_host_allocator)) then
+      need_separate_host_allocator = separate_host_allocator
+    end if
+
+#ifdef CUDA
+    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
+    ierr = cudaGetDeviceCount(ndevs)
+    if (ndevs < 1) then
+      error stop 'backend_runtime_t%init: no CUDA devices available'
+    end if
+    ierr = cudaSetDevice(mod(nrank, ndevs))
+    ierr = cudaGetDevice(devnum)
+
+    self%backend_name = 'CUDA'
+    self%cuda_allocator = cuda_allocator_t(dims, SZ)
+    self%allocator => self%cuda_allocator
+    ! CUDA always needs a separate host allocator because the main
+    ! allocator lives in device memory.  The solver and case objects
+    ! (xcompact.f90) unconditionally pass host_allocator, so it must
+    ! be valid regardless of whether the caller requested one.
+    self%host_allocator_storage = allocator_t(dims, SZ)
+    self%host_allocator => self%host_allocator_storage
+    self%cuda_backend = cuda_backend_t(mesh, self%allocator)
+    self%backend => self%cuda_backend
+#else
+    self%backend_name = 'OMP'
+    self%omp_allocator = allocator_t(dims, SZ)
+    self%allocator => self%omp_allocator
+
+    if (need_separate_host_allocator) then
+      self%host_allocator_storage = allocator_t(dims, SZ)
+      self%host_allocator => self%host_allocator_storage
+    else
+      self%host_allocator => self%omp_allocator
+    end if
+
+    self%omp_backend = omp_backend_t(mesh, self%allocator)
+    self%backend => self%omp_backend
+#endif
+
+  end subroutine init
+
+end module m_backend_runtime

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -17,6 +17,7 @@ module m_cuda_backend
   use m_cuda_allocator, only: cuda_allocator_t, cuda_field_t
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused, exec_dist_tds_compact
+  use m_cuda_exec_thom, only: exec_thom_tds_compact
   use m_cuda_poisson_fft, only: cuda_poisson_fft_t
   use m_cuda_sendrecv, only: sendrecv_fields, sendrecv_3fields
   use m_cuda_tdsops, only: cuda_tdsops_t
@@ -59,6 +60,7 @@ module m_cuda_backend
     procedure :: transeq_z => transeq_z_cuda
     procedure :: transeq_species => transeq_species_cuda
     procedure :: tds_solve => tds_solve_cuda
+    procedure :: thom_solve => thom_solve_cuda
     procedure :: reorder => reorder_cuda
     procedure :: sum_yintox => sum_yintox_cuda
     procedure :: sum_zintox => sum_zintox_cuda
@@ -81,6 +83,8 @@ module m_cuda_backend
     procedure :: copy_data_to_f => copy_data_to_f_cuda
     procedure :: copy_f_to_data => copy_f_to_data_cuda
     procedure :: init_poisson_fft => init_cuda_poisson_fft
+    procedure :: sync => sync_cuda
+    procedure :: get_device_bw_info => get_device_bw_info_cuda
     procedure :: transeq_cuda_dist
     procedure :: transeq_cuda_thom
     procedure :: tds_solve_dist
@@ -179,6 +183,33 @@ contains
     end select
 
   end subroutine alloc_cuda_tdsops
+
+  subroutine sync_cuda(self)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    integer :: ierr
+
+    ierr = cudaDeviceSynchronize()
+
+  end subroutine sync_cuda
+
+  subroutine get_device_bw_info_cuda(self, mem_clock_rt, mem_bus_width, &
+                                     available)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    integer, intent(out) :: mem_clock_rt
+    integer, intent(out) :: mem_bus_width
+    logical, intent(out) :: available
+    integer :: ierr
+
+    ierr = cudaDeviceGetAttribute(mem_clock_rt, cudaDevAttrMemoryClockRate, 0)
+    ierr = cudaDeviceGetAttribute(mem_bus_width, &
+                                  cudaDevAttrGlobalMemoryBusWidth, 0)
+    available = .true.
+
+  end subroutine get_device_bw_info_cuda
 
   subroutine transeq_x_cuda(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
@@ -477,6 +508,43 @@ contains
     call tds_solve_dist(self, du, u, tdsops, blocks, threads)
 
   end subroutine tds_solve_cuda
+
+  subroutine thom_solve_cuda(self, du, u, tdsops)
+    implicit none
+
+    class(cuda_backend_t) :: self
+    class(field_t), intent(inout) :: du
+    class(field_t), intent(in) :: u
+    class(tdsops_t), intent(in) :: tdsops
+
+    real(dp), device, pointer, dimension(:, :, :) :: du_dev, u_dev
+    type(cuda_tdsops_t), pointer :: tdsops_dev
+    type(dim3) :: blocks, threads
+
+    if (u%dir /= du%dir) then
+      error stop 'DIR mismatch between fields in thom_solve.'
+    end if
+
+    blocks = dim3(self%allocator%get_n_groups(u%dir), 1, 1)
+    threads = dim3(SZ, 1, 1)
+
+    if (u%data_loc /= NULL_LOC) then
+      call du%set_data_loc(move_data_loc(u%data_loc, u%dir, tdsops%move))
+    end if
+
+    call resolve_field_t(du_dev, du)
+    call resolve_field_t(u_dev, u)
+
+    select type (tdsops)
+    type is (cuda_tdsops_t)
+      tdsops_dev => tdsops
+    class default
+      error stop 'Expected cuda_tdsops_t in thom_solve_cuda.'
+    end select
+
+    call exec_thom_tds_compact(du_dev, u_dev, tdsops_dev, blocks, threads)
+
+  end subroutine thom_solve_cuda
 
   subroutine tds_solve_dist(self, du, u, tdsops, blocks, threads)
     implicit none

--- a/src/backend/cuda/backend.f90
+++ b/src/backend/cuda/backend.f90
@@ -202,11 +202,13 @@ contains
     integer, intent(out) :: mem_clock_rt
     integer, intent(out) :: mem_bus_width
     logical, intent(out) :: available
-    integer :: ierr
+    integer :: ierr, devnum
 
-    ierr = cudaDeviceGetAttribute(mem_clock_rt, cudaDevAttrMemoryClockRate, 0)
+    ierr = cudaGetDevice(devnum)
+    ierr = cudaDeviceGetAttribute(mem_clock_rt, cudaDevAttrMemoryClockRate, &
+                                  devnum)
     ierr = cudaDeviceGetAttribute(mem_bus_width, &
-                                  cudaDevAttrGlobalMemoryBusWidth, 0)
+                                  cudaDevAttrGlobalMemoryBusWidth, devnum)
     available = .true.
 
   end subroutine get_device_bw_info_cuda

--- a/src/backend/omp/backend.f90
+++ b/src/backend/omp/backend.f90
@@ -13,6 +13,7 @@ module m_omp_backend
 
   use m_omp_common, only: SZ
   use m_omp_exec_dist, only: exec_dist_tds_compact, exec_dist_transeq_compact
+  use m_exec_thom, only: exec_thom_tds_compact
   use m_omp_sendrecv, only: sendrecv_fields
 
   implicit none
@@ -35,6 +36,7 @@ module m_omp_backend
     procedure :: transeq_z => transeq_z_omp
     procedure :: transeq_species => transeq_species_omp
     procedure :: tds_solve => tds_solve_omp
+    procedure :: thom_solve => thom_solve_omp
     procedure :: reorder => reorder_omp
     procedure :: sum_yintox => sum_yintox_omp
     procedure :: sum_zintox => sum_zintox_omp
@@ -57,6 +59,8 @@ module m_omp_backend
     procedure :: copy_data_to_f => copy_data_to_f_omp
     procedure :: copy_f_to_data => copy_f_to_data_omp
     procedure :: init_poisson_fft => init_omp_poisson_fft
+    procedure :: sync => sync_omp
+    procedure :: get_device_bw_info => get_device_bw_info_omp
     procedure :: transeq_omp_dist
   end type omp_backend_t
 
@@ -144,6 +148,28 @@ contains
     end select
 
   end subroutine alloc_omp_tdsops
+
+  subroutine sync_omp(self)
+    implicit none
+
+    class(omp_backend_t) :: self
+
+  end subroutine sync_omp
+
+  subroutine get_device_bw_info_omp(self, mem_clock_rt, mem_bus_width, &
+                                    available)
+    implicit none
+
+    class(omp_backend_t) :: self
+    integer, intent(out) :: mem_clock_rt
+    integer, intent(out) :: mem_bus_width
+    logical, intent(out) :: available
+
+    mem_clock_rt = 0
+    mem_bus_width = 0
+    available = .false.
+
+  end subroutine get_device_bw_info_omp
 
   subroutine transeq_x_omp(self, du, dv, dw, u, v, w, nu, dirps)
     implicit none
@@ -360,6 +386,27 @@ contains
     call tds_solve_dist(self, du, u, tdsops)
 
   end subroutine tds_solve_omp
+
+  subroutine thom_solve_omp(self, du, u, tdsops)
+    implicit none
+
+    class(omp_backend_t) :: self
+    class(field_t), intent(inout) :: du
+    class(field_t), intent(in) :: u
+    class(tdsops_t), intent(in) :: tdsops
+
+    if (u%dir /= du%dir) then
+      error stop 'DIR mismatch between fields in thom_solve.'
+    end if
+
+    if (u%data_loc /= NULL_LOC) then
+      call du%set_data_loc(move_data_loc(u%data_loc, u%dir, tdsops%move))
+    end if
+
+    call exec_thom_tds_compact(du%data, u%data, tdsops, &
+                               self%allocator%get_n_groups(u%dir))
+
+  end subroutine thom_solve_omp
 
   subroutine tds_solve_dist(self, du, u, tdsops)
     implicit none

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,46 @@ else()
   target_compile_options(x3d2_test_utils PRIVATE "-cpp")
 endif()
 
+# Build the backend-dependent test runtime once per backend. A single build can
+# contain CPU, CUDA, and OpenMP-target tests, so each variant needs its own 
+# preprocessor definitions and module directory.
+function(define_test_backend_runtime backend)
+  set(runtime_target x3d2_test_runtime_${backend})
+  if(TARGET ${runtime_target})
+    return()
+  endif()
+
+  add_library(${runtime_target} STATIC common/backend_runtime.f90)
+  set_target_properties(${runtime_target} PROPERTIES
+    Fortran_MODULE_DIRECTORY
+      "${CMAKE_CURRENT_BINARY_DIR}/modules/${runtime_target}")
+  target_include_directories(${runtime_target} INTERFACE
+    "${CMAKE_CURRENT_BINARY_DIR}/modules/${runtime_target}")
+
+  if(${backend} STREQUAL cuda)
+    target_compile_options(${runtime_target} PRIVATE "-cpp" "-cuda" "-DCUDA")
+    target_link_options(${runtime_target} INTERFACE "-cuda")
+  else()
+    if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray")
+      target_compile_options(${runtime_target} PRIVATE "-eF")
+    else()
+      target_compile_options(${runtime_target} PRIVATE "-cpp")
+    endif()
+    if(${backend} STREQUAL omp_tgt)
+      target_compile_options(${runtime_target} PRIVATE "-fopenmp" "-DOMP_TGT")
+      target_link_options(${runtime_target} INTERFACE "-fopenmp")
+      if(NOT ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray")
+        target_compile_options(${runtime_target} PRIVATE
+          "--offload-arch=${OMP_TGT_ARCH}")
+        target_link_options(${runtime_target} INTERFACE
+          "--offload-arch=${OMP_TGT_ARCH}")
+      endif()
+    endif()
+  endif()
+
+  target_link_libraries(${runtime_target} PRIVATE x3d2_backends x3d2)
+endfunction()
+
 # Base test definition function
 function(define_test testfile np backend)
   # Capture optional arguments passed to the function (e.g. input file or flags)
@@ -27,8 +67,8 @@ function(define_test testfile np backend)
   get_filename_component(test_name ${testfile} NAME_WE)
   string(CONCAT test_name ${test_name} _ ${backend} _ ${np})
 
-  add_executable(${test_name} ${testfile}
-                 ${CMAKE_SOURCE_DIR}/src/backend/backend_runtime.f90)
+  define_test_backend_runtime(${backend})
+  add_executable(${test_name} ${testfile})
   set_target_properties(${test_name} PROPERTIES
     Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/modules/${test_name}")
 
@@ -65,6 +105,7 @@ function(define_test testfile np backend)
       endif()
     endif()
   endif()
+  target_link_libraries(${test_name} PRIVATE x3d2_test_runtime_${backend})
   target_link_libraries(${test_name} PRIVATE x3d2_backends)
   target_link_libraries(${test_name} PRIVATE x3d2_test_utils)
   target_link_libraries(${test_name} PRIVATE x3d2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -219,6 +219,7 @@ if((${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
   define_test(unit/test_reordering.f90 1 cuda)
   define_test(unit/test_vecadd.f90 1 cuda)
   define_test(unit/test_kinetic_energy.f90 1 cuda)
+  define_test(unit/test_setget_field.f90 1 cuda)
   define_test(unit/test_cuda_allocator.f90 1 cuda)
   define_test(unit/test_cuda_reorder.f90 1 cuda)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,10 @@ option(WITH_NIGHTLY_REGRESSION
 # Shared test utilities library
 add_library(x3d2_test_utils STATIC common/test_utils.f90)
 target_link_libraries(x3d2_test_utils PRIVATE x3d2)
+set_target_properties(x3d2_test_utils PROPERTIES
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/modules/x3d2_test_utils")
+target_include_directories(x3d2_test_utils INTERFACE
+  "${CMAKE_CURRENT_BINARY_DIR}/modules/x3d2_test_utils")
 if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray")
   target_compile_options(x3d2_test_utils PRIVATE "-eF")
 else()
@@ -23,7 +27,10 @@ function(define_test testfile np backend)
   get_filename_component(test_name ${testfile} NAME_WE)
   string(CONCAT test_name ${test_name} _ ${backend} _ ${np})
 
-  add_executable(${test_name} ${testfile})
+  add_executable(${test_name} ${testfile}
+                 ${CMAKE_SOURCE_DIR}/src/backend/backend_runtime.f90)
+  set_target_properties(${test_name} PROPERTIES
+    Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/modules/${test_name}")
 
   if(${backend} STREQUAL cuda)
     target_compile_options(${test_name} PRIVATE "-cpp")

--- a/tests/common/backend_runtime.f90
+++ b/tests/common/backend_runtime.f90
@@ -3,6 +3,7 @@ module m_backend_runtime
 
   use m_allocator, only: allocator_t
   use m_base_backend, only: base_backend_t
+  use m_common, only: VERT
   use m_mesh, only: mesh_t
 
 #ifdef CUDA
@@ -30,7 +31,7 @@ module m_backend_runtime
 #endif
 
   type :: backend_runtime_t
-    !! Convenience wrapper that creates the correct backend and allocator
+    !! Test helper that creates the correct backend and allocator
     !! for the current build.  The pointer components (backend, allocator,
     !! host_allocator) alias concrete members of this same object, so
     !! instances must be declared with the TARGET attribute and must
@@ -91,7 +92,7 @@ contains
     integer :: ierr, nrank
 #endif
 
-    dims = mesh%grid%vert_dims
+    dims = mesh%get_dims(VERT)
 #if !defined(CUDA) && !defined(OMP_TGT)
     need_separate_host_allocator = .false.
     if (present(separate_host_allocator)) then

--- a/tests/common/test_utils.f90
+++ b/tests/common/test_utils.f90
@@ -1,10 +1,11 @@
 module m_test_utils
   use mpi
+  use iso_fortran_env, only: stderr => error_unit
   use m_common, only: dp, nbytes
   implicit none
 
   private
-  public :: initialise_mpi, checkerr, &
+  public :: initialise_mpi, finalise_test, checkerr, &
             write_perf_metric, write_perf_minmax_metrics, &
             write_perf_summary, write_perf_minmax_summary, &
             write_device_bw_metric
@@ -26,6 +27,33 @@ contains
     if (present(pprev)) pprev = modulo(nrank - 1, nproc)
     if (present(pnext)) pnext = modulo(nrank - nproc + 1, nproc)
   end subroutine initialise_mpi
+
+  subroutine finalise_test(allpass, nrank, finalize_mpi)
+    !! Report the aggregate test result and finalise MPI, aborting via
+    !! `error stop` (non-zero exit status) if any check failed. When nrank is
+    !! given, the success message is only printed by rank 0. Set finalize_mpi
+    !! to .false. for serial tests that never called MPI_Init.
+    logical, intent(in) :: allpass
+    integer, optional, intent(in) :: nrank
+    logical, optional, intent(in) :: finalize_mpi
+
+    integer :: ierr
+    logical :: is_root, do_finalize
+
+    is_root = .true.
+    if (present(nrank)) is_root = (nrank == 0)
+
+    do_finalize = .true.
+    if (present(finalize_mpi)) do_finalize = finalize_mpi
+
+    if (allpass) then
+      if (is_root) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
+    else
+      error stop 'SOME TESTS FAILED.'
+    end if
+
+    if (do_finalize) call MPI_Finalize(ierr)
+  end subroutine finalise_test
 
   subroutine check_norm(norm, tol, label, allpass)
     real(dp), intent(in) :: norm

--- a/tests/common/test_utils.f90
+++ b/tests/common/test_utils.f90
@@ -1,13 +1,31 @@
 module m_test_utils
+  use mpi
   use m_common, only: dp, nbytes
   implicit none
 
   private
-  public :: checkerr, write_perf_metric, write_perf_minmax_metrics, &
+  public :: initialise_mpi, checkerr, &
+            write_perf_metric, write_perf_minmax_metrics, &
             write_perf_summary, write_perf_minmax_summary, &
             write_device_bw_metric
 
 contains
+
+  subroutine initialise_mpi(nrank, nproc, pprev, pnext)
+    !! Initialise MPI and return the rank and communicator size. Optionally
+    !! return the neighbouring ranks for a 1D periodic decomposition.
+    integer, intent(out) :: nrank, nproc
+    integer, optional, intent(out) :: pprev, pnext
+
+    integer :: ierr
+
+    call MPI_Init(ierr)
+    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
+    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+
+    if (present(pprev)) pprev = modulo(nrank - 1, nproc)
+    if (present(pnext)) pnext = modulo(nrank - nproc + 1, nproc)
+  end subroutine initialise_mpi
 
   subroutine check_norm(norm, tol, label, allpass)
     real(dp), intent(in) :: norm

--- a/tests/common/test_utils.f90
+++ b/tests/common/test_utils.f90
@@ -5,7 +5,8 @@ module m_test_utils
   implicit none
 
   private
-  public :: initialise_mpi, finalise_test, global_all, global_sum, checkerr, &
+  public :: initialise_mpi, finalise_test, global_all, global_sum, &
+            check_status, checkerr, &
             write_perf_metric, write_perf_minmax_metrics, &
             write_perf_summary, write_perf_minmax_summary, &
             write_device_bw_metric
@@ -47,6 +48,19 @@ contains
     call MPI_Allreduce(MPI_IN_PLACE, value, 1, MPI_INTEGER, MPI_SUM, &
                        MPI_COMM_WORLD, ierr)
   end subroutine global_sum
+
+  subroutine check_status(status, label, allpass)
+    !! Mark a test or benchmark as failed when an API returns a non-zero
+    !! status code. The caller decides where ranks must synchronise allpass.
+    integer, intent(in) :: status
+    character(len=*), intent(in) :: label
+    logical, intent(inout) :: allpass
+
+    if (status /= 0) then
+      write (stderr, '(a,": status=",i0)') trim(label), status
+      allpass = .false.
+    end if
+  end subroutine check_status
 
   subroutine finalise_test(allpass, nrank, finalize_mpi)
     !! Report the aggregate test result and finalise MPI, aborting via

--- a/tests/common/test_utils.f90
+++ b/tests/common/test_utils.f90
@@ -63,16 +63,16 @@ contains
   end subroutine check_status
 
   subroutine finalise_test(allpass, nrank, finalize_mpi)
-    !! Report the aggregate test result and finalise MPI, aborting via
-    !! `error stop` (non-zero exit status) if any check failed. When nrank is
-    !! given, the success message is only printed by rank 0. Set finalize_mpi
-    !! to .false. for serial tests that never called MPI_Init.
+    !! Aggregate and report the test result, then finalise MPI before exiting
+    !! with a non-zero status if any check failed. When nrank is given, the
+    !! success message is only printed by rank 0. Set finalize_mpi to .false.
+    !! for serial tests that never called MPI_Init.
     logical, intent(in) :: allpass
     integer, optional, intent(in) :: nrank
     logical, optional, intent(in) :: finalize_mpi
 
     integer :: ierr
-    logical :: is_root, do_finalize
+    logical :: is_root, do_finalize, test_pass
 
     is_root = .true.
     if (present(nrank)) is_root = (nrank == 0)
@@ -80,13 +80,17 @@ contains
     do_finalize = .true.
     if (present(finalize_mpi)) do_finalize = finalize_mpi
 
-    if (allpass) then
+    test_pass = allpass
+    if (do_finalize) then
+      call global_all(test_pass)
+      call MPI_Finalize(ierr)
+    end if
+
+    if (test_pass) then
       if (is_root) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
     else
       error stop 'SOME TESTS FAILED.'
     end if
-
-    if (do_finalize) call MPI_Finalize(ierr)
   end subroutine finalise_test
 
   subroutine check_norm(norm, tol, label, allpass)

--- a/tests/common/test_utils.f90
+++ b/tests/common/test_utils.f90
@@ -5,7 +5,7 @@ module m_test_utils
   implicit none
 
   private
-  public :: initialise_mpi, finalise_test, checkerr, &
+  public :: initialise_mpi, finalise_test, global_all, global_sum, checkerr, &
             write_perf_metric, write_perf_minmax_metrics, &
             write_perf_summary, write_perf_minmax_summary, &
             write_device_bw_metric
@@ -27,6 +27,26 @@ contains
     if (present(pprev)) pprev = modulo(nrank - 1, nproc)
     if (present(pnext)) pnext = modulo(nrank - nproc + 1, nproc)
   end subroutine initialise_mpi
+
+  subroutine global_all(value)
+    !! Replace a local logical value with the logical AND across all ranks.
+    logical, intent(inout) :: value
+
+    integer :: ierr
+
+    call MPI_Allreduce(MPI_IN_PLACE, value, 1, MPI_LOGICAL, MPI_LAND, &
+                       MPI_COMM_WORLD, ierr)
+  end subroutine global_all
+
+  subroutine global_sum(value)
+    !! Replace a local integer value with the sum across all ranks.
+    integer, intent(inout) :: value
+
+    integer :: ierr
+
+    call MPI_Allreduce(MPI_IN_PLACE, value, 1, MPI_INTEGER, MPI_SUM, &
+                       MPI_COMM_WORLD, ierr)
+  end subroutine global_sum
 
   subroutine finalise_test(allpass, nrank, finalize_mpi)
     !! Report the aggregate test result and finalise MPI, aborting via

--- a/tests/performance/perf_cuda_penta.f90
+++ b/tests/performance/perf_cuda_penta.f90
@@ -13,8 +13,8 @@ program perf_cuda_penta
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_penta_compact
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
-  use m_test_utils, only: write_perf_minmax_metrics, write_perf_minmax_summary, &
-                          write_device_bw_metric
+  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics, &
+                          write_perf_minmax_summary, write_device_bw_metric
 
   implicit none
 
@@ -36,7 +36,12 @@ program perf_cuda_penta
   type(dim3) :: blocks, threads
   real(dp) :: dx
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) then
+    print *, 'Performance benchmark for compact10_penta (Lele 10 penta 1st-deriv)'
+    print *, 'Scheme: alpha=0.5 beta=0.05, non-periodic, single-GPU Thomas'
+    print *, 'Ranks:', nproc
+  end if
   call select_device()
   call configure_benchmark()
   call allocate_fields()
@@ -45,21 +50,6 @@ program perf_cuda_penta
   call finalise()
 
 contains
-
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) then
-      print *, 'Performance benchmark for compact10_penta (Lele 10 penta 1st-deriv)'
-      print *, 'Scheme: alpha=0.5 beta=0.05, non-periodic, single-GPU Thomas'
-      print *, 'Ranks:', nproc
-    end if
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine configure_benchmark()
     n_glob = 1024

--- a/tests/performance/perf_cuda_penta.f90
+++ b/tests/performance/perf_cuda_penta.f90
@@ -13,7 +13,10 @@ program perf_cuda_penta
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_penta_compact
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
-  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics, &
+  use m_backend_runtime, only: select_cuda_device
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all, &
+                          check_status, &
+                          write_perf_minmax_metrics, &
                           write_perf_minmax_summary, write_device_bw_metric
 
   implicit none
@@ -31,10 +34,11 @@ program perf_cuda_penta
   integer :: n, n_block, n_halo, n_iters, n_warmup, n_glob, ndof, nrank, nproc
   integer :: pprev, pnext
   integer :: ierr
-  integer :: ndevs, devnum
+  integer :: devnum
   integer :: memClockRt, memBusWidth
   type(dim3) :: blocks, threads
   real(dp) :: dx
+  logical :: allpass = .true.
 
   call initialise_mpi(nrank, nproc, pprev, pnext)
   if (nrank == 0) then
@@ -42,12 +46,14 @@ program perf_cuda_penta
     print *, 'Scheme: alpha=0.5 beta=0.05, non-periodic, single-GPU Thomas'
     print *, 'Ranks:', nproc
   end if
-  call select_device()
+  call select_cuda_device(nrank, devnum)
   call configure_benchmark()
   call allocate_fields()
   call setup_backend()
-  call run_case('penta_lele10_nonper', dx, penta_bw)
-  call finalise()
+  call global_all(allpass)
+  if (allpass) call run_case('penta_lele10_nonper', dx, penta_bw)
+  call global_all(allpass)
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -72,12 +78,6 @@ contains
     u_recv_e_dev = 0._dp
   end subroutine allocate_fields
 
-  subroutine select_device()
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs))
-    ierr = cudaGetDevice(devnum)
-  end subroutine select_device
-
   subroutine setup_backend()
     integer :: i, j, k
 
@@ -101,7 +101,9 @@ contains
     threads = dim3(SZ, 1, 1)
 
     ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, devnum)
+    call check_status(ierr, 'query CUDA memory clock rate', allpass)
     ierr = cudaDeviceGetAttribute(memBusWidth, cudaDevAttrGlobalMemoryBusWidth, devnum)
+    call check_status(ierr, 'query CUDA memory bus width', allpass)
   end subroutine setup_backend
 
   subroutine run_case(case_name, delta, consumed_bw)
@@ -119,12 +121,14 @@ contains
       call run_kernel()
     end do
     call sync_backend()
+    if (.not. allpass) return
 
     call start_timer(tstart)
     do iter = 1, n_iters
       call run_kernel()
     end do
     call sync_backend()
+    if (.not. allpass) return
     call stop_timer(tend)
 
     call collect_perf_stats(tend - tstart, consumed_bw, achieved_bw, &
@@ -180,7 +184,9 @@ contains
 
   subroutine sync_backend()
     ierr = cudaDeviceSynchronize()
+    call check_status(ierr, 'synchronise CUDA device', allpass)
     call MPI_Barrier(MPI_COMM_WORLD, ierr)
+    call global_all(allpass)
   end subroutine sync_backend
 
   subroutine start_timer(t)
@@ -194,9 +200,5 @@ contains
 
     call cpu_time(t)
   end subroutine stop_timer
-
-  subroutine finalise()
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program perf_cuda_penta

--- a/tests/performance/perf_cuda_reorder.f90
+++ b/tests/performance/perf_cuda_reorder.f90
@@ -6,7 +6,10 @@ program perf_cuda_reorder
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c
-  use m_test_utils, only: write_perf_metric, write_perf_summary, &
+  use m_backend_runtime, only: select_cuda_device
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all, &
+                          check_status, &
+                          write_perf_metric, write_perf_summary, &
                           write_device_bw_metric
 
   implicit none
@@ -29,12 +32,17 @@ program perf_cuda_reorder
 
   integer :: ierr
   integer :: n_block, ndof
+  integer :: nrank, nproc, devnum
   integer :: memClockRt, memBusWidth
   real(dp), allocatable :: u_i(:, :, :)
   real(dp), device, allocatable :: u_i_d(:, :, :), u_o_d(:, :, :), &
                                    u_temp_d(:, :, :)
   real(dp), device, allocatable :: u_c_d(:, :, :)
   type(dim3) :: blocks, threads
+  logical :: allpass = .true.
+
+  call initialise_mpi(nrank, nproc)
+  call select_cuda_device(nrank, devnum)
 
   n_block = ny*nz/SZ
   ndof = nx*ny*nz
@@ -47,20 +55,26 @@ program perf_cuda_reorder
   call random_number(u_i)
   u_i_d = u_i
 
-  ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, 0)
+  ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, &
+                                devnum)
+  call check_status(ierr, 'query CUDA memory clock rate', allpass)
   ierr = cudaDeviceGetAttribute(memBusWidth, &
-                                cudaDevAttrGlobalMemoryBusWidth, 0)
+                                cudaDevAttrGlobalMemoryBusWidth, devnum)
+  call check_status(ierr, 'query CUDA memory bus width', allpass)
+  call global_all(allpass)
 
-  call run_case('cuda_reorder_x2y', CASE_X2Y)
-  call run_case('cuda_reorder_x2z', CASE_X2Z)
-  call run_case('cuda_reorder_y2x', CASE_Y2X)
-  call run_case('cuda_reorder_y2z', CASE_Y2Z)
-  call run_case('cuda_reorder_z2x', CASE_Z2X)
-  call run_case('cuda_reorder_z2y', CASE_Z2Y)
-  call run_case('cuda_reorder_x2c', CASE_X2C)
-  call run_case('cuda_reorder_c2x', CASE_C2X)
+  if (allpass) call run_case('cuda_reorder_x2y', CASE_X2Y)
+  if (allpass) call run_case('cuda_reorder_x2z', CASE_X2Z)
+  if (allpass) call run_case('cuda_reorder_y2x', CASE_Y2X)
+  if (allpass) call run_case('cuda_reorder_y2z', CASE_Y2Z)
+  if (allpass) call run_case('cuda_reorder_z2x', CASE_Z2X)
+  if (allpass) call run_case('cuda_reorder_z2y', CASE_Z2Y)
+  if (allpass) call run_case('cuda_reorder_x2c', CASE_X2C)
+  if (allpass) call run_case('cuda_reorder_c2x', CASE_C2X)
 
-  call write_device_bw_metric(memClockRt, memBusWidth)
+  if (allpass) call write_device_bw_metric(memClockRt, memBusWidth)
+  call global_all(allpass)
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -74,17 +88,20 @@ contains
     print *, 'Performance test:', trim(label)
 
     call prepare_input(case_id)
+    if (.not. allpass) return
 
     do iter = 1, n_warmup
       call launch_kernel(case_id)
     end do
     call sync_device()
+    if (.not. allpass) return
 
     call cpu_time(tstart)
     do iter = 1, n_iters
       call launch_kernel(case_id)
     end do
     call sync_device()
+    if (.not. allpass) return
     call cpu_time(tend)
 
     call write_perf_metric(label, tend - tstart, n_iters, ndof, consumed_bw)
@@ -157,6 +174,8 @@ contains
 
   subroutine sync_device()
     ierr = cudaDeviceSynchronize()
+    call check_status(ierr, 'synchronise CUDA device', allpass)
+    call global_all(allpass)
   end subroutine sync_device
 
 end program perf_cuda_reorder

--- a/tests/performance/perf_cuda_transeq.f90
+++ b/tests/performance/perf_cuda_transeq.f90
@@ -7,7 +7,7 @@ program perf_cuda_transeq
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t
-  use m_test_utils, only: write_perf_minmax_metrics, &
+  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics, &
                           write_perf_minmax_summary, write_device_bw_metric
 
   implicit none
@@ -39,7 +39,8 @@ real(dp), device, allocatable :: du_send_s_dev(:, :, :), du_send_e_dev(:, :, :)
   type(dim3) :: blocks, threads
   real(dp) :: dx_per, nu
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
   call select_device()
   call configure_benchmark()
   call allocate_fields()
@@ -48,17 +49,6 @@ real(dp), device, allocatable :: du_send_s_dev(:, :, :), du_send_e_dev(:, :, :)
   call finalise()
 
 contains
-
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine configure_benchmark()
     n_glob = 512

--- a/tests/performance/perf_cuda_transeq.f90
+++ b/tests/performance/perf_cuda_transeq.f90
@@ -7,7 +7,10 @@ program perf_cuda_transeq
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t
-  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics, &
+  use m_backend_runtime, only: select_cuda_device
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all, &
+                          check_status, &
+                          write_perf_minmax_metrics, &
                           write_perf_minmax_summary, write_device_bw_metric
 
   implicit none
@@ -34,19 +37,22 @@ real(dp), device, allocatable :: du_send_s_dev(:, :, :), du_send_e_dev(:, :, :)
   integer :: n, n_block, n_halo, n_iters, n_warmup, n_glob, ndof, nrank, nproc
   integer :: pprev, pnext
   integer :: ierr
-  integer :: ndevs, devnum
+  integer :: devnum
   integer :: memClockRt, memBusWidth
   type(dim3) :: blocks, threads
   real(dp) :: dx_per, nu
+  logical :: allpass = .true.
 
   call initialise_mpi(nrank, nproc, pprev, pnext)
   if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
-  call select_device()
+  call select_cuda_device(nrank, devnum)
   call configure_benchmark()
   call allocate_fields()
   call setup_backend()
-  call run_case('periodic', dx_per, periodic_bw)
-  call finalise()
+  call global_all(allpass)
+  if (allpass) call run_case('periodic', dx_per, periodic_bw)
+  call global_all(allpass)
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -80,12 +86,6 @@ allocate (v_recv_s_dev(SZ, n_halo, n_block), v_recv_e_dev(SZ, n_halo, n_block))
     allocate (d2u_recv_s_dev(SZ, 1, n_block), d2u_recv_e_dev(SZ, 1, n_block))
   end subroutine allocate_fields
 
-  subroutine select_device()
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs))
-    ierr = cudaGetDevice(devnum)
-  end subroutine select_device
-
   subroutine setup_backend()
     integer :: i, j, k
 
@@ -112,7 +112,9 @@ allocate (v_recv_s_dev(SZ, n_halo, n_block), v_recv_e_dev(SZ, n_halo, n_block))
 
     ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, &
                                   devnum)
+    call check_status(ierr, 'query CUDA memory clock rate', allpass)
     ierr = cudaDeviceGetAttribute(memBusWidth, cudaDevAttrGlobalMemoryBusWidth, devnum)
+    call check_status(ierr, 'query CUDA memory bus width', allpass)
   end subroutine setup_backend
 
   subroutine run_case(case_name, delta, consumed_bw)
@@ -130,12 +132,14 @@ allocate (v_recv_s_dev(SZ, n_halo, n_block), v_recv_e_dev(SZ, n_halo, n_block))
       call run_kernel()
     end do
     call sync_backend()
+    if (.not. allpass) return
 
     call start_timer(tstart)
     do iter = 1, n_iters
       call run_kernel()
     end do
     call sync_backend()
+    if (.not. allpass) return
     call stop_timer(tend)
 
     call collect_perf_stats(tend - tstart, consumed_bw, achieved_bw, &
@@ -216,7 +220,9 @@ allocate (v_recv_s_dev(SZ, n_halo, n_block), v_recv_e_dev(SZ, n_halo, n_block))
 
   subroutine sync_backend()
     ierr = cudaDeviceSynchronize()
+    call check_status(ierr, 'synchronise CUDA device', allpass)
     call MPI_Barrier(MPI_COMM_WORLD, ierr)
+    call global_all(allpass)
   end subroutine sync_backend
 
   subroutine start_timer(t)
@@ -230,9 +236,5 @@ allocate (v_recv_s_dev(SZ, n_halo, n_block), v_recv_e_dev(SZ, n_halo, n_block))
 
     call cpu_time(t)
   end subroutine stop_timer
-
-  subroutine finalise()
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program perf_cuda_transeq

--- a/tests/performance/perf_cuda_tridiag.f90
+++ b/tests/performance/perf_cuda_tridiag.f90
@@ -7,7 +7,7 @@ program perf_cuda_tridiag
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
-  use m_test_utils, only: write_perf_minmax_metrics, &
+  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics, &
                           write_perf_minmax_summary, write_device_bw_metric
 
   implicit none
@@ -34,7 +34,8 @@ program perf_cuda_tridiag
   type(dim3) :: blocks, threads
   real(dp) :: dx_per
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
   call select_device()
   call configure_benchmark()
   call allocate_fields()
@@ -43,17 +44,6 @@ program perf_cuda_tridiag
   call finalise()
 
 contains
-
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine configure_benchmark()
     n_glob = 1024

--- a/tests/performance/perf_cuda_tridiag.f90
+++ b/tests/performance/perf_cuda_tridiag.f90
@@ -7,7 +7,10 @@ program perf_cuda_tridiag
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
-  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics, &
+  use m_backend_runtime, only: select_cuda_device
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all, &
+                          check_status, &
+                          write_perf_minmax_metrics, &
                           write_perf_minmax_summary, write_device_bw_metric
 
   implicit none
@@ -29,19 +32,22 @@ program perf_cuda_tridiag
   integer :: n, n_block, n_halo, n_iters, n_warmup, n_glob, ndof, nrank, nproc
   integer :: pprev, pnext
   integer :: ierr
-  integer :: ndevs, devnum
+  integer :: devnum
   integer :: memClockRt, memBusWidth
   type(dim3) :: blocks, threads
   real(dp) :: dx_per
+  logical :: allpass = .true.
 
   call initialise_mpi(nrank, nproc, pprev, pnext)
   if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
-  call select_device()
+  call select_cuda_device(nrank, devnum)
   call configure_benchmark()
   call allocate_fields()
   call setup_backend()
-  call run_case('periodic', dx_per, periodic_bw)
-  call finalise()
+  call global_all(allpass)
+  if (allpass) call run_case('periodic', dx_per, periodic_bw)
+  call global_all(allpass)
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -68,12 +74,6 @@ contains
     allocate (du_recv_s_dev(SZ, 1, n_block), du_recv_e_dev(SZ, 1, n_block))
   end subroutine allocate_fields
 
-  subroutine select_device()
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs))
-    ierr = cudaGetDevice(devnum)
-  end subroutine select_device
-
   subroutine setup_backend()
     integer :: i, j, k
 
@@ -95,7 +95,9 @@ contains
 
     ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, &
                                   devnum)
+    call check_status(ierr, 'query CUDA memory clock rate', allpass)
     ierr = cudaDeviceGetAttribute(memBusWidth, cudaDevAttrGlobalMemoryBusWidth, devnum)
+    call check_status(ierr, 'query CUDA memory bus width', allpass)
   end subroutine setup_backend
 
   subroutine run_case(case_name, delta, consumed_bw)
@@ -113,12 +115,14 @@ contains
       call run_kernel()
     end do
     call sync_backend()
+    if (.not. allpass) return
 
     call start_timer(tstart)
     do iter = 1, n_iters
       call run_kernel()
     end do
     call sync_backend()
+    if (.not. allpass) return
     call stop_timer(tend)
 
     call collect_perf_stats(tend - tstart, consumed_bw, achieved_bw, &
@@ -183,7 +187,9 @@ contains
 
   subroutine sync_backend()
     ierr = cudaDeviceSynchronize()
+    call check_status(ierr, 'synchronise CUDA device', allpass)
     call MPI_Barrier(MPI_COMM_WORLD, ierr)
+    call global_all(allpass)
   end subroutine sync_backend
 
   subroutine start_timer(t)
@@ -197,9 +203,5 @@ contains
 
     call cpu_time(t)
   end subroutine stop_timer
-
-  subroutine finalise()
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program perf_cuda_tridiag

--- a/tests/performance/perf_omp_tridiag.f90
+++ b/tests/performance/perf_omp_tridiag.f90
@@ -7,7 +7,7 @@ program perf_omp_tridiag
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_exec_dist, only: exec_dist_tds_compact
   use m_tdsops, only: tdsops_t, tdsops_init
-  use m_test_utils, only: write_perf_minmax_metrics
+  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics
 
   implicit none
 
@@ -27,24 +27,14 @@ program perf_omp_tridiag
   integer :: ierr
   real(dp) :: dx_per
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
   call configure_benchmark()
   call allocate_fields()
   call run_case('periodic', dx_per, periodic_bw)
   call finalise()
 
 contains
-
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Performance benchmark with', nproc, 'ranks'
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine configure_benchmark()
     n_glob = 1024

--- a/tests/performance/perf_omp_tridiag.f90
+++ b/tests/performance/perf_omp_tridiag.f90
@@ -7,7 +7,8 @@ program perf_omp_tridiag
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_exec_dist, only: exec_dist_tds_compact
   use m_tdsops, only: tdsops_t, tdsops_init
-  use m_test_utils, only: initialise_mpi, write_perf_minmax_metrics
+  use m_test_utils, only: initialise_mpi, finalise_test, &
+                          write_perf_minmax_metrics
 
   implicit none
 
@@ -32,7 +33,7 @@ program perf_omp_tridiag
   call configure_benchmark()
   call allocate_fields()
   call run_case('periodic', dx_per, periodic_bw)
-  call finalise()
+  call finalise_test(.true., nrank)
 
 contains
 
@@ -154,9 +155,5 @@ contains
 
     t = omp_get_wtime()
   end subroutine stop_timer
-
-  subroutine finalise()
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program perf_omp_tridiag

--- a/tests/performance/perf_thom.f90
+++ b/tests/performance/perf_thom.f90
@@ -78,7 +78,7 @@ contains
       n_groups = 512*512/backend_sz
       n_iters = 1000
     else
-      backend_label = 'omp '
+      backend_label = 'omp'
       periodic_bw = 3.0_dp
       dirichlet_bw = 3.0_dp
       n_groups = 128*128/backend_sz

--- a/tests/performance/perf_thom.f90
+++ b/tests/performance/perf_thom.f90
@@ -1,188 +1,153 @@
 program perf_thom
+  use mpi, only: MPI_Wtime
 
-#ifdef CUDA
-  use cudafor
-#else
-  use omp_lib
-#endif
-  use m_common, only: dp, pi, BC_PERIODIC, BC_DIRICHLET
-#ifdef CUDA
-  use m_cuda_common, only: SZ
-  use m_cuda_exec_thom, only: exec_thom_tds_compact
-  use m_cuda_tdsops, only: tdsops_t => cuda_tdsops_t, tdsops_init => cuda_tdsops_init
-#else
-  use m_omp_common, only: SZ
-  use m_tdsops, only: tdsops_t, tdsops_init
-  use m_exec_thom, only: exec_thom_tds_compact
-#endif
-  use m_test_utils, only: write_perf_metric, write_perf_summary, write_device_bw_metric
+  use m_allocator, only: allocator_t, field_t
+  use m_backend_runtime, only: backend_runtime_t, backend_is_cuda, backend_sz
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, pi, BC_PERIODIC, BC_DIRICHLET, DIR_X, VERT
+  use m_mesh, only: mesh_t
+  use m_tdsops, only: tdsops_t
+  use m_test_utils, only: initialise_mpi, finalise_test, &
+                          write_perf_metric, write_perf_summary, &
+                          write_device_bw_metric
 
   implicit none
 
-#ifdef CUDA
-  character(len=*), parameter :: backend_label = 'cuda'
-  real(dp), parameter :: periodic_bw = 6.0_dp
-  real(dp), parameter :: dirichlet_bw = 4.0_dp
-#else
-  character(len=*), parameter :: backend_label = 'omp'
-  real(dp), parameter :: periodic_bw = 3.0_dp
-  real(dp), parameter :: dirichlet_bw = 3.0_dp
-#endif
-
-  integer :: i, j, k
   integer :: n_glob, n, n_groups
   integer :: n_iters, n_warmup
   integer :: ndof
+  integer :: nrank, nproc
+  integer :: mem_clock_rt, mem_bus_width
+  logical :: has_device_bw_info
   real(dp) :: dx_per, dx
+  real(dp) :: periodic_bw, dirichlet_bw
+  character(len=4) :: backend_label
 
-#ifdef CUDA
-  integer :: ierr
-  integer :: memClockRt, memBusWidth
-  real(dp), allocatable :: u(:, :, :)
-  real(dp), device, allocatable :: u_dev(:, :, :), du_dev(:, :, :)
-  type(dim3) :: blocks, threads
-#else
-  real(dp), allocatable :: u(:, :, :), du(:, :, :)
-#endif
+  type(backend_runtime_t), target :: runtime
+  type(mesh_t), target :: mesh
+  class(base_backend_t), pointer :: backend
+  class(allocator_t), pointer :: allocator
+  class(field_t), pointer :: u_field, du_field
+  class(tdsops_t), allocatable :: periodic_tdsops, dirichlet_tdsops
+  real(dp), allocatable :: u_data(:, :, :)
 
-  type(tdsops_t) :: tdsops
-
+  call initialise_mpi(nrank, nproc)
   call configure_benchmark()
-  call allocate_fields()
-  call setup_backend()
+
+  mesh = build_mesh(n_glob, n_groups)
+  call runtime%init(mesh)
+  backend => runtime%backend
+  allocator => runtime%allocator
+
+  u_field => allocator%get_block(DIR_X, VERT)
+  du_field => allocator%get_block(DIR_X, VERT)
+  allocate (u_data(backend_sz, n, n_groups))
+
+  call backend%get_device_bw_info(mem_clock_rt, mem_bus_width, &
+                                  has_device_bw_info)
 
   dx_per = 2*pi/n_glob
   dx = 2*pi/(n_glob - 1)
 
-  call run_case('periodic', dx_per, BC_PERIODIC, BC_PERIODIC, periodic_bw)
-  call run_case('dirichlet', dx, BC_DIRICHLET, BC_DIRICHLET, dirichlet_bw)
+  call backend%alloc_tdsops(periodic_tdsops, n, dx_per, &
+                            operation='second-deriv', scheme='compact6', &
+                            bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
+  call backend%alloc_tdsops(dirichlet_tdsops, n, dx, &
+                            operation='second-deriv', scheme='compact6', &
+                            bc_start=BC_DIRICHLET, bc_end=BC_DIRICHLET)
 
-#ifdef CUDA
-  call write_device_bw_metric(memClockRt, memBusWidth)
-#endif
+  call run_case('periodic', dx_per, periodic_tdsops, periodic_bw)
+  call run_case('dirichlet', dx, dirichlet_tdsops, dirichlet_bw)
+
+  if (has_device_bw_info) then
+    call write_device_bw_metric(mem_clock_rt, mem_bus_width)
+  end if
+
+  call allocator%release_block(u_field)
+  call allocator%release_block(du_field)
+  call finalise_test(.true., nrank)
 
 contains
 
   subroutine configure_benchmark()
     n_glob = 512
-#ifdef CUDA
-    n_groups = 512*512/SZ
-    n_iters = 1000
-#else
-    n_groups = 128*128/SZ
-    n_iters = 500
-#endif
+    if (backend_is_cuda) then
+      backend_label = 'cuda'
+      periodic_bw = 6.0_dp
+      dirichlet_bw = 4.0_dp
+      n_groups = 512*512/backend_sz
+      n_iters = 1000
+    else
+      backend_label = 'omp '
+      periodic_bw = 3.0_dp
+      dirichlet_bw = 3.0_dp
+      n_groups = 128*128/backend_sz
+      n_iters = 500
+    end if
     n_warmup = 10
     n = n_glob
-    ndof = n_glob*n_groups*SZ
+    ndof = n_glob*n_groups*backend_sz
   end subroutine configure_benchmark
 
-  subroutine allocate_fields()
-#ifdef CUDA
-    allocate (u(SZ, n, n_groups))
-    allocate (u_dev(SZ, n, n_groups), du_dev(SZ, n, n_groups))
-#else
-    allocate (u(SZ, n, n_groups), du(SZ, n, n_groups))
-#endif
-  end subroutine allocate_fields
+  function build_mesh(nx, nz) result(mesh_out)
+    integer, intent(in) :: nx, nz
+    type(mesh_t) :: mesh_out
 
-  subroutine setup_backend()
-#ifdef CUDA
-    blocks = dim3(n_groups, 1, 1)
-    threads = dim3(SZ, 1, 1)
+    character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
-    ierr = cudaDeviceGetAttribute(memClockRt, cudaDevAttrMemoryClockRate, 0)
-    ierr = cudaDeviceGetAttribute(memBusWidth, &
-                                  cudaDevAttrGlobalMemoryBusWidth, 0)
-#endif
-  end subroutine setup_backend
+    BC_x = ['periodic', 'periodic']
+    BC_y = ['periodic', 'periodic']
+    BC_z = ['periodic', 'periodic']
 
-  subroutine run_case(case_name, delta, bc_start, bc_end, consumed_bw)
+    mesh_out = mesh_t([nx, backend_sz, nz], [1, 1, 1], &
+                      [2*pi, 1.0_dp, 1.0_dp], &
+                      BC_x, BC_y, BC_z)
+  end function build_mesh
+
+  subroutine run_case(case_name, delta, tdsops, consumed_bw)
     character(len=*), intent(in) :: case_name
     real(dp), intent(in) :: delta, consumed_bw
-    integer, intent(in) :: bc_start, bc_end
+    class(tdsops_t), intent(in) :: tdsops
 
     integer :: iter
     real(dp) :: tstart, tend
 
     call initialise_input(delta)
-
-#ifdef CUDA
-    u_dev = u
-#endif
-
-    tdsops = tdsops_init(n, delta, &
-                         operation='second-deriv', scheme='compact6', &
-                         bc_start=bc_start, bc_end=bc_end)
+    call backend%set_field_data(u_field, u_data, DIR_X)
 
     do iter = 1, n_warmup
-      call run_kernel()
+      call backend%thom_solve(du_field, u_field, tdsops)
     end do
-    call sync_backend()
+    call backend%sync()
 
-    call start_timer(tstart)
+    tstart = MPI_Wtime()
     do iter = 1, n_iters
-      call run_kernel()
+      call backend%thom_solve(du_field, u_field, tdsops)
     end do
-    call sync_backend()
-    call stop_timer(tend)
+    call backend%sync()
+    tend = MPI_Wtime()
 
     call write_perf_metric(trim(backend_label)//'_thom_'//trim(case_name), &
                            tend - tstart, n_iters, ndof, consumed_bw)
-#ifdef CUDA
-    call write_perf_summary(tend - tstart, n_iters, ndof, consumed_bw, &
-                            memClockRt, memBusWidth)
-#else
-    call write_perf_summary(tend - tstart, n_iters, ndof, consumed_bw)
-#endif
+    if (has_device_bw_info) then
+      call write_perf_summary(tend - tstart, n_iters, ndof, consumed_bw, &
+                              mem_clock_rt, mem_bus_width)
+    else
+      call write_perf_summary(tend - tstart, n_iters, ndof, consumed_bw)
+    end if
   end subroutine run_case
 
   subroutine initialise_input(delta)
     real(dp), intent(in) :: delta
+    integer :: i, j, k
 
     do k = 1, n_groups
       do j = 1, n
-        do i = 1, SZ
-          u(i, j, k) = sin((j - 1)*delta)
+        do i = 1, backend_sz
+          u_data(i, j, k) = sin((j - 1)*delta)
         end do
       end do
     end do
   end subroutine initialise_input
-
-  subroutine run_kernel()
-#ifdef CUDA
-    call exec_thom_tds_compact(du_dev, u_dev, tdsops, blocks, threads)
-#else
-    call exec_thom_tds_compact(du, u, tdsops, n_groups)
-#endif
-  end subroutine run_kernel
-
-  subroutine sync_backend()
-#ifdef CUDA
-    integer :: ierr
-
-    ierr = cudaDeviceSynchronize()
-#endif
-  end subroutine sync_backend
-
-  subroutine start_timer(t)
-    real(dp), intent(out) :: t
-
-#ifdef CUDA
-    call cpu_time(t)
-#else
-    t = omp_get_wtime()
-#endif
-  end subroutine start_timer
-
-  subroutine stop_timer(t)
-    real(dp), intent(out) :: t
-
-#ifdef CUDA
-    call cpu_time(t)
-#else
-    t = omp_get_wtime()
-#endif
-  end subroutine stop_timer
 
 end program perf_thom

--- a/tests/unit/test_ab_checkpoint.f90
+++ b/tests/unit/test_ab_checkpoint.f90
@@ -11,6 +11,7 @@ program test_ab_checkpoint
   use m_solver, only: solver_t
   use m_omp_backend, only: omp_backend_t
   use m_omp_common, only: SZ
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all
 
   implicit none
 
@@ -27,7 +28,7 @@ program test_ab_checkpoint
   type(checkpoint_manager_t) :: chk_mgr_write, chk_mgr_restart
   type(flist_t), allocatable :: curr(:)
   type(flist_t), allocatable :: deriv(:)
-  integer :: ierr, irank, nproc
+  integer :: irank, nproc
   integer :: dims_global(3), nproc_dir(3)
   real(dp) :: L_global(3)
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
@@ -39,9 +40,7 @@ program test_ab_checkpoint
   logical :: allpass
   real(dp) :: diff
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(irank, nproc)
 
   allpass = .true.
 
@@ -120,15 +119,8 @@ program test_ab_checkpoint
     deallocate (olds_ref)
   end if
 
-  call MPI_Finalize(ierr)
-
-  if (irank == 0) then
-    if (allpass) then
-      write (stderr, '(a)') 'AB checkpoint test passed.'
-    else
-      error stop 'AB checkpoint test failed.'
-    end if
-  end if
+  call global_all(allpass)
+  call finalise_test(allpass, irank)
 
 contains
 

--- a/tests/unit/test_adios2_read_write.f90
+++ b/tests/unit/test_adios2_read_write.f90
@@ -4,7 +4,7 @@ program test_adios2
   use m_io_base, only: io_writer_t, io_reader_t, io_file_t, io_mode_write, &
                        io_mode_read
   use m_common, only: dp, i8, is_sp
-  use iso_fortran_env, only: stderr => error_unit
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all
   implicit none
 
   ! ADIOS2 handlers
@@ -24,9 +24,7 @@ program test_adios2
   real(dp) :: expected, tolerance
 
   ! launch MPI
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)
+  call initialise_mpi(irank, isize)
 
   ! data initialisation
   allocate (data_write(inx, iny, inz))
@@ -111,15 +109,7 @@ program test_adios2
 
   ! Cleanup and finalize
   call MPI_Barrier(MPI_COMM_WORLD, ierr)
-  call MPI_Finalize(ierr)
-
-  ! Test result
-  if (irank == 0) then
-    if (allpass) then
-      write (stderr, '(a)') 'ADIOS2 TEST PASSED SUCCESSFULLY.'
-    else
-      error stop 'ADIOS2 TEST FAILED.'
-    end if
-  end if
+  call global_all(allpass)
+  call finalise_test(allpass, irank)
 
 end program test_adios2

--- a/tests/unit/test_allocator.f90
+++ b/tests/unit/test_allocator.f90
@@ -5,6 +5,7 @@ program test_allocator
   use m_allocator, only: allocator_t
   use m_field, only: field_t
   use m_common, only: DIR_X, pi, dp
+  use m_test_utils, only: finalise_test
 
   implicit none
 
@@ -76,11 +77,5 @@ program test_allocator
 
   call allocator%destroy()
 
-  if (allpass) then
-    write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
-
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass)
 end program test_allocator

--- a/tests/unit/test_allocator.f90
+++ b/tests/unit/test_allocator.f90
@@ -1,11 +1,10 @@
 program test_allocator
-  use mpi
   use iso_fortran_env, only: stderr => error_unit
 
   use m_allocator, only: allocator_t
   use m_field, only: field_t
   use m_common, only: DIR_X, pi, dp
-  use m_test_utils, only: finalise_test
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -16,9 +15,9 @@ program test_allocator
   class(allocator_t), allocatable :: allocator
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
-  integer :: ierr
+  integer :: nrank, nproc
 
-  call MPI_Init(ierr)
+  call initialise_mpi(nrank, nproc)
 
   allocator = allocator_t([8, 8, 8], 8)
 
@@ -77,5 +76,5 @@ program test_allocator
 
   call allocator%destroy()
 
-  call finalise_test(allpass)
+  call finalise_test(allpass, nrank)
 end program test_allocator

--- a/tests/unit/test_cuda_allocator.f90
+++ b/tests/unit/test_cuda_allocator.f90
@@ -5,6 +5,8 @@ program test_allocator_cuda
   use m_common, only: dp, pi, DIR_X
 
   use m_cuda_allocator, only: cuda_allocator_t
+  use m_backend_runtime, only: select_cuda_device
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -12,9 +14,10 @@ program test_allocator_cuda
   class(allocator_t), allocatable :: allocator
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
-  integer :: ierr
+  integer :: nrank, nproc
 
-  call MPI_Init(ierr)
+  call initialise_mpi(nrank, nproc)
+  call select_cuda_device(nrank)
 
   allocator = cuda_allocator_t([8, 8, 8], 8)
 
@@ -73,5 +76,5 @@ program test_allocator_cuda
 
   call allocator%destroy()
 
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 end program test_allocator_cuda

--- a/tests/unit/test_cuda_reorder.f90
+++ b/tests/unit/test_cuda_reorder.f90
@@ -7,6 +7,7 @@ program test_cuda_reorder
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c
+  use m_test_utils, only: finalise_test
 
   implicit none
 
@@ -128,10 +129,6 @@ program test_cuda_reorder
     write (stderr, '(a)') 'Check reorder x2c and c2x... passed'
   end if
 
-  if (allpass) then
-    write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
+  call finalise_test(allpass, finalize_mpi=.false.)
 
 end program test_cuda_reorder

--- a/tests/unit/test_cuda_reorder.f90
+++ b/tests/unit/test_cuda_reorder.f90
@@ -7,7 +7,8 @@ program test_cuda_reorder
   use m_cuda_kernels_reorder, only: reorder_x2y, reorder_x2z, reorder_y2x, &
                                     reorder_y2z, reorder_z2x, reorder_z2y, &
                                     reorder_c2x, reorder_x2c
-  use m_test_utils, only: finalise_test
+  use m_backend_runtime, only: select_cuda_device
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -19,9 +20,13 @@ program test_cuda_reorder
 
   integer :: n_block
   integer :: nx, ny, nz
+  integer :: nrank, nproc
 
   type(dim3) :: blocks, threads
   real(dp) :: norm_u
+
+  call initialise_mpi(nrank, nproc)
+  call select_cuda_device(nrank)
 
   nx = 256; ny = 256; nz = 256
   n_block = ny*nz/SZ
@@ -129,6 +134,6 @@ program test_cuda_reorder
     write (stderr, '(a)') 'Check reorder x2c and c2x... passed'
   end if
 
-  call finalise_test(allpass, finalize_mpi=.false.)
+  call finalise_test(allpass, nrank)
 
 end program test_cuda_reorder

--- a/tests/unit/test_io_session.f90
+++ b/tests/unit/test_io_session.f90
@@ -3,7 +3,7 @@ program test_io_session
   use mpi
   use m_common, only: dp, i8
   use m_io_session, only: writer_session_t, reader_session_t
-  use iso_fortran_env, only: stderr => error_unit
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all
   implicit none
 
   integer, parameter, dimension(3) :: local_dims = [8, 6, 1]
@@ -22,9 +22,7 @@ program test_io_session
   logical :: allpass = .true.
   integer :: i, j, k
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(irank, nproc)
 
   ! setup global domain dimensions
   global_dims = [int(local_dims(1), i8), int(local_dims(2), i8), &
@@ -93,19 +91,11 @@ program test_io_session
     if (.not. allpass) exit
   end do
 
-  call MPI_Allreduce(MPI_IN_PLACE, allpass, 1, MPI_LOGICAL, &
-                     MPI_LAND, MPI_COMM_WORLD, ierr)
+  call global_all(allpass)
 
   ! cleanup
   if (irank == 0) call execute_command_line("rm -rf "//test_file)
 
-  call MPI_Finalize(ierr)
-
-  if (allpass) then
-    if (irank == 0) write (stderr, &
-                        '(a)') 'PARALLEL I/O SESSION TEST PASSED SUCCESSFULLY.'
-  else
-    error stop 'PARALLEL I/O SESSION TEST FAILED.'
-  end if
+  call finalise_test(allpass, irank)
 
 end program test_io_session

--- a/tests/unit/test_mesh.f90
+++ b/tests/unit/test_mesh.f90
@@ -6,6 +6,7 @@ program test_mesh
   use m_field, only: field_t
   use m_mesh, only: mesh_t
   use m_common, only: DIR_X, pi, dp, CELL, DIR_C, DIR_Y, DIR_Z, VERT, Z_FACE
+  use m_test_utils, only: finalise_test
 
   implicit none
 
@@ -47,13 +48,7 @@ program test_mesh
   call run_test_mesh(.true., allpass)
 #endif
 
-  if (allpass) then
-    write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
-
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 
 contains
 

--- a/tests/unit/test_mesh.f90
+++ b/tests/unit/test_mesh.f90
@@ -1,12 +1,11 @@
 program test_mesh
-  use mpi
   use iso_fortran_env, only: stderr => error_unit
 
   use m_allocator, only: allocator_t
   use m_field, only: field_t
   use m_mesh, only: mesh_t
   use m_common, only: DIR_X, pi, dp, CELL, DIR_C, DIR_Y, DIR_Z, VERT, Z_FACE
-  use m_test_utils, only: finalise_test
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -19,15 +18,13 @@ program test_mesh
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, dimension(3) :: dims
   integer, dimension(3) :: dims_check
-  integer :: ierr, nrank, nproc
+  integer :: nrank, nproc
   integer :: n_cell, n_vert, n_x_face
   ! -ffast-math reciprocal division can be ~1 ulp off even for exactly
   ! representable results, so the tolerance must scale with the precision
   real(dp), parameter :: eps = 1000*epsilon(1._dp)
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
 
   allpass = .true.
 

--- a/tests/unit/test_omptgt_allocator.f90
+++ b/tests/unit/test_omptgt_allocator.f90
@@ -5,6 +5,7 @@ program test_allocator_omptgt
   use m_common, only: dp, pi, DIR_X
 
   use m_omptgt_allocator, only: omptgt_allocator_t
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -15,9 +16,9 @@ program test_allocator_omptgt
   class(allocator_t), allocatable :: allocator
   class(field_t), pointer :: ptr1, ptr2, ptr3
   integer, allocatable :: l(:)
-  integer :: ierr
+  integer :: nrank, nproc
 
-  call MPI_Init(ierr)
+  call initialise_mpi(nrank, nproc)
 
   dims = [8, 8, 8]
   nproc_dir = [1, 1, 1]
@@ -88,5 +89,5 @@ program test_allocator_omptgt
 
   call allocator%destroy()
 
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 end program test_allocator_omptgt

--- a/tests/unit/test_output_scalars.f90
+++ b/tests/unit/test_output_scalars.f90
@@ -4,26 +4,25 @@ program test_output_scalars
   !! These checks validate the file-writing behavior shared by scalar time
   !! series outputs, including the infrastructure used by monitoring.csv.
   use iso_fortran_env, only: stderr => error_unit, iostat_end
-  use mpi
-
   use m_common, only: dp
   use m_scalar_series, only: scalar_series_t
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all
 
   implicit none
 
-  integer :: ierr, irank
+  integer :: irank, nproc
+  logical :: allpass = .true.
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
+  call initialise_mpi(irank, nproc)
 
   if (irank == 0) then
     call test_root_writes_named_columns()
     call test_append_adds_rows_without_header()
     call test_non_root_is_noop()
-    write (stderr, '(a)') 'Output scalar tests passed.'
   end if
 
-  call MPI_Finalize(ierr)
+  call global_all(allpass)
+  call finalise_test(allpass, irank)
 
 contains
 
@@ -47,22 +46,22 @@ contains
     call series%finalise()
 
     open (newunit=unit, file=filename, status='old', action='read', iostat=ios)
-    call assert_iostat_ok(ios, 'open root output')
+    if (.not. assert_iostat_ok(ios, 'open root output')) return
 
     read (unit, '(A)', iostat=ios) header
-    call assert_iostat_ok(ios, 'read root header')
+    if (.not. assert_iostat_ok(ios, 'read root header')) return
     call assert_equal(trim(header), '# time, lift, drag, moment', &
                       'root header')
 
     read (unit, *, iostat=ios) t, a, b, c
-    call assert_iostat_ok(ios, 'read first root row')
+    if (.not. assert_iostat_ok(ios, 'read first root row')) return
     call assert_close(t, 0.0_dp, 'first row time')
     call assert_close(a, 1.25_dp, 'first row lift')
     call assert_close(b, -2.5_dp, 'first row drag')
     call assert_close(c, 3.75_dp, 'first row moment')
 
     read (unit, *, iostat=ios) t, a, b, c
-    call assert_iostat_ok(ios, 'read second root row')
+    if (.not. assert_iostat_ok(ios, 'read second root row')) return
     call assert_close(t, 0.5_dp, 'second row time')
     call assert_close(a, 4.0_dp, 'second row lift')
     call assert_close(b, 5.5_dp, 'second row drag')
@@ -98,20 +97,20 @@ contains
     call series%finalise()
 
     open (newunit=unit, file=filename, status='old', action='read', iostat=ios)
-    call assert_iostat_ok(ios, 'open append output')
+    if (.not. assert_iostat_ok(ios, 'open append output')) return
 
     read (unit, '(A)', iostat=ios) header
-    call assert_iostat_ok(ios, 'read append header')
+    if (.not. assert_iostat_ok(ios, 'read append header')) return
     call assert_equal(trim(header), '# time, ke, enstrophy', 'append header')
 
     read (unit, *, iostat=ios) t, a, b
-    call assert_iostat_ok(ios, 'read first append row')
+    if (.not. assert_iostat_ok(ios, 'read first append row')) return
     call assert_close(t, 1.0_dp, 'first append row time')
     call assert_close(a, 10.0_dp, 'first append row ke')
     call assert_close(b, 20.0_dp, 'first append row enstrophy')
 
     read (unit, *, iostat=ios) t, a, b
-    call assert_iostat_ok(ios, 'read second append row')
+    if (.not. assert_iostat_ok(ios, 'read second append row')) return
     call assert_close(t, 2.0_dp, 'second append row time')
     call assert_close(a, 30.0_dp, 'second append row ke')
     call assert_close(b, 40.0_dp, 'second append row enstrophy')
@@ -140,7 +139,8 @@ contains
     inquire (file=filename, exist=exists)
     if (exists) then
       call remove_file(filename)
-      error stop 'non-root scalar series writer created a file'
+      write (stderr, '(a)') 'non-root scalar series writer created a file'
+      allpass = .false.
     end if
   end subroutine test_non_root_is_noop
 
@@ -157,19 +157,19 @@ contains
 
     open (newunit=unit, file=filename, status='old', action='readwrite', &
           iostat=ios)
-    call assert_iostat_ok(ios, 'open file for cleanup')
+    if (.not. assert_iostat_ok(ios, 'open file for cleanup')) return
     close (unit, status='delete')
   end subroutine remove_file
 
   subroutine assert_equal(actual, expected, label)
-    !! Compare two strings and stop the test with a useful diagnostic if they
+    !! Compare two strings and report a useful diagnostic if they
     !! differ. The label identifies which output field or line failed.
     character(len=*), intent(in) :: actual, expected, label
 
     if (actual /= expected) then
       write (stderr, '(a,": expected [",a,"], got [",a,"]")') &
         trim(label), expected, actual
-      error stop 'scalar series string assertion failed'
+      allpass = .false.
     end if
   end subroutine assert_equal
 
@@ -185,21 +185,22 @@ contains
     if (abs(actual - expected) > tol) then
       write (stderr, '(a,": expected ",ES20.12,", got ",ES20.12)') &
         trim(label), expected, actual
-      error stop 'scalar series numeric assertion failed'
+      allpass = .false.
     end if
   end subroutine assert_close
 
-  subroutine assert_iostat_ok(ios, label)
+  logical function assert_iostat_ok(ios, label)
     !! Check that a file operation completed successfully. Non-zero iostat
-    !! values are reported with context before stopping the test.
+    !! values are reported with context and make the test fail.
     integer, intent(in) :: ios
     character(len=*), intent(in) :: label
 
-    if (ios /= 0) then
+    assert_iostat_ok = ios == 0
+    if (.not. assert_iostat_ok) then
       write (stderr, '(a,": iostat=",i0)') trim(label), ios
-      error stop 'scalar series file operation failed'
+      allpass = .false.
     end if
-  end subroutine assert_iostat_ok
+  end function assert_iostat_ok
 
   subroutine assert_eof(ios, label)
     !! Check that reading past the expected rows reaches end-of-file. This
@@ -209,7 +210,7 @@ contains
 
     if (ios /= iostat_end) then
       write (stderr, '(a,": expected EOF, iostat=",i0)') trim(label), ios
-      error stop 'scalar series output had unexpected extra data'
+      allpass = .false.
     end if
   end subroutine assert_eof
 

--- a/tests/unit/test_reordering.f90
+++ b/tests/unit/test_reordering.f90
@@ -1,7 +1,5 @@
 program test_reorder
   use iso_fortran_env, only: stderr => error_unit
-  use mpi
-
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
 
@@ -12,7 +10,7 @@ program test_reorder
   use m_backend_runtime, only: backend_runtime_t, backend_sz
   use m_ordering, only: get_index_dir, get_index_ijk
   use m_mesh, only: mesh_t
-  use m_test_utils, only: finalise_test
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -25,7 +23,7 @@ program test_reorder
   integer :: dims(3)
 
   integer :: nrank, nproc
-  integer :: ierr, i, j, k
+  integer :: i, j, k
 
   real(dp) :: dx, dx_per
 
@@ -39,9 +37,7 @@ program test_reorder
   logical :: pass_X, pass_Y, pass_Z
 
   ! Initialise variables and arrays
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
 
   ! Global number of cells in each direction
   dims_global = [64, 64, 96]
@@ -164,4 +160,3 @@ contains
   end subroutine
 
 end program test_reorder
-

--- a/tests/unit/test_reordering.f90
+++ b/tests/unit/test_reordering.f90
@@ -12,6 +12,7 @@ program test_reorder
 
   use m_ordering, only: get_index_dir, get_index_ijk
   use m_mesh, only: mesh_t
+  use m_test_utils, only: finalise_test
 
 #ifdef CUDA
   use cudafor
@@ -169,13 +170,7 @@ program test_reorder
   call backend%reorder(u_x, u_y, RDR_Y2X)
   call check_reorder(allpass, u_x, u_x_original, "testing Z2Y and Y2X failed")
 
-  if (allpass) then
-    if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
-
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 
 contains
 

--- a/tests/unit/test_reordering.f90
+++ b/tests/unit/test_reordering.f90
@@ -4,26 +4,15 @@ program test_reorder
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
-  use m_tdsops, only: dirps_t
 
   use m_common, only: dp, pi, &
                       RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
                       DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
 
+  use m_backend_runtime, only: backend_runtime_t, backend_sz
   use m_ordering, only: get_index_dir, get_index_ijk
   use m_mesh, only: mesh_t
   use m_test_utils, only: finalise_test
-
-#ifdef CUDA
-  use cudafor
-
-  use m_cuda_allocator, only: cuda_allocator_t, cuda_field_t
-  use m_cuda_backend, only: cuda_backend_t
-  use m_cuda_common, only: SZ
-#else
-  use m_omp_common, only: SZ
-  use m_omp_backend, only: omp_backend_t
-#endif
 
   implicit none
 
@@ -40,34 +29,19 @@ program test_reorder
 
   real(dp) :: dx, dx_per
 
+  type(backend_runtime_t), target :: runtime
   class(base_backend_t), pointer :: backend
-  class(mesh_t), allocatable :: mesh
+  type(mesh_t), target :: mesh
   class(allocator_t), pointer :: allocator
-  type(dirps_t), target :: xdirps, ydirps, zdirps
   integer, dimension(3) :: dims_padded, dims_global, nproc_dir
   real(dp), dimension(3) :: L_global
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
   logical :: pass_X, pass_Y, pass_Z
 
-#ifdef CUDA
-  type(cuda_backend_t), target :: cuda_backend
-  type(cuda_allocator_t), target :: cuda_allocator
-  integer :: ndevs, devnum
-#else
-  type(omp_backend_t), target :: omp_backend
-  type(allocator_t), target :: omp_allocator
-#endif
-
   ! Initialise variables and arrays
   call MPI_Init(ierr)
   call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
   call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-#ifdef CUDA
-  ierr = cudaGetDeviceCount(ndevs)
-  ierr = cudaSetDevice(mod(nrank, ndevs)) ! round-robin
-  ierr = cudaGetDevice(devnum)
-#endif
 
   ! Global number of cells in each direction
   dims_global = [64, 64, 96]
@@ -84,23 +58,13 @@ program test_reorder
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
 
-#ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => cuda_allocator
-  print *, 'CUDA allocator instantiated'
-
-  cuda_backend = cuda_backend_t(mesh, allocator)
-  backend => cuda_backend
-  print *, 'CUDA backend instantiated'
-#else
-  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omp_allocator
-  print *, 'OpenMP allocator instantiated'
-
-  omp_backend = omp_backend_t(mesh, allocator)
-  backend => omp_backend
-  print *, 'OpenMP backend instantiated'
-#endif
+  call runtime%init(mesh)
+  allocator => runtime%allocator
+  backend => runtime%backend
+  if (nrank == 0) then
+    print *, trim(runtime%backend_name), 'allocator instantiated'
+    print *, trim(runtime%backend_name), 'backend instantiated'
+  end if
 
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   pass_X = .true.
@@ -113,11 +77,14 @@ program test_reorder
   do k = 1, mesh%get_n(DIR_Z, VERT)
     do j = 1, mesh%get_n(DIR_Y, VERT)
       do i = 1, mesh%get_n(DIR_X, VERT)
-        call test_index_reversing(pass_X, i, j, k, DIR_X, SZ, dims_padded(1), &
+        call test_index_reversing(pass_X, i, j, k, DIR_X, backend_sz, &
+                                  dims_padded(1), &
                                   dims_padded(2), dims_padded(3))
-        call test_index_reversing(pass_Y, i, j, k, DIR_Y, SZ, dims_padded(1), &
+        call test_index_reversing(pass_Y, i, j, k, DIR_Y, backend_sz, &
+                                  dims_padded(1), &
                                   dims_padded(2), dims_padded(3))
-        call test_index_reversing(pass_Z, i, j, k, DIR_Z, SZ, dims_padded(1), &
+        call test_index_reversing(pass_Z, i, j, k, DIR_Z, backend_sz, &
+                                  dims_padded(1), &
                                   dims_padded(2), dims_padded(3))
       end do
     end do
@@ -136,23 +103,11 @@ program test_reorder
 
   dims(:) = allocator%get_padded_dims(DIR_X)
   allocate (u_array(dims(1), dims(2), dims(3)))
-
-  call random_number(u_array)
-
-#ifdef CUDA
   allocate (temp_1(dims(1), dims(2), dims(3)))
   allocate (temp_2(dims(1), dims(2), dims(3)))
 
-  select type (u_x_original)
-  type is (cuda_field_t)
-    u_x_original%data_d = u_array
-  end select
-#else
-  select type (u_x_original)
-  type is (field_t)
-    u_x_original%data = u_array
-  end select
-#endif
+  call random_number(u_array)
+  call backend%set_field_data(u_x_original, u_array, DIR_X)
 
   call backend%reorder(u_y, u_x_original, RDR_X2Y)
   call backend%reorder(u_x, u_y, RDR_Y2X)
@@ -198,20 +153,13 @@ contains
     character(len=*), intent(in) :: message
     real(dp) :: tol = 1d-8
 
-#ifdef CUDA
-    select type (a); type is (cuda_field_t); temp_1 = a%data_d; end select
-    select type (b); type is (cuda_field_t); temp_2 = b%data_d; end select
-    if (norm2(temp_1 - temp_2) > tol) then
+    call backend%get_field_data(temp_1, a, DIR_X)
+    call backend%get_field_data(temp_2, b, DIR_X)
+    if (norm2(temp_1(:, 1:mesh%get_n(DIR_X, VERT), :) - &
+              temp_2(:, 1:mesh%get_n(DIR_X, VERT), :)) > tol) then
       allpass = .false.
       write (stderr, '(a)') message
     end if
-#else
-    if (norm2(a%data(:, 1:mesh%get_n(DIR_X, VERT), :) - &
-              b%data(:, 1:mesh%get_n(DIR_X, VERT), :)) > tol) then
-      allpass = .false.
-      write (stderr, '(a)') message
-    end if
-#endif
 
   end subroutine
 

--- a/tests/unit/test_scalar_product.f90
+++ b/tests/unit/test_scalar_product.f90
@@ -4,30 +4,23 @@ program test_scalar_product
   !! Given two fields, a and b, computes s = a_i * b_i where repeated indices
   !! imply summation.
 
-  use m_common, only: DIR_X, DIR_Y, DIR_Z, DIR_C
+  use m_common, only: DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
 
   use m_allocator
   use m_base_backend
-#ifdef CUDA
-#else
-  use m_omp_backend
-  use m_omp_common, only: SZ
-#endif
+  use m_backend_runtime, only: backend_runtime_t
+  use m_test_utils, only: initialise_mpi, finalise_test, &
+                          global_all, global_sum
 
   implicit none
 
   integer, parameter :: nx = 17, ny = 32, nz = 59
   real(dp), parameter :: lx = 1.618, ly = 3.141529, lz = 1.729
 
+  type(backend_runtime_t), target :: runtime
   class(base_backend_t), pointer :: backend
-  class(allocator_t), pointer :: allocator
-#ifdef CUDA
-#else
-  type(omp_backend_t), target :: omp_backend
-  type(allocator_t), target :: omp_allocator
-#endif
 
-  type(mesh_t) :: mesh
+  type(mesh_t), target :: mesh
 
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
@@ -39,13 +32,10 @@ program test_scalar_product
   integer :: i
 
   integer :: nrank, nproc
-  integer :: ierr
 
   logical :: test_pass = .true.
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
 
   BC_x = ['periodic', 'periodic']
   BC_y = ['periodic', 'periodic']
@@ -56,26 +46,14 @@ program test_scalar_product
                 [lx, ly, lz], &
                 BC_x, BC_y, BC_z)
 
-#ifdef CUDA
-#else
-  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omp_allocator
-  omp_backend = omp_backend_t(mesh, allocator)
-  backend => omp_backend
-#endif
+  call runtime%init(mesh)
+  backend => runtime%backend
 
   do i = 1, 4
     call runtest(test(i), dir(i))
   end do
 
-  if (nrank == 0) then
-    if (.not. test_pass) then
-      error stop "Test failed"
-    end if
-  end if
-  call MPI_Barrier(MPI_COMM_WORLD, ierr)
-
-  call MPI_Finalize(ierr)
+  call finalise_test(test_pass, nrank)
 
 contains
 
@@ -109,9 +87,7 @@ contains
     else
       check_pass = .true.
     end if
-    call MPI_Allreduce(MPI_IN_PLACE, check_pass, 1, &
-                       MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
-                       ierr)
+    call global_all(check_pass)
     if (nrank == 0) then
       print *, "- Got: ", s
       print *, "- Expected: ", 0
@@ -136,17 +112,13 @@ contains
     call backend%allocator%release_block(c)
 
     expt = n*(nrank + 1)**2
-    call MPI_Allreduce(MPI_IN_PLACE, expt, 1, &
-                       MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD, &
-                       ierr)
+    call global_sum(expt)
     if (s /= real(expt, kind(s))) then
       check_pass = .false.
     else
       check_pass = .true.
     end if
-    call MPI_Allreduce(MPI_IN_PLACE, check_pass, 1, &
-                       MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
-                       ierr)
+    call global_all(check_pass)
     if (nrank == 0) then
       print *, "- Got: ", s
       print *, "- Expected: ", expt

--- a/tests/unit/test_setget_field.f90
+++ b/tests/unit/test_setget_field.f90
@@ -1,52 +1,27 @@
 program test_setget_field
 
-  use mpi
-
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
-  use m_common, only: dp, DIR_C, DIR_X, DIR_Y, DIR_Z, VERT
-#ifdef CUDA
-  use m_cuda_allocator, only: cuda_allocator_t
-  use m_cuda_backend, only: cuda_backend_t
-  use m_cuda_common, only: SZ
-#else
-#ifndef OMP_TGT
-  use m_omp_backend, only: omp_backend_t
-#else
-  use m_omptgt_backend, only: omptgt_backend_t
-  use m_omptgt_allocator, only: omptgt_allocator_t
-#endif
-  use m_omp_common, only: SZ
-#endif
+  use m_backend_runtime, only: backend_runtime_t
+  use m_common, only: dp, DIR_C, DIR_X, VERT
   use m_mesh, only: mesh_t
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
+  type(backend_runtime_t), target :: runtime
   class(allocator_t), pointer :: allocator
   class(base_backend_t), pointer :: backend
-#ifdef CUDA
-  type(cuda_allocator_t), target :: cuda_allocator
-  type(cuda_backend_t), target :: cuda_backend
-#else
-#ifndef OMP_TGT
-  type(allocator_t), target :: omp_allocator
-  type(omp_backend_t), target :: omp_backend
-#else
-  type(omptgt_allocator_t), target :: omptgt_allocator
-  type(omptgt_backend_t), target :: omptgt_backend
-#endif
-#endif
-  type(mesh_t) :: mesh
+  type(mesh_t), target :: mesh
 
   class(field_t), pointer :: fld, fld_c
   real(dp), dimension(:, :, :), allocatable :: arr
   integer, dimension(3) :: shape_c
 
-  integer :: irank
-  integer :: ierr
+  integer :: nrank, nproc
+  logical :: allpass
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
+  call initialise_mpi(nrank, nproc)
 
   print *, "Initialised MPI"
 
@@ -57,24 +32,9 @@ program test_setget_field
 
   print *, "Initialised mesh"
 
-#ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => cuda_allocator
-#else
-#ifndef OMP_TGT
-  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omp_allocator
-
-  omp_backend = omp_backend_t(mesh, allocator)
-  backend => omp_backend
-#else
-  omptgt_allocator = omptgt_allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omptgt_allocator
-
-  omptgt_backend = omptgt_backend_t(mesh, allocator)
-  backend => omptgt_backend
-#endif
-#endif
+  call runtime%init(mesh)
+  allocator => runtime%allocator
+  backend => runtime%backend
 
   print *, "Initialised backend"
 
@@ -91,14 +51,17 @@ program test_setget_field
 
   print *, "Set field data"
 
+  allpass = .true.
   if (fld%data_loc /= VERT) then
-    error stop "Field location was changed by set_field_data"
+    print *, "Field location was changed by set_field_data"
+    allpass = .false.
   end if
 
   arr = 0.0_dp
   call backend%get_field_data(arr, fld)
   if (any(arr /= 1.0_dp)) then
-    error stop "Getting/setting field data failed"
+    print *, "Getting/setting field data failed"
+    allpass = .false.
   end if
 
   print *, "Get field data"
@@ -107,10 +70,6 @@ program test_setget_field
   call backend%allocator%release_block(fld)
   call backend%allocator%release_block(fld_c)
 
-  call MPI_Barrier(MPI_COMM_WORLD, ierr)
-  call MPI_Finalize(ierr)
-  if (irank == 0) then
-    print *, "PASS"
-  end if
+  call finalise_test(allpass, nrank)
 
 end program test_setget_field

--- a/tests/unit/test_snapshot_species_fields.f90
+++ b/tests/unit/test_snapshot_species_fields.f90
@@ -1,7 +1,4 @@
 program test_snapshot_species_fields
-  use iso_fortran_env, only: stderr => error_unit
-  use mpi
-
   use m_allocator, only: allocator_t
   use m_base_backend, only: base_backend_t
   use m_common, only: dp, DIR_X, VERT
@@ -11,6 +8,7 @@ program test_snapshot_species_fields
   use m_omp_backend, only: omp_backend_t
   use m_omp_common, only: SZ
   use m_solver, only: solver_t
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all
 
   implicit none
 
@@ -26,12 +24,11 @@ program test_snapshot_species_fields
   type(field_ptr_t), allocatable :: field_ptrs(:), host_fields(:)
   character(len=32) :: field_names(3)
 
-  integer :: ierr, irank
+  integer :: irank, nproc
   integer :: dims(3)
   logical :: allpass
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
+  call initialise_mpi(irank, nproc)
 
   allpass = .true.
 
@@ -73,15 +70,8 @@ program test_snapshot_species_fields
   call cleanup_field_arrays(solver, field_ptrs, host_fields)
   call release_solver_fields(solver)
 
-  call MPI_Finalize(ierr)
-
-  if (irank == 0) then
-    if (allpass) then
-      write (stderr, '(a)') 'Snapshot species field test passed.'
-    else
-      error stop 'Snapshot species field test failed.'
-    end if
-  end if
+  call global_all(allpass)
+  call finalise_test(allpass, irank)
 
 contains
 

--- a/tests/unit/test_statistics.f90
+++ b/tests/unit/test_statistics.f90
@@ -3,27 +3,27 @@ program test_statistics
 
   use m_common, only: dp
   use m_stats, only: accumulate_mean
-  use mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
-  integer :: ierr
+  integer :: nrank, nproc
+  logical :: allpass = .true.
 
-  call MPI_Init(ierr)
+  call initialise_mpi(nrank, nproc)
 
-  call test_constant_field()
-  call test_known_mean()
-  call test_rms_nonzero()
-  call test_reynolds_stress()
+  call test_constant_field(allpass)
+  call test_known_mean(allpass)
+  call test_rms_nonzero(allpass)
+  call test_reynolds_stress(allpass)
 
-  print *, 'All statistics accumulation tests passed'
-
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 
 contains
 
-  subroutine test_constant_field()
+  subroutine test_constant_field(allpass)
     !! Constant field c=1: umean==1, uprime==0.
+    logical, intent(inout) :: allpass
     real(dp), parameter :: c = 1.0_dp
     integer, parameter :: n_samples = 100
     real(dp) :: umean(1, 1, 1), uumean(1, 1, 1), val(1, 1, 1)
@@ -46,16 +46,17 @@ contains
     if (abs(umean(1, 1, 1) - c) > tol) then
       print *, 'FAIL test_constant_field: umean =', umean(1, 1, 1), &
         'expected', c
-      error stop 'test_constant_field: umean /= constant'
+      allpass = .false.
     end if
     if (abs(uprime) > tol) then
       print *, 'FAIL test_constant_field: uprime =', uprime, 'expected 0'
-      error stop 'test_constant_field: uprime /= 0 for constant field'
+      allpass = .false.
     end if
   end subroutine test_constant_field
 
-  subroutine test_known_mean()
+  subroutine test_known_mean(allpass)
     !! Values 1..N: mean must equal (N+1)/2.
+    logical, intent(inout) :: allpass
     integer, parameter :: n_samples = 50
     real(dp) :: umean(1, 1, 1), val(1, 1, 1)
     real(dp) :: stat_inc, expected
@@ -74,12 +75,13 @@ contains
     if (abs(umean(1, 1, 1) - expected) > tol) then
       print *, 'FAIL test_known_mean: umean =', umean(1, 1, 1), &
         'expected', expected
-      error stop 'test_known_mean: mean /= analytical mean'
+      allpass = .false.
     end if
   end subroutine test_known_mean
 
-  subroutine test_rms_nonzero()
+  subroutine test_rms_nonzero(allpass)
     !! Alternating -1/+1: mean==0, uprime==1.
+    logical, intent(inout) :: allpass
     integer, parameter :: n_samples = 200
     real(dp) :: umean(1, 1, 1), uumean(1, 1, 1), val(1, 1, 1)
     real(dp) :: uprime, stat_inc
@@ -101,17 +103,18 @@ contains
     if (abs(umean(1, 1, 1)) > tol) then
       print *, 'FAIL test_rms_nonzero: umean =', umean(1, 1, 1), &
         'expected 0'
-      error stop 'test_rms_nonzero: mean of alternating series /= 0'
+      allpass = .false.
     end if
     if (abs(uprime - 1.0_dp) > tol) then
       print *, 'FAIL test_rms_nonzero: uprime =', uprime, 'expected 1'
-      error stop 'test_rms_nonzero: rms of alternating series /= 1'
+      allpass = .false.
     end if
   end subroutine test_rms_nonzero
 
-  subroutine test_reynolds_stress()
+  subroutine test_reynolds_stress(allpass)
     !! u=v=1..N: Reynolds stress <u'v'> = <uv> - <u><v> must equal var(u).
     !! u=-v: Reynolds stress must equal -var(u).
+    logical, intent(inout) :: allpass
     integer, parameter :: n_samples = 100
     real(dp) :: umean(1, 1, 1), vmean(1, 1, 1)
     real(dp) :: uumean(1, 1, 1), uvmean(1, 1, 1)
@@ -139,7 +142,7 @@ contains
 
     if (abs(reynolds_stress - uprime2) > tol*abs(uprime2)) then
       print *, 'FAIL test_reynolds_stress: <u''v''> /= var(u) for u==v'
-      error stop 'test_reynolds_stress: correlated case failed'
+      allpass = .false.
     end if
 
     ! Anticorrelated: u = -v
@@ -163,7 +166,7 @@ contains
 
     if (abs(reynolds_stress + uprime2) > tol*abs(uprime2)) then
       print *, 'FAIL test_reynolds_stress: <u''v''> /= -var(u) for u==-v'
-      error stop 'test_reynolds_stress: anticorrelated case failed'
+      allpass = .false.
     end if
   end subroutine test_reynolds_stress
 

--- a/tests/unit/test_sum_intox.f90
+++ b/tests/unit/test_sum_intox.f90
@@ -6,37 +6,25 @@ program test_sum_intox
 
   use m_allocator
   use m_base_backend
-#ifdef CUDA
-  use m_cuda_common, only: SZ
-#else
-  use m_omp_backend
-  use m_omp_common, only: SZ
-#endif
+  use m_backend_runtime, only: backend_runtime_t, backend_sz
+  use m_test_utils, only: initialise_mpi, finalise_test, global_all
 
   implicit none
 
   integer, parameter :: nx = 17, ny = 32, nz = 59
   real(dp), parameter :: lx = 1.618, ly = 3.141529, lz = 1.729
 
+  type(backend_runtime_t), target :: runtime
   class(base_backend_t), pointer :: backend
-  class(allocator_t), pointer :: allocator
-#ifdef CUDA
-#else
-  type(omp_backend_t), target :: omp_backend
-  type(allocator_t), target :: omp_allocator
-#endif
 
-  type(mesh_t) :: mesh
+  type(mesh_t), target :: mesh
 
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
   integer :: nrank, nproc
-  integer :: ierr
 
   logical :: test_pass = .true.
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
 
   BC_x = ['periodic', 'periodic']
   BC_y = ['periodic', 'periodic']
@@ -47,24 +35,13 @@ program test_sum_intox
                 [lx, ly, lz], &
                 BC_x, BC_y, BC_z)
 
-#ifdef CUDA
-#else
-  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omp_allocator
-  omp_backend = omp_backend_t(mesh, allocator)
-  backend => omp_backend
-#endif
+  call runtime%init(mesh)
+  backend => runtime%backend
 
   call runtest("YintoX", DIR_Y)
   call runtest("ZintoX", DIR_Z)
 
-  if (nrank == 0) then
-    if (.not. test_pass) then
-      error stop "Test failed"
-    end if
-  end if
-
-  call MPI_Finalize(ierr)
+  call finalise_test(test_pass, nrank)
 
 contains
 
@@ -97,10 +74,10 @@ contains
     do k = 1, dims(3)
       do j = 1, dims(2)
         do i = 1, dims(1)
-          call get_index_dir(ii, jj, kk, i, j, k, DIR_X, SZ, &
+          call get_index_dir(ii, jj, kk, i, j, k, DIR_X, backend_sz, &
                              dims(1), dims(2), dims(3))
           a%data(ii, jj, kk) = ctr
-          call get_index_dir(ii, jj, kk, i, j, k, dir_from, SZ, &
+          call get_index_dir(ii, jj, kk, i, j, k, dir_from, backend_sz, &
                              dims(1), dims(2), dims(3))
           b%data(ii, jj, kk) = -ctr
           ctr = ctr + 1
@@ -115,9 +92,7 @@ contains
     end if
 
     check_pass = .not. ((minval(a%data) /= 0) .or. (maxval(a%data) /= 0))
-    call MPI_Allreduce(MPI_IN_PLACE, check_pass, 1, &
-                       MPI_LOGICAL, MPI_LAND, MPI_COMM_WORLD, &
-                       ierr)
+    call global_all(check_pass)
     test_pass = test_pass .and. check_pass
 
     if (nrank == 0) then

--- a/tests/unit/test_vecadd.f90
+++ b/tests/unit/test_vecadd.f90
@@ -4,25 +4,12 @@
 
 program test_vecadd
 
-  use MPI
-
-  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z, DIR_C, VERT
+  use m_common, only: dp, DIR_X, DIR_Y, DIR_Z
   use m_mesh, only: mesh_t
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
-#ifdef CUDA
-  use m_cuda_common, only: SZ
-  use m_cuda_allocator, only: cuda_allocator_t
-  use m_cuda_backend, only: cuda_backend_t
-#else
-  use m_omp_common, only: SZ
-#ifndef OMP_TGT
-  use m_omp_backend, only: omp_backend_t
-#else
-  use m_omptgt_backend, only: omptgt_backend_t
-  use m_omptgt_allocator, only: omptgt_allocator_t
-#endif
-#endif
+  use m_backend_runtime, only: backend_runtime_t
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -30,23 +17,11 @@ program test_vecadd
   character(len=5), dimension(3), parameter :: dirnames = &
                                                ["DIR_X", "DIR_Y", "DIR_Z"]
 
-  class(mesh_t), allocatable :: mesh
+  type(mesh_t), target :: mesh
+  type(backend_runtime_t), target :: runtime
   class(allocator_t), pointer :: allocator => null()
+  type(allocator_t), pointer :: host_allocator => null()
   class(base_backend_t), pointer :: backend => null()
-#ifdef CUDA
-  type(cuda_allocator_t), target :: cuda_allocator
-  type(allocator_t), target :: host_allocator
-  type(cuda_backend_t), target :: cuda_backend
-#else
-  type(allocator_t), target :: omp_allocator
-  type(allocator_t), pointer :: host_allocator
-#ifndef OMP_TGT
-  type(omp_backend_t), target :: omp_backend
-#else
-  type(omptgt_allocator_t), target :: omptgt_allocator
-  type(omptgt_backend_t), target :: omptgt_backend
-#endif
-#endif
   class(field_t), pointer :: a => null()
   class(field_t), pointer :: b => null()
   class(field_t), pointer :: c => null()
@@ -57,12 +32,12 @@ program test_vecadd
   real(dp), dimension(3) :: L_global
   character(len=8), dimension(2) :: BC_x, BC_y, BC_z
 
-  integer :: ierr
+  integer :: nrank, nproc
 
   logical :: test_pass
   integer :: d
 
-  call MPI_Init(ierr)
+  call initialise_mpi(nrank, nproc)
 
   dims_global = [32, 32, 32]
   L_global = [1.0, 1.0, 1.0]
@@ -93,15 +68,18 @@ program test_vecadd
   call allocator%release_block(c)
   call allocator%release_block(z)
 
-  if (test_pass) then
-    print *, "PASS"
-  else
-    error stop "FAIL"
-  end if
-
-  call MPI_Finalize(ierr)
+  call finalise_test(test_pass, nrank)
 
 contains
+
+  subroutine initialise_test()
+
+    call runtime%init(mesh)
+    allocator => runtime%allocator
+    host_allocator => runtime%host_allocator
+    backend => runtime%backend
+
+  end subroutine initialise_test
 
   subroutine test_add_zero(d)
 
@@ -230,32 +208,6 @@ contains
 
   end subroutine
 
-  subroutine initialise_test()
-
-#ifdef CUDA
-    cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
-    allocator => cuda_allocator
-    host_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-
-    cuda_backend = cuda_backend_t(mesh, allocator)
-    backend => cuda_backend
-#else
-    omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-#ifdef OMP_TGT
-    omptgt_allocator = omptgt_allocator_t(mesh%get_dims(VERT), SZ)
-    allocator => omptgt_allocator
-    omptgt_backend = omptgt_backend_t(mesh, allocator)
-    backend => omptgt_backend
-#else
-    allocator => omp_allocator
-    omp_backend = omp_backend_t(mesh, allocator)
-    backend => omp_backend
-#endif
-    host_allocator => omp_allocator
-#endif
-
-  end subroutine
-
   subroutine initialise_data(a, b, c, z, d)
 
     integer, intent(in) :: d
@@ -306,4 +258,3 @@ contains
   end subroutine initialise_data
 
 end program test_vecadd
-

--- a/tests/verification/test_cuda_penta.f90
+++ b/tests/verification/test_cuda_penta.f90
@@ -25,7 +25,7 @@ program test_cuda_penta
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_penta_compact, exec_dist_penta_periodic
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -39,7 +39,7 @@ program test_cuda_penta
   call run_neumann_sym_true()
   call run_neumann_sym_false()
   call run_periodic_test()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -447,14 +447,5 @@ contains
     converged_tol = max(1e-12_dp, &
                         20._dp*epsilon(1._dp)*real(n_glob, dp))
   end function converged_tol
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program test_cuda_penta

--- a/tests/verification/test_cuda_penta.f90
+++ b/tests/verification/test_cuda_penta.f90
@@ -25,16 +25,17 @@ program test_cuda_penta
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_penta_compact, exec_dist_penta_periodic
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
+  use m_backend_runtime, only: select_cuda_device
   use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
   logical :: allpass = .true.
-  integer :: nrank, nproc, ierr, ndevs, devnum
+  integer :: nrank, nproc, ierr
 
   call initialise_mpi(nrank, nproc)
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-  call select_device()
+  call select_cuda_device(nrank)
   call run_dirichlet_test()
   call run_neumann_sym_true()
   call run_neumann_sym_false()
@@ -42,13 +43,6 @@ program test_cuda_penta
   call finalise_test(allpass, nrank)
 
 contains
-
-
-  subroutine select_device()
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs))
-    ierr = cudaGetDevice(devnum)
-  end subroutine select_device
 
   ! ─────────────────────────────────────────────────────────────────────────────
   ! BC_DIRICHLET: f = sin(pi*x), f' = pi*cos(pi*x).

--- a/tests/verification/test_cuda_penta.f90
+++ b/tests/verification/test_cuda_penta.f90
@@ -25,13 +25,15 @@ program test_cuda_penta
   use m_cuda_common, only: SZ
   use m_cuda_exec_dist, only: exec_dist_penta_compact, exec_dist_penta_periodic
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
   logical :: allpass = .true.
   integer :: nrank, nproc, ierr, ndevs, devnum
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call select_device()
   call run_dirichlet_test()
   call run_neumann_sym_true()
@@ -41,12 +43,6 @@ program test_cuda_penta
 
 contains
 
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-  end subroutine initialise_mpi
 
   subroutine select_device()
     ierr = cudaGetDeviceCount(ndevs)

--- a/tests/verification/test_cuda_transeq.f90
+++ b/tests/verification/test_cuda_transeq.f90
@@ -8,6 +8,7 @@ program test_cuda_transeq
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
@@ -41,7 +42,8 @@ program test_cuda_transeq
 #endif
   real(dp) :: dx_per, nu, norm_du
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call select_device()
   call setup_geometry()
   call allocate_fields()
@@ -53,17 +55,6 @@ program test_cuda_transeq
 
 contains
 
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-
-    !print*, 'I am rank', nrank, 'I am running on device', devnum
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine select_device()
     ierr = cudaGetDeviceCount(ndevs)

--- a/tests/verification/test_cuda_transeq.f90
+++ b/tests/verification/test_cuda_transeq.f90
@@ -8,7 +8,7 @@ program test_cuda_transeq
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -51,7 +51,7 @@ program test_cuda_transeq
   call setup_backend()
   call run_kernel()
   call check_result()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -180,15 +180,5 @@ contains
     end if
 
   end subroutine check_result
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program test_cuda_transeq

--- a/tests/verification/test_cuda_transeq.f90
+++ b/tests/verification/test_cuda_transeq.f90
@@ -8,6 +8,7 @@ program test_cuda_transeq
   use m_cuda_exec_dist, only: exec_dist_transeq_3fused
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t
+  use m_backend_runtime, only: select_cuda_device
   use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
@@ -30,7 +31,7 @@ program test_cuda_transeq
 
   integer :: n, n_block, n_halo, n_glob
   integer :: nrank, nproc, pprev, pnext
-  integer :: ierr, ndevs, devnum
+  integer :: ierr
 
   type(dim3) :: blocks, threads
   ! The diffusion term's roundoff floor is ~eps/dx^2: at n=512 this is
@@ -44,7 +45,7 @@ program test_cuda_transeq
 
   call initialise_mpi(nrank, nproc, pprev, pnext)
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-  call select_device()
+  call select_cuda_device(nrank)
   call setup_geometry()
   call allocate_fields()
   call initialise_input()
@@ -54,13 +55,6 @@ program test_cuda_transeq
   call finalise_test(allpass, nrank)
 
 contains
-
-
-  subroutine select_device()
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs)) ! round-robine
-    ierr = cudaGetDevice(devnum)
-  end subroutine select_device
 
   subroutine setup_geometry()
     n_glob = 512

--- a/tests/verification/test_cuda_tridiag.f90
+++ b/tests/verification/test_cuda_tridiag.f90
@@ -8,6 +8,7 @@ program test_cuda_tridiag
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
+  use m_backend_runtime, only: select_cuda_device
   use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
@@ -25,7 +26,7 @@ program test_cuda_tridiag
 
   integer :: n, n_block, n_halo, n_glob
   integer :: nrank, nproc, pprev, pnext
-  integer :: ierr, ndevs, devnum
+  integer :: ierr
 
   type(dim3) :: blocks, threads
   ! The second-derivative roundoff floor is ~eps/dx^2: at n=1024 this is
@@ -40,7 +41,7 @@ program test_cuda_tridiag
 
   call initialise_mpi(nrank, nproc, pprev, pnext)
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-  call select_device()
+  call select_cuda_device(nrank)
   call setup_geometry()
   call allocate_fields()
   call initialise_input()
@@ -50,13 +51,6 @@ program test_cuda_tridiag
   call finalise_test(allpass, nrank)
 
 contains
-
-
-  subroutine select_device()
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs)) ! round-robin
-    ierr = cudaGetDevice(devnum)
-  end subroutine select_device
 
   subroutine setup_geometry()
     n_glob = 512*2

--- a/tests/verification/test_cuda_tridiag.f90
+++ b/tests/verification/test_cuda_tridiag.f90
@@ -8,6 +8,7 @@ program test_cuda_tridiag
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
@@ -37,7 +38,8 @@ program test_cuda_tridiag
 #endif
   real(dp) :: dx_per, norm_du
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call select_device()
   call setup_geometry()
   call allocate_fields()
@@ -49,16 +51,6 @@ program test_cuda_tridiag
 
 contains
 
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine select_device()
     ierr = cudaGetDeviceCount(ndevs)

--- a/tests/verification/test_cuda_tridiag.f90
+++ b/tests/verification/test_cuda_tridiag.f90
@@ -8,7 +8,7 @@ program test_cuda_tridiag
   use m_cuda_exec_dist, only: exec_dist_tds_compact
   use m_cuda_sendrecv, only: sendrecv_fields
   use m_cuda_tdsops, only: cuda_tdsops_t, cuda_tdsops_init
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -47,7 +47,7 @@ program test_cuda_tridiag
   call setup_backend()
   call run_kernel()
   call check_result()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -136,15 +136,5 @@ contains
     end if
 
   end subroutine check_result
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program test_cuda_tridiag

--- a/tests/verification/test_fft.f90
+++ b/tests/verification/test_fft.f90
@@ -1,29 +1,17 @@
 program test_fft
-  use iso_fortran_env, only: stderr => error_unit
   use mpi
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
+  use m_backend_runtime, only: backend_runtime_t, backend_is_cuda
   use m_tdsops, only: dirps_t
   use m_solver, only: allocate_tdsops
 
   use m_common, only: dp, pi, MPI_X3D2_DP, &
-                      RDR_X2Y, RDR_X2Z, RDR_Y2X, RDR_Y2Z, RDR_Z2X, RDR_Z2Y, &
-                      DIR_X, DIR_Y, DIR_Z, DIR_C, VERT, CELL
+                      DIR_X, DIR_Y, DIR_Z, DIR_C, CELL
 
-  use m_ordering, only: get_index_dir, get_index_ijk
   use m_mesh, only: mesh_t
-
-#ifdef CUDA
-  use cudafor
-
-  use m_cuda_allocator, only: cuda_allocator_t, cuda_field_t
-  use m_cuda_backend, only: cuda_backend_t
-  use m_cuda_common, only: SZ
-#else
-  use m_omp_common, only: SZ
-  use m_omp_backend, only: omp_backend_t
-#endif
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -34,10 +22,9 @@ program test_fft
   integer :: nrank, nproc
   integer :: ierr, i, j, k
 
-  real(dp) :: dx, dx_per
-
+  type(backend_runtime_t), target :: runtime
   class(base_backend_t), pointer :: backend
-  class(mesh_t), allocatable :: mesh
+  type(mesh_t), target :: mesh
   class(allocator_t), pointer :: allocator
   type(dirps_t), pointer :: xdirps, ydirps, zdirps
   integer, dimension(3) :: dims_padded, dims_global, nproc_dir
@@ -47,39 +34,18 @@ program test_fft
   real(dp) :: error_norm
   real(dp), dimension(3) :: xloc
 #ifdef SINGLE_PREC
-#ifdef CUDA
-  real(dp), parameter :: tol = 1e-06
+  real(dp), parameter :: tol = merge(1e-6_dp, 1e-5_dp, backend_is_cuda)
 #else
-  real(dp), parameter :: tol = 1e-05
-#endif
-#else
-  real(dp), parameter :: tol = 1e-10
+  real(dp), parameter :: tol = 1e-10_dp
 #endif
   logical :: use_2decomp
+  logical :: allpass
   real(dp), allocatable, dimension(:, :, :) :: input_data, output_data
 
-#ifdef CUDA
-  type(cuda_backend_t), target :: cuda_backend
-  type(cuda_allocator_t), target :: cuda_allocator
-  integer :: ndevs, devnum
-#else
-  type(omp_backend_t), target :: omp_backend
-  type(allocator_t), target :: omp_allocator
-#endif
-
   ! Initialise variables and arrays
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
 
-#ifdef CUDA
-  ierr = cudaGetDeviceCount(ndevs)
-  ierr = cudaSetDevice(mod(nrank, ndevs)) ! round-robin
-  ierr = cudaGetDevice(devnum)
-  use_2decomp = .false.
-#else
-  use_2decomp = .true.
-#endif
+  use_2decomp = .not. backend_is_cuda
 
   ! Global number of cells in each direction
   dims_global = [64, 32, 128]
@@ -98,21 +64,9 @@ program test_fft
                 BC_x, BC_y, BC_z, &
                 use_2decomp=use_2decomp)
 
-#ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => cuda_allocator
-  print *, 'CUDA allocator instantiated'
-
-  cuda_backend = cuda_backend_t(mesh, allocator)
-  backend => cuda_backend
-  print *, 'CUDA backend instantiated'
-#else
-  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omp_allocator
-
-  omp_backend = omp_backend_t(mesh, allocator)
-  backend => omp_backend
-#endif
+  call runtime%init(mesh)
+  allocator => runtime%allocator
+  backend => runtime%backend
 
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
 
@@ -168,17 +122,19 @@ program test_fft
                      MPI_COMM_WORLD, ierr)
   error_norm = sqrt(error_norm)
 
-  if (error_norm > tol) then
+  allpass = (error_norm <= tol)
+  if (.not. allpass) then
     if (mesh%par%is_root()) then
       print *, "error in FFT result, error norm=", error_norm
     end if
-    error stop 'TEST FAILED.'
   else
     if (mesh%par%is_root()) then
       print *, "TEST PASS"
     end if
   end if
 
-  call MPI_Finalize(ierr)
+  call allocator%release_block(input_field)
+  call allocator%release_block(output_field)
+  call finalise_test(allpass, nrank)
 
 end program test_fft

--- a/tests/verification/test_fft.f90
+++ b/tests/verification/test_fft.f90
@@ -127,10 +127,6 @@ program test_fft
     if (mesh%par%is_root()) then
       print *, "error in FFT result, error norm=", error_norm
     end if
-  else
-    if (mesh%par%is_root()) then
-      print *, "TEST PASS"
-    end if
   end if
 
   call allocator%release_block(input_field)

--- a/tests/verification/test_omp_dist_transeq.f90
+++ b/tests/verification/test_omp_dist_transeq.f90
@@ -7,6 +7,7 @@ program test_transeq
   use m_omp_exec_dist, only: exec_dist_transeq_compact
   use m_omp_sendrecv, only: sendrecv_fields
   use m_tdsops, only: tdsops_t
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
@@ -37,7 +38,8 @@ program test_transeq
   real(dp) :: tol = 1d-8
 #endif
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call setup_geometry()
   call allocate_fields()
   call initialise_input()
@@ -48,16 +50,6 @@ program test_transeq
 
 contains
 
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine setup_geometry()
     n_glob = 32*4

--- a/tests/verification/test_omp_dist_transeq.f90
+++ b/tests/verification/test_omp_dist_transeq.f90
@@ -7,7 +7,7 @@ program test_transeq
   use m_omp_exec_dist, only: exec_dist_transeq_compact
   use m_omp_sendrecv, only: sendrecv_fields
   use m_tdsops, only: tdsops_t
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -46,7 +46,7 @@ program test_transeq
   call setup_tdsops()
   call run_kernel()
   call check_result()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -155,15 +155,5 @@ contains
     end if
 
   end subroutine check_result
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program test_transeq

--- a/tests/verification/test_omp_penta.f90
+++ b/tests/verification/test_omp_penta.f90
@@ -18,16 +18,14 @@ program test_omp_penta
   use m_omp_common, only: SZ
   use m_omp_exec_dist, only: exec_dist_penta_compact, exec_dist_penta_periodic
   use m_tdsops, only: tdsops_t, tdsops_init
-  use m_test_utils, only: finalise_test
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
   logical :: allpass = .true.
   integer :: nrank, nproc, ierr
 
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
 
   call run_dirichlet_test()

--- a/tests/verification/test_omp_penta.f90
+++ b/tests/verification/test_omp_penta.f90
@@ -18,6 +18,7 @@ program test_omp_penta
   use m_omp_common, only: SZ
   use m_omp_exec_dist, only: exec_dist_penta_compact, exec_dist_penta_periodic
   use m_tdsops, only: tdsops_t, tdsops_init
+  use m_test_utils, only: finalise_test
 
   implicit none
 
@@ -34,12 +35,7 @@ program test_omp_penta
   call run_neumann_sym_false()
   call run_periodic_test()
 
-  if (allpass) then
-    if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 
 contains
 

--- a/tests/verification/test_omp_transeq.f90
+++ b/tests/verification/test_omp_transeq.f90
@@ -9,6 +9,7 @@ program test_omp_transeq
   use m_tdsops, only: dirps_t
   use m_solver, only: allocate_tdsops
   use m_mesh, only: mesh_t
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
@@ -38,7 +39,8 @@ program test_omp_transeq
   type(allocator_t), target :: omp_allocator
   type(dirps_t) :: xdirps, ydirps, zdirps
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call setup_mesh()
   call setup_backend()
   call initialise_input()
@@ -48,14 +50,6 @@ program test_omp_transeq
 
 contains
 
-  subroutine initialise_mpi()
-    ! Initialise variables and arrays
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-  end subroutine initialise_mpi
 
   subroutine setup_mesh()
     integer, dimension(3) :: nproc_dir

--- a/tests/verification/test_omp_transeq.f90
+++ b/tests/verification/test_omp_transeq.f90
@@ -9,7 +9,7 @@ program test_omp_transeq
   use m_tdsops, only: dirps_t
   use m_solver, only: allocate_tdsops
   use m_mesh, only: mesh_t
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -46,7 +46,7 @@ program test_omp_transeq
   call initialise_input()
   call run_kernel()
   call check_result()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -143,15 +143,5 @@ contains
     end if
 
   end subroutine check_result
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program test_omp_transeq

--- a/tests/verification/test_omp_transeq_species.f90
+++ b/tests/verification/test_omp_transeq_species.f90
@@ -9,7 +9,7 @@ program test_omp_transeq_species
   use m_tdsops, only: dirps_t
   use m_solver, only: allocate_tdsops
   use m_mesh, only: mesh_t
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -46,7 +46,7 @@ program test_omp_transeq_species
   call initialise_input()
   call run_kernel()
   call check_result()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -146,15 +146,5 @@ contains
     end if
 
   end subroutine check_result
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
 end program test_omp_transeq_species

--- a/tests/verification/test_omp_transeq_species.f90
+++ b/tests/verification/test_omp_transeq_species.f90
@@ -9,6 +9,7 @@ program test_omp_transeq_species
   use m_tdsops, only: dirps_t
   use m_solver, only: allocate_tdsops
   use m_mesh, only: mesh_t
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
@@ -38,7 +39,8 @@ program test_omp_transeq_species
   type(allocator_t), target :: omp_allocator
   type(dirps_t) :: xdirps, ydirps, zdirps
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call setup_mesh()
   call setup_backend()
   call initialise_input()
@@ -48,14 +50,6 @@ program test_omp_transeq_species
 
 contains
 
-  subroutine initialise_mpi()
-    ! Initialise variables and arrays
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-  end subroutine initialise_mpi
 
   subroutine setup_mesh()
     integer, dimension(3) :: nproc_dir

--- a/tests/verification/test_omp_tridiag.f90
+++ b/tests/verification/test_omp_tridiag.f90
@@ -8,7 +8,7 @@ program test_omp_tridiag
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_exec_dist, only: exec_dist_tds_compact
   use m_tdsops, only: tdsops_t, tdsops_init
-  use m_test_utils, only: initialise_mpi
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -52,7 +52,7 @@ program test_omp_tridiag
   call allocate_fields()
   call initialise_input()
   call run_all_cases()
-  call finalise()
+  call finalise_test(allpass, nrank)
 
 contains
 
@@ -348,16 +348,6 @@ contains
       end if
     end if
   end subroutine run_all_cases
-
-  subroutine finalise()
-    if (allpass) then
-      if (nrank == 0) write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    else
-      error stop 'SOME TESTS FAILED.'
-    end if
-
-    call MPI_Finalize(ierr)
-  end subroutine finalise
 
   subroutine run_kernel(n_iters, n_groups, u, du, tdsops, n, &
                         u_recv_s, u_recv_e, u_send_s, u_send_e, &

--- a/tests/verification/test_omp_tridiag.f90
+++ b/tests/verification/test_omp_tridiag.f90
@@ -8,6 +8,7 @@ program test_omp_tridiag
   use m_omp_sendrecv, only: sendrecv_fields
   use m_omp_exec_dist, only: exec_dist_tds_compact
   use m_tdsops, only: tdsops_t, tdsops_init
+  use m_test_utils, only: initialise_mpi
 
   implicit none
 
@@ -45,7 +46,8 @@ program test_omp_tridiag
   real(dp) :: tol = 1d-8, tol_2nd = 1d-8, tol_hyper = 1d-8
 #endif
 
-  call initialise_mpi()
+  call initialise_mpi(nrank, nproc, pprev, pnext)
+  if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
   call setup_geometry()
   call allocate_fields()
   call initialise_input()
@@ -54,16 +56,6 @@ program test_omp_tridiag
 
 contains
 
-  subroutine initialise_mpi()
-    call MPI_Init(ierr)
-    call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-    call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-    if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-
-    pnext = modulo(nrank - nproc + 1, nproc)
-    pprev = modulo(nrank - 1, nproc)
-  end subroutine initialise_mpi
 
   subroutine setup_geometry()
     n_glob = 1024

--- a/tests/verification/test_poisson_bc.f90
+++ b/tests/verification/test_poisson_bc.f90
@@ -33,6 +33,7 @@ program test_poisson
   use m_solver, only: allocate_tdsops
   use m_tdsops, only: dirps_t
   use m_vector_calculus, only: vector_calculus_t
+  use m_test_utils, only: finalise_test
 
 #ifdef CUDA
   use cudafor
@@ -206,15 +207,7 @@ program test_poisson
     end do
   end do
 
-  if (allpass) then
-    if (nrank == 0) then
-      write (stderr, '(A)') 'ALL TESTS PASSED SUCCESSFULLY.'
-    end if
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
-
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass, nrank)
 
 contains
 

--- a/tests/verification/test_poisson_bc.f90
+++ b/tests/verification/test_poisson_bc.f90
@@ -23,28 +23,17 @@ program test_poisson
   !! NOTE: Dirichlet directions require odd dims_global (e.g. 65)
 
   use iso_fortran_env, only: stderr => error_unit
-  use mpi
 
   use m_allocator, only: allocator_t, field_t
   use m_base_backend, only: base_backend_t
-  use m_common, only: dp, pi, DIR_C, DIR_X, DIR_Y, DIR_Z, VERT, CELL, &
+  use m_backend_runtime, only: backend_runtime_t, backend_is_cuda
+  use m_common, only: dp, pi, DIR_C, DIR_X, DIR_Y, DIR_Z, CELL, &
                       RDR_C2Z, RDR_C2X, RDR_Z2X
   use m_mesh, only: mesh_t
   use m_solver, only: allocate_tdsops
   use m_tdsops, only: dirps_t
   use m_vector_calculus, only: vector_calculus_t
-  use m_test_utils, only: finalise_test
-
-#ifdef CUDA
-  use cudafor
-
-  use m_cuda_allocator, only: cuda_allocator_t
-  use m_cuda_backend, only: cuda_backend_t
-  use m_cuda_common, only: SZ
-#else
-  use m_omp_backend, only: omp_backend_t
-  use m_omp_common, only: SZ
-#endif
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
@@ -70,13 +59,12 @@ program test_poisson
   real(dp), parameter :: ERROR_TOLERANCE = 1.0e-11_dp
 #endif
 
-  integer :: nrank, nproc, ierr
+  integer :: nrank, nproc
   integer :: ic, idx, iarg
   character(len=32) :: arg
   character(len=3) :: only_config
   logical :: config_run(NUM_CONFIGS)
   logical :: allpass
-  character(32) :: backend_name
 
   ! Per-config results for final summary
   logical :: all_results(NUM_TESTS, NUM_CONFIGS)
@@ -90,23 +78,9 @@ program test_poisson
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
   ! Initialise MPI
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
+  call initialise_mpi(nrank, nproc)
 
   if (nrank == 0) print *, 'Parallel run with', nproc, 'ranks'
-
-#ifdef CUDA
-  block
-    integer :: ndevs, devnum
-    ierr = cudaGetDeviceCount(ndevs)
-    ierr = cudaSetDevice(mod(nrank, ndevs))
-    ierr = cudaGetDevice(devnum)
-  end block
-  backend_name = "CUDA"
-#else
-  backend_name = "OMP"
-#endif
 
   config_labels = ['000', '010', '100', '110']
 
@@ -221,20 +195,12 @@ contains
     integer, intent(in) :: dims_global(3)
     character(len=*), intent(in) :: BC_x(2), BC_y(2), BC_z(2)
 
+    type(backend_runtime_t), target :: runtime
     class(base_backend_t), pointer :: backend
-    class(allocator_t), pointer :: allocator
     type(allocator_t), pointer :: host_allocator
     type(mesh_t), target :: mesh
     type(dirps_t), pointer :: xdirps, ydirps, zdirps
     type(vector_calculus_t) :: vector_calculus
-
-#ifdef CUDA
-    type(cuda_backend_t), target :: cuda_backend
-    type(cuda_allocator_t), target :: cuda_allocator
-#else
-    type(omp_backend_t), target :: omp_backend
-#endif
-    type(allocator_t), target :: omp_allocator
 
     integer :: nproc_dir(3)
     real(dp) :: L_global(3)
@@ -262,33 +228,15 @@ contains
     L_global = [1.0_dp, 1.0_dp, 1.0_dp]
 
     ! Decide whether 2decomp is used
-#ifdef CUDA
-    use_2decomp = .false.
-#else
-    use_2decomp = .true.
-#endif
+    use_2decomp = .not. backend_is_cuda
 
     mesh = mesh_t(dims_global, nproc_dir, L_global, &
                   BC_x, BC_y, BC_z, &
                   use_2decomp=use_2decomp)
 
-#ifdef CUDA
-    cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
-    allocator => cuda_allocator
-
-    omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-    host_allocator => omp_allocator
-
-    cuda_backend = cuda_backend_t(mesh, allocator)
-    backend => cuda_backend
-#else
-    omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-    allocator => omp_allocator
-    host_allocator => omp_allocator
-
-    omp_backend = omp_backend_t(mesh, allocator)
-    backend => omp_backend
-#endif
+    call runtime%init(mesh)
+    backend => runtime%backend
+    host_allocator => runtime%host_allocator
 
     ! Setup tdsops directly (like test_fft.f90)
     allocate (xdirps, ydirps, zdirps)

--- a/tests/verification/test_thom.f90
+++ b/tests/verification/test_thom.f90
@@ -1,19 +1,12 @@
 program test_thom
+  use m_allocator, only: allocator_t, field_t
+  use m_backend_runtime, only: backend_runtime_t, backend_is_cuda, backend_sz
+  use m_base_backend, only: base_backend_t
+  use m_common, only: dp, pi, BC_PERIODIC, BC_DIRICHLET, DIR_X, VERT
+  use m_mesh, only: mesh_t
+  use m_tdsops, only: tdsops_t
+  use m_test_utils, only: initialise_mpi, finalise_test, checkerr
 
-#ifdef CUDA
-  use cudafor
-#endif
-  use m_common, only: dp, pi, BC_PERIODIC, BC_DIRICHLET
-#ifdef CUDA
-  use m_cuda_common, only: SZ
-  use m_cuda_exec_thom, only: exec_thom_tds_compact
-  use m_cuda_tdsops, only: tdsops_t => cuda_tdsops_t, tdsops_init => cuda_tdsops_init
-#else
-  use m_omp_common, only: SZ
-  use m_tdsops, only: tdsops_t, tdsops_init
-  use m_exec_thom, only: exec_thom_tds_compact
-#endif
-  use m_test_utils, only: checkerr, finalise_test
   implicit none
 
   ! The second-derivative roundoff floor is ~eps/dx^2: at n=1024 this is
@@ -24,111 +17,102 @@ program test_thom
 #else
   real(dp), parameter :: residual_tol = 1.0e-8_dp
 #endif
+
   logical :: allpass = .true.
+  integer :: n_glob, n_groups
+  integer :: nrank, nproc
 
-#ifdef CUDA
-  type(dim3) :: blocks, threads
-#endif
-  integer :: i, j, k
-  integer :: n_glob, n, n_groups
+  type(backend_runtime_t), target :: runtime
+  type(mesh_t), target :: mesh
+  class(base_backend_t), pointer :: backend
+  class(allocator_t), pointer :: allocator
+  class(tdsops_t), allocatable :: periodic_tdsops, dirichlet_tdsops
 
-  real(dp), allocatable, dimension(:, :, :) :: u, du
-#ifdef CUDA
-  real(dp), device, allocatable, dimension(:, :, :) :: u_dev, du_dev
-#endif
-  real(dp) :: dx, dx_per
+  call initialise_mpi(nrank, nproc)
 
-  type(tdsops_t) :: tdsops
-
-#ifdef CUDA
   n_glob = 1024
-  n_groups = 128*128/SZ
-#else
-  n_glob = 1024
-  n_groups = 64*64/SZ
-#endif
-  n = n_glob
+  if (backend_is_cuda) then
+    n_groups = 128*128/backend_sz
+  else
+    n_groups = 64*64/backend_sz
+  end if
 
-  allocate (u(SZ, n, n_groups), du(SZ, n, n_groups))
-#ifdef CUDA
-  allocate (u_dev(SZ, n, n_groups), du_dev(SZ, n, n_groups))
-#endif
+  mesh = build_mesh(n_glob, n_groups)
 
-  dx_per = 2*pi/n_glob
-  dx = 2*pi/(n_glob - 1)
+  call runtime%init(mesh)
+  backend => runtime%backend
+  allocator => runtime%allocator
 
-  !! Periodic case
-  print *, "=== Testing periodic case ==="
+  call backend%alloc_tdsops(periodic_tdsops, n_glob, 2*pi/n_glob, &
+                            operation='second-deriv', scheme='compact6', &
+                            bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
+  call backend%alloc_tdsops(dirichlet_tdsops, n_glob, 2*pi/(n_glob - 1), &
+                            operation='second-deriv', scheme='compact6', &
+                            bc_start=BC_DIRICHLET, bc_end=BC_DIRICHLET)
 
-  do k = 1, n_groups
-    do j = 1, n
-      do i = 1, SZ
-        u(i, j, k) = sin((j - 1)*dx_per)
+  if (nrank == 0) then
+    print *, trim(runtime%backend_name), 'allocator instantiated'
+    print *, trim(runtime%backend_name), 'backend instantiated'
+  end if
+
+  call run_case('=== Testing periodic case ===', 2*pi/n_glob, &
+                periodic_tdsops, 'thom_periodic')
+  call run_case('=== Testing Dirichlet case ===', 2*pi/(n_glob - 1), &
+                dirichlet_tdsops, 'thom_dirichlet')
+
+  call finalise_test(allpass, nrank)
+
+contains
+
+  function build_mesh(nx, nz) result(mesh_out)
+    integer, intent(in) :: nx, nz
+    type(mesh_t) :: mesh_out
+
+    character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
+
+    BC_x = ['periodic', 'periodic']
+    BC_y = ['periodic', 'periodic']
+    BC_z = ['periodic', 'periodic']
+
+    mesh_out = mesh_t([nx, backend_sz, nz], [1, 1, 1], &
+                      [2*pi, 1.0_dp, 1.0_dp], &
+                      BC_x, BC_y, BC_z)
+  end function build_mesh
+
+  subroutine run_case(banner, delta, tdsops, label)
+    character(len=*), intent(in) :: banner, label
+    real(dp), intent(in) :: delta
+    class(tdsops_t), intent(in) :: tdsops
+
+    class(field_t), pointer :: u_field, du_field
+    real(dp), allocatable :: u_data(:, :, :), du_data(:, :, :)
+    integer :: i, j, k
+
+    if (nrank == 0) print *, banner
+
+    allocate (u_data(backend_sz, n_glob, n_groups))
+    allocate (du_data(backend_sz, n_glob, n_groups))
+
+    do k = 1, n_groups
+      do j = 1, n_glob
+        do i = 1, backend_sz
+          u_data(i, j, k) = sin((j - 1)*delta)
+        end do
       end do
     end do
-  end do
 
-#ifdef CUDA
-  ! move data to device
-  u_dev = u
-#endif
+    u_field => allocator%get_block(DIR_X, VERT)
+    du_field => allocator%get_block(DIR_X, VERT)
+    call backend%set_field_data(u_field, u_data, DIR_X)
 
-  ! preprocess the operator and coefficient arrays
-  tdsops = tdsops_init(n, dx_per, &
-                       operation="second-deriv", scheme="compact6", &
-                       bc_start=BC_PERIODIC, bc_end=BC_PERIODIC)
+    call backend%thom_solve(du_field, u_field, tdsops)
+    call backend%get_field_data(du_data, du_field, DIR_X)
 
-#ifdef CUDA
-  blocks = dim3(n_groups, 1, 1)
-  threads = dim3(SZ, 1, 1)
-#endif
-#ifdef CUDA
-  call exec_thom_tds_compact(du_dev, u_dev, tdsops, blocks, threads)
-#else
-  call exec_thom_tds_compact(du, u, tdsops, n_groups)
-#endif
+    call checkerr(u_data, du_data, residual_tol, label, allpass)
 
-#ifdef CUDA
-  ! move data to host
-  du = du_dev
-#endif
+    call allocator%release_block(u_field)
+    call allocator%release_block(du_field)
 
-  call checkerr(u, du, residual_tol, 'thom_periodic', allpass)
-
-  !! Dirichlet case
-  print *, "=== Testing Dirichlet case ==="
-
-  do k = 1, n_groups
-    do j = 1, n
-      do i = 1, SZ
-        u(i, j, k) = sin((j - 1)*dx)
-      end do
-    end do
-  end do
-
-#ifdef CUDA
-  ! move data to device
-  u_dev = u
-#endif
-
-  ! preprocess the operator and coefficient arrays
-  tdsops = tdsops_init(n, dx, &
-                       operation="second-deriv", scheme="compact6", &
-                       bc_start=BC_DIRICHLET, bc_end=BC_DIRICHLET)
-
-#ifdef CUDA
-  call exec_thom_tds_compact(du_dev, u_dev, tdsops, blocks, threads)
-#else
-  call exec_thom_tds_compact(du, u, tdsops, n_groups)
-#endif
-
-#ifdef CUDA
-  ! move data to host
-  du = du_dev
-#endif
-
-  call checkerr(u, du, residual_tol, 'thom_dirichlet', allpass)
-
-  call finalise_test(allpass, finalize_mpi=.false.)
+  end subroutine run_case
 
 end program test_thom

--- a/tests/verification/test_thom.f90
+++ b/tests/verification/test_thom.f90
@@ -13,7 +13,7 @@ program test_thom
   use m_tdsops, only: tdsops_t, tdsops_init
   use m_exec_thom, only: exec_thom_tds_compact
 #endif
-  use m_test_utils, only: checkerr
+  use m_test_utils, only: checkerr, finalise_test
   implicit none
 
   ! The second-derivative roundoff floor is ~eps/dx^2: at n=1024 this is
@@ -129,10 +129,6 @@ program test_thom
 
   call checkerr(u, du, residual_tol, 'thom_dirichlet', allpass)
 
-  if (allpass) then
-    print *, 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
+  call finalise_test(allpass, finalize_mpi=.false.)
 
 end program test_thom

--- a/tests/verification/test_time_integrator.f90
+++ b/tests/verification/test_time_integrator.f90
@@ -8,6 +8,7 @@ program test_omp_adamsbashforth
   use m_base_backend, only: base_backend_t
   use m_time_integrator, only: time_intg_t
   use m_field, only: flist_t
+  use m_test_utils, only: finalise_test
 #ifdef CUDA
   use cudafor
 
@@ -198,12 +199,6 @@ program test_omp_adamsbashforth
   end do
 
   ! check if all tests are passing
-  if (allpass) then
-    write (stderr, '(a)') 'ALL TESTS PASSED SUCCESSFULLY.'
-  else
-    error stop 'SOME TESTS FAILED.'
-  end if
-
   call allocator%release_block(sol(1)%ptr)
   call allocator%release_block(deriv(1)%ptr)
 
@@ -212,8 +207,7 @@ program test_omp_adamsbashforth
   deallocate (deriv)
   deallocate (norm)
 
-  ! finalize MPI
-  call MPI_Finalize(ierr)
+  call finalise_test(allpass)
 
 contains
   function dahlquist_rhs(u)

--- a/tests/verification/test_time_integrator.f90
+++ b/tests/verification/test_time_integrator.f90
@@ -1,34 +1,19 @@
 program test_omp_adamsbashforth
   use iso_fortran_env, only: stderr => error_unit
-  use mpi
 
-  use m_common, only: dp, pi, DIR_X, VERT
+  use m_common, only: dp, pi, DIR_X
   use m_mesh, only: mesh_t
-  use m_allocator, only: allocator_t, field_t
+  use m_allocator, only: allocator_t
   use m_base_backend, only: base_backend_t
+  use m_backend_runtime, only: backend_runtime_t
   use m_time_integrator, only: time_intg_t
   use m_field, only: flist_t
-  use m_test_utils, only: finalise_test
-#ifdef CUDA
-  use cudafor
-
-  use m_cuda_allocator, only: cuda_allocator_t, cuda_field_t
-  use m_cuda_backend, only: cuda_backend_t
-  use m_cuda_common, only: SZ
-#else
-  use m_omp_common, only: SZ
-#ifndef OMP_TGT
-  use m_omp_backend, only: omp_backend_t
-#else
-  use m_omptgt_backend, only: omptgt_backend_t
-  use m_omptgt_allocator, only: omptgt_allocator_t
-#endif
-#endif
+  use m_test_utils, only: initialise_mpi, finalise_test
 
   implicit none
 
   logical :: allpass = .true.
-  integer :: i, j, k, stage, istartup, nrank, nproc, ierr
+  integer :: i, j, k, stage, istartup, nrank, nproc
   integer :: nstep0 = 64, nstep, nrun = 3, nmethod = 8
   character(len=3) :: method(8)
   real(dp), allocatable, dimension(:) :: err
@@ -38,7 +23,6 @@ program test_omp_adamsbashforth
 #else
   real(dp) :: dt0 = 0.01_dp, dt, order
 #endif
-  real(dp) :: u0
   type(flist_t), allocatable :: sol(:)
   type(flist_t), allocatable :: deriv(:)
   real(dp), allocatable, dimension(:, :, :) :: data_array
@@ -46,34 +30,14 @@ program test_omp_adamsbashforth
   real(dp), dimension(3) :: L_global
   character(len=20) :: BC_x(2), BC_y(2), BC_z(2)
 
+  type(backend_runtime_t), target :: runtime
   class(base_backend_t), pointer :: backend
   class(allocator_t), pointer :: allocator
-  class(mesh_t), allocatable :: mesh
-#ifdef CUDA
-  type(cuda_backend_t), target :: cuda_backend
-  type(cuda_allocator_t), target :: cuda_allocator
-  integer :: ndevs, devnum
-#else
-#ifndef OMP_TGT
-  type(allocator_t), target :: omp_allocator
-  type(omp_backend_t), target :: omp_backend
-#else
-  type(omptgt_allocator_t), target :: omptgt_allocator
-  type(omptgt_backend_t), target :: omptgt_backend
-#endif
-#endif
+  type(mesh_t), target :: mesh
   class(time_intg_t), allocatable :: time_integrator
 
   ! initialize MPI
-  call MPI_Init(ierr)
-  call MPI_Comm_rank(MPI_COMM_WORLD, nrank, ierr)
-  call MPI_Comm_size(MPI_COMM_WORLD, nproc, ierr)
-
-#ifdef CUDA
-  ierr = cudaGetDeviceCount(ndevs)
-  ierr = cudaSetDevice(mod(nrank, ndevs)) ! round-robin
-  ierr = cudaGetDevice(devnum)
-#endif
+  call initialise_mpi(nrank, nproc)
 
   ! Global number of cells in each direction
   dims_global = [1, 1, 1]
@@ -90,34 +54,13 @@ program test_omp_adamsbashforth
 
   mesh = mesh_t(dims_global, nproc_dir, L_global, BC_x, BC_y, BC_z)
 
-  ! allocate object
-#ifdef CUDA
-  cuda_allocator = cuda_allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => cuda_allocator
-  if (nrank == 0) print *, 'CUDA allocator instantiated'
-
-  cuda_backend = cuda_backend_t(mesh, allocator)
-  backend => cuda_backend
-  if (nrank == 0) print *, 'CUDA backend instantiated'
-#else
-#ifndef OMP_TGT
-  omp_allocator = allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omp_allocator
-#else
-  omptgt_allocator = omptgt_allocator_t(mesh%get_dims(VERT), SZ)
-  allocator => omptgt_allocator
-#endif
-  if (nrank == 0) print *, 'OpenMP allocator instantiated'
-
-#ifndef OMP_TGT
-  omp_backend = omp_backend_t(mesh, allocator)
-  backend => omp_backend
-#else
-  omptgt_backend = omptgt_backend_t(mesh, allocator)
-  backend => omptgt_backend
-#endif
-  if (nrank == 0) print *, 'OpenMP backend instantiated'
-#endif
+  call runtime%init(mesh)
+  allocator => runtime%allocator
+  backend => runtime%backend
+  if (nrank == 0) then
+    print *, trim(runtime%backend_name), 'allocator instantiated'
+    print *, trim(runtime%backend_name), 'backend instantiated'
+  end if
 
   ! allocate memory
   allocate (sol(1))
@@ -207,7 +150,7 @@ program test_omp_adamsbashforth
   deallocate (deriv)
   deallocate (norm)
 
-  call finalise_test(allpass)
+  call finalise_test(allpass, nrank)
 
 contains
   function dahlquist_rhs(u)
@@ -235,4 +178,3 @@ contains
   end function dahlquist_exact_sol
 
 end program test_omp_adamsbashforth
-


### PR DESCRIPTION
Closes #293 

- Centralise MPI initialisation, result reporting, and finalisation in shared test utilities
- Add shared runtime setup for backend, allocator, and CUDA device selection while retaining OMP, CUDA, and OMP-target support
- Use backend-neutral field access and solver operations to remove repeated preprocessor and `select type` blocks
- Isolate backend-specific Fortran modules in the test build.

#### Testing

Built and ran the affected GNU/OpenMP and NVHPC/CUDA tests locally. OMP-target paths are covered by CI.