### PR TITLE
Fix link failure with GCC built with OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(cmake_minimum_version 3.11)
+set(cmake_minimum_version 3.13)
 cmake_minimum_required(VERSION ${cmake_minimum_version})
 project(x3d2 LANGUAGES Fortran CXX C)
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,5 +58,12 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" OR
   endif()
 endif()
 
+# Give the imported target the link option FindOpenMP omits: every target that
+# links OpenMP::OpenMP_Fortran picks it up, executables and tests alike.
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND OpenMP_Fortran_FLAGS)
+  set_property(TARGET OpenMP::OpenMP_Fortran APPEND PROPERTY
+    INTERFACE_LINK_OPTIONS "SHELL:${OpenMP_Fortran_FLAGS}")
+endif()
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -32,7 +32,7 @@ You can install Open MPI using your package manager. For Ubuntu, this can be obt
 CMake
 ^^^^^
 
-To build x3d2, you will need CMake version 3.11 and above (3.20+ recommended). You can download the latest version from the `CMake website <https://cmake.org/download/>`_. Alternatively, you can install it using your package manager. For Ubuntu, this can be obtained using:
+To build x3d2, you will need CMake version 3.13 and above (3.20+ recommended). You can download the latest version from the `CMake website <https://cmake.org/download/>`_. Alternatively, you can install it using your package manager. For Ubuntu, this can be obtained using:
 
 .. code-block:: bash
 
@@ -149,7 +149,7 @@ You must build Open MPI from source to ensure it is compatible with GNU compiler
 CMake
 ^^^^^
 
-To build x3d2, you will need CMake version 3.11 and above (3.20+ recommended). You can download the latest version from the `CMake website <https://cmake.org/download/>`_. Alternatively, you can install it using Homebrew:
+To build x3d2, you will need CMake version 3.13 and above (3.20+ recommended). You can download the latest version from the `CMake website <https://cmake.org/download/>`_. Alternatively, you can install it using Homebrew:
 
 .. code-block:: bash
 


### PR DESCRIPTION
After #337 , the OpenMP build fails on GNU compiler 

```
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccaAYwGg.crtoffloadtable.o:(.rodata+0x0): undefined reference to `__offload_func_table'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccaAYwGg.crtoffloadtable.o:(.rodata+0x8): undefined reference to `__offload_funcs_end'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccaAYwGg.crtoffloadtable.o:(.rodata+0x10): undefined reference to `__offload_var_table'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccaAYwGg.crtoffloadtable.o:(.rodata+0x18): undefined reference to `__offload_vars_end'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccaAYwGg.crtoffloadtable.o:(.rodata+0x20): undefined reference to `__offload_ind_func_table'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccaAYwGg.crtoffloadtable.o:(.rodata+0x28): undefined reference to `__offload_ind_funcs_end'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccGBGgDW.crtoffloadtable.o:(.rodata+0x0): undefined reference to `__offload_func_table'
/opt/software/software/binutils/2.42-GCCcore-14.2.0/bin/ld: /tmp/ccGBGgDW.crtoffloadtable.o:(.rodata+0x8): undefined reference to `__offload_funcs_end'
```

This fixes missing OpenMP link