### PR TITLE
Fix bundled ADIOS2 options and disable unused HDF5/CURL support

### DIFF
--- a/cmake/adios2/downloadBuildAdios2.cmake.in
+++ b/cmake/adios2/downloadBuildAdios2.cmake.in
@@ -12,8 +12,10 @@ ExternalProject_Add(downloadBuildAdios2
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX:PATH=@adios2_install_dir@
       -DADIOS2_BUILD_EXAMPLES=OFF
-      -DADIOS2_BUILD_TESTING=OFF
+      -DBUILD_TESTING=OFF
       -DADIOS2_USE_Fortran=ON
+      -DADIOS2_USE_HDF5=OFF
+      -DADIOS2_USE_CURL=OFF
       -DADIOS2_USE_CUDA=@X3D2_ADIOS2_CUDA@
       -DCMAKE_CUDA_ARCHITECTURES=@x3d2_adios2_cuda_arch@
 )


### PR DESCRIPTION
Fixes #345 

The cause of the build failure was neither a CMake 3.31 issue nor an ADIOS2 bug. It is an EasyBuild module dependency contaminating ADIOS2's automatic dependency discovery.

The CMake module automatically loads: `cURL/8.11.1-GCCore-14.20` and `OpenSSL/3` and add their prefixes to `CMAKE_PREFIX_PATH`. ADIOS2 then combines Ubuntu HDF5 (expects CURL_OPENSSL_4) and EasyBuild libcurl (does not provide versioned CURL_OPENSSL_4 symbols). This incomplete mixture causes the `adios2_remote_server` link failure reported in #345. The apparent CMake-version correlation is incidental - system CMake does not bring the EasyBuild curl stack into dependency discovery. I've created an issue on easybuild- easyconfigs: https://github.com/easybuilders/easybuild-easyconfigs/issues/26684

The fix I've done here is to make the bundled ADIOS2 build minimal as x3d2 does not require ADIOS2's HDF5 engine or HTTPS remote-access support. Therefore, I've disabled `ADIOS2_USE_HDF5` and `ADIOS2_USE_CURL`. If we ever use HDF5 or curl we'll need to revisit this, but this change should make compiling more robust when using CMake loaded from EasyBuild.

Note that I also fixed another flag `DBUILD_TESTING` which was wrong before.