### PR TITLE
Fix regression test suite portability and robustness

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,9 +74,15 @@ jobs:
     - name: Build tests (single precision)
       run: make -C build-single-debug
 
+    - name: Run unit and verification tests (single precision)
+      run: ctest --test-dir build-single-debug -L "unit|verification" --output-on-failure
+
     - name: Configure Release build (single precision)
       run: FC=mpif90 cmake -S . -B build-single -DCMAKE_BUILD_TYPE=Release -DSINGLE_PREC=ON -DWITH_ADIOS2=ON -DUSE_SYSTEM_ADIOS2=ON
 
     - name: Build tests (single precision)
       run: make -C build-single
+
+    - name: Run unit and verification tests (single precision)
+      run: ctest --test-dir build-single -L "unit|verification" --output-on-failure
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,7 +75,7 @@ jobs:
       run: make -C build-single-debug
 
     - name: Run unit and verification tests (single precision)
-      run: ctest --test-dir build-single-debug -L "unit|verification" --output-on-failure
+      run: ctest --test-dir build-single-debug -L "unit|verification|regression" --output-on-failure
 
     - name: Configure Release build (single precision)
       run: FC=mpif90 cmake -S . -B build-single -DCMAKE_BUILD_TYPE=Release -DSINGLE_PREC=ON -DWITH_ADIOS2=ON -DUSE_SYSTEM_ADIOS2=ON

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ build-and-test-single-prec:
     ADIOS2_VERSION: 2.10.2
     EXTRA_MODULE: "adios2"
     SINGLE_PREC: "ON"
-    RUN_TEST: "OFF"
+    RUN_TEST: "ON"
 
 build-and-test-cuda:
   <<: *build-and-test-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,13 +48,25 @@ stages:
     - echo "Build tests"
     - make -C build-debug
     - echo "Run the tests"
-    - if [ "${RUN_TEST}" == "ON" ]; then ctest --test-dir build-debug -L "unit|verification" --output-on-failure; fi
+    - if [ "${RUN_TEST}" == "ON" ]; then ctest --test-dir build-debug -L "unit|verification" --output-on-failure --output-junit ctest-junit.xml; fi
     - echo "Configure Release build"
     - FC=mpif90 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_ADIOS2=ON -DUSE_SYSTEM_ADIOS2=ON -DSINGLE_PREC=${SINGLE_PREC}
     - echo "Build tests"
     - make -C build
     - echo "Run the tests"
-    - if [ "${RUN_TEST}" == "ON" ]; then ctest --test-dir build -L "unit|verification" --output-on-failure; fi
+    - if [ "${RUN_TEST}" == "ON" ]; then ctest --test-dir build -L "unit|verification" --output-on-failure --output-junit ctest-junit.xml; fi
+  # Surface individual test results in the pipeline's Tests tab. Without a
+  # report GitLab shows "Tests 0" and a failing test is only visible by
+  # scrolling the raw job log. ctest still sets the job's exit status, so this
+  # is purely additive. Paths are relative to the build dir --output-junit was
+  # given, so they sit inside build-debug/ and build/.
+  artifacts:
+    when: always
+    expire_in: 1 month
+    reports:
+      junit:
+        - build-debug/ctest-junit.xml
+        - build/ctest-junit.xml
   tags:
     - gpu
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,13 +48,13 @@ stages:
     - echo "Build tests"
     - make -C build-debug
     - echo "Run the tests"
-    - if [ "${RUN_TEST}" == "ON" ]; then cd build-debug && ctest -L "unit|verification" --output-on-failure && cd ..; fi
+    - if [ "${RUN_TEST}" == "ON" ]; then ctest --test-dir build-debug -L "unit|verification" --output-on-failure; fi
     - echo "Configure Release build"
     - FC=mpif90 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_ADIOS2=ON -DUSE_SYSTEM_ADIOS2=ON -DSINGLE_PREC=${SINGLE_PREC}
     - echo "Build tests"
     - make -C build
     - echo "Run the tests"
-    - if [ "${RUN_TEST}" == "ON" ]; then cd build && ctest -L "unit|verification" --output-on-failure && cd ..; fi
+    - if [ "${RUN_TEST}" == "ON" ]; then ctest --test-dir build -L "unit|verification" --output-on-failure; fi
   tags:
     - gpu
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,7 +196,7 @@ endif()
 if(SINGLE_PREC)
   set(_smoke_cmp_args --rtol 1e-4
       --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
-  set(_nightly_cmp_args --rtol 1e-4
+  set(_nightly_cmp_args --rtol 1e-3
       --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
 else()
   set(_smoke_cmp_args --rtol 1e-10

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,20 +189,33 @@ endif()
 
 # The divergence columns are a "stays at round-off" assertion, not a value to
 # reproduce, so they are bounded absolutely rather than diffed (see the
-# comparator docstring). The ceilings are per case because the two differ by
-# four orders: the smoke case peaks at 8.7e-10 and the nightly at 3.3e-14.
-# Each is set about an order above the observed maximum, which leaves room for
+# comparator docstring). Round-off is what the ceiling tracks, so it depends on
+# the working precision, and on the case: in double the smoke case peaks at
+# 8.7e-10 and the nightly at 3.3e-14, while in single both sit at ~4e-6. Each
+# is set about an order above the observed maximum, which leaves room for
 # compiler variation while staying far below any real loss of solenoidality.
+# The golden itself is double precision in both cases -- the diffed columns
+# agree to ~2e-7 relative in single, well inside rtol.
+if(SINGLE_PREC)
+  set(_smoke_ceilings --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
+  set(_nightly_ceilings --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
+else()
+  set(_smoke_ceilings --ceiling div_u_max=1e-8 --ceiling div_u_mean=1e-9)
+  set(_nightly_ceilings --ceiling div_u_max=1e-12 --ceiling div_u_mean=1e-13)
+endif()
+
 if(WITH_2DECOMPFFT AND _cpu_omp_backend)
   define_regression_case_test(tgv_smoke tgv_smoke.x3d tgv_smoke_golden_omp.csv 2 omp
-    --ceiling div_u_max=1e-8 --ceiling div_u_mean=1e-9)
+    ${_smoke_ceilings})
 endif()
 
 # Heavier nightly regression case (opt-in; kept out of PR CI to stay fast).
 if(WITH_2DECOMPFFT AND _cpu_omp_backend AND WITH_NIGHTLY_REGRESSION)
   define_regression_case_test(tgv_nightly tgv_nightly.x3d tgv_nightly_golden_omp.csv 2 omp
-    --ceiling div_u_max=1e-12 --ceiling div_u_mean=1e-13)
+    ${_nightly_ceilings})
 endif()
+unset(_smoke_ceilings)
+unset(_nightly_ceilings)
 unset(_cpu_omp_backend)
 
 if(${OMP_TGT})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,10 @@ endfunction()
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 function(define_regression_case_test case_name input_file golden_file np backend)
+  # Trailing arguments are passed through to the comparator (e.g. --ceiling).
+  set(extra_args "${ARGN}")
+  string(REPLACE ";" " " extra_args_str "${extra_args}")
+
   set(test_name regression_${case_name}_${backend}_${np})
   set(work_dir ${CMAKE_CURRENT_BINARY_DIR}/regression/${test_name})
   file(MAKE_DIRECTORY ${work_dir})
@@ -132,7 +136,7 @@ function(define_regression_case_test case_name input_file golden_file np backend
     COMMAND sh -c
       "${launcher} $<TARGET_FILE:xcompact> ${input} && \
        ${Python3_EXECUTABLE} ${comparator} golden \
-       --produced monitoring.csv --golden ${golden}"
+       --produced monitoring.csv --golden ${golden} ${extra_args_str}"
     WORKING_DIRECTORY ${work_dir})
   set_tests_properties(${test_name} PROPERTIES LABELS "regression;${backend}")
 endfunction()
@@ -183,13 +187,21 @@ if((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" OR
   set(_cpu_omp_backend FALSE)
 endif()
 
+# The divergence columns are a "stays at round-off" assertion, not a value to
+# reproduce, so they are bounded absolutely rather than diffed (see the
+# comparator docstring). The ceilings are per case because the two differ by
+# four orders: the smoke case peaks at 8.7e-10 and the nightly at 3.3e-14.
+# Each is set about an order above the observed maximum, which leaves room for
+# compiler variation while staying far below any real loss of solenoidality.
 if(WITH_2DECOMPFFT AND _cpu_omp_backend)
-  define_regression_case_test(tgv_smoke tgv_smoke.x3d tgv_smoke_golden_omp.csv 2 omp)
+  define_regression_case_test(tgv_smoke tgv_smoke.x3d tgv_smoke_golden_omp.csv 2 omp
+    --ceiling div_u_max=1e-8 --ceiling div_u_mean=1e-9)
 endif()
 
 # Heavier nightly regression case (opt-in; kept out of PR CI to stay fast).
 if(WITH_2DECOMPFFT AND _cpu_omp_backend AND WITH_NIGHTLY_REGRESSION)
-  define_regression_case_test(tgv_nightly tgv_nightly.x3d tgv_nightly_golden_omp.csv 2 omp)
+  define_regression_case_test(tgv_nightly tgv_nightly.x3d tgv_nightly_golden_omp.csv 2 omp
+    --ceiling div_u_max=1e-12 --ceiling div_u_mean=1e-13)
 endif()
 unset(_cpu_omp_backend)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -187,35 +187,36 @@ if((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" OR
   set(_cpu_omp_backend FALSE)
 endif()
 
-# The divergence columns are a "stays at round-off" assertion, not a value to
-# reproduce, so they are bounded absolutely rather than diffed (see the
-# comparator docstring). Round-off is what the ceiling tracks, so it depends on
-# the working precision, and on the case: in double the smoke case peaks at
-# 8.7e-10 and the nightly at 3.3e-14, while in single both sit at ~4e-6. Each
-# is set about an order above the observed maximum, which leaves room for
-# compiler variation while staying far below any real loss of solenoidality.
-# The golden itself is double precision in both cases -- the diffed columns
-# agree to ~2e-7 relative in single, well inside rtol.
+# div_u is a "stays at round-off" assertion, so it is bounded absolutely rather
+# than diffed (see the comparator docstring). Round-off tracks the working
+# precision, and the case, so the ceilings do too; rtol tracks precision
+# because it sets what the suite can detect. The golden is double precision for
+# both. If a CI compiler drifts past these, the failure prints the observed
+# |diff| -- loosen to that, not back to the 1e-4 default.
 if(SINGLE_PREC)
-  set(_smoke_ceilings --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
-  set(_nightly_ceilings --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
+  set(_smoke_cmp_args --rtol 1e-4
+      --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
+  set(_nightly_cmp_args --rtol 1e-4
+      --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
 else()
-  set(_smoke_ceilings --ceiling div_u_max=1e-8 --ceiling div_u_mean=1e-9)
-  set(_nightly_ceilings --ceiling div_u_max=1e-12 --ceiling div_u_mean=1e-13)
+  set(_smoke_cmp_args --rtol 1e-10
+      --ceiling div_u_max=1e-8 --ceiling div_u_mean=1e-9)
+  set(_nightly_cmp_args --rtol 1e-10
+      --ceiling div_u_max=1e-12 --ceiling div_u_mean=1e-13)
 endif()
 
 if(WITH_2DECOMPFFT AND _cpu_omp_backend)
   define_regression_case_test(tgv_smoke tgv_smoke.x3d tgv_smoke_golden_omp.csv 2 omp
-    ${_smoke_ceilings})
+    ${_smoke_cmp_args})
 endif()
 
 # Heavier nightly regression case (opt-in; kept out of PR CI to stay fast).
 if(WITH_2DECOMPFFT AND _cpu_omp_backend AND WITH_NIGHTLY_REGRESSION)
   define_regression_case_test(tgv_nightly tgv_nightly.x3d tgv_nightly_golden_omp.csv 2 omp
-    ${_nightly_ceilings})
+    ${_nightly_cmp_args})
 endif()
-unset(_smoke_ceilings)
-unset(_nightly_ceilings)
+unset(_smoke_cmp_args)
+unset(_nightly_cmp_args)
 unset(_cpu_omp_backend)
 
 if(${OMP_TGT})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,10 +120,17 @@ function(define_regression_case_test case_name input_file golden_file np backend
   set(comparator ${CMAKE_CURRENT_SOURCE_DIR}/regression/compare_monitoring.py)
   set(input ${CMAKE_CURRENT_SOURCE_DIR}/regression/${input_file})
   set(golden ${CMAKE_CURRENT_SOURCE_DIR}/regression/${golden_file})
+  # Match the launcher define_test() uses: Cray machines are Slurm-driven and
+  # have no mpirun, so an mpirun-based test cannot start there at all.
+  if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray")
+    set(launcher "srun -n ${np}")
+  else()
+    set(launcher "mpirun --oversubscribe -np ${np}")
+  endif()
   add_test(
     NAME ${test_name}
     COMMAND sh -c
-      "mpirun --oversubscribe -np ${np} $<TARGET_FILE:xcompact> ${input} && \
+      "${launcher} $<TARGET_FILE:xcompact> ${input} && \
        ${Python3_EXECUTABLE} ${comparator} golden \
        --produced monitoring.csv --golden ${golden}"
     WORKING_DIRECTORY ${work_dir})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -191,12 +191,14 @@ endif()
 # than diffed (see the comparator docstring). Round-off tracks the working
 # precision, and the case, so the ceilings do too; rtol tracks precision
 # because it sets what the suite can detect. The golden is double precision for
-# both. If a CI compiler drifts past these, the failure prints the observed
-# |diff| -- loosen to that, not back to the 1e-4 default.
+# both. The single-precision tolerances leave roughly an order of magnitude or
+# more above the largest observed cross-build differences while retaining useful
+# regression sensitivity. If a CI compiler drifts past these, the failure prints
+# the observed |diff| so the tolerance can be revisited empirically.
 if(SINGLE_PREC)
-  set(_smoke_cmp_args --rtol 1e-4
+  set(_smoke_cmp_args --rtol 1e-5
       --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
-  set(_nightly_cmp_args --rtol 1e-3
+  set(_nightly_cmp_args --rtol 1e-4
       --ceiling div_u_max=1e-4 --ceiling div_u_mean=1e-5)
 else()
   set(_smoke_cmp_args --rtol 1e-10

--- a/tests/regression/compare_monitoring.py
+++ b/tests/regression/compare_monitoring.py
@@ -87,11 +87,15 @@ def compare_golden(produced: Path, golden: Path, rtol: float, atol: float,
 
     # Rows are matched by index, so bail early with a clear message if the time
     # columns disagree rather than emitting a cascade of value mismatches.
+    # This guards row *alignment*, where a mismatch is a whole output interval,
+    # so it uses the same tolerance as everything else. A tighter bound would
+    # not catch anything extra and would trip on representation alone: float32
+    # writes t=0.05 as 4.999999701977e-02, which is not a disagreement.
     if "time" in prod_cols and "time" in gold_cols:
         prod_t = column("time", prod_cols, prod_rows)
         gold_t = column("time", gold_cols, gold_rows)
         for i, (pt, gt) in enumerate(zip(prod_t, gold_t)):
-            if abs(pt - gt) > 1e-9 + 1e-9 * abs(gt):
+            if abs(pt - gt) > atol + rtol * abs(gt):
                 print(
                     f"FAIL: time column misaligned at row {i}: "
                     f"produced t={pt:.12e} vs golden t={gt:.12e}",

--- a/tests/regression/compare_monitoring.py
+++ b/tests/regression/compare_monitoring.py
@@ -10,6 +10,16 @@ quantities such as divergence (via ``atol``). This is the day-to-day "did any
 commit change the numbers" guard. Physics validation against reference data is
 performed separately and manually.
 
+Ceilings
+    ``--ceiling COLUMN=VALUE`` checks a column against an absolute bound and
+    skips its element-wise diff. Use it for quantities whose stored value is
+    round-off rather than signal. The divergence columns are a "stays at
+    zero" assertion: diffing them against a reference to ``rtol`` is checking
+    noise, which happens to be reproducible in double precision and is not at
+    float32, where they move by 10-20% between builds of the same compiler. A
+    ceiling states the real assertion and holds across compilers and
+    precisions.
+
 Blessing
     Passing ``--bless`` copies the produced file to the golden path and exits
     0. This is the *only* way to write a golden: a ``--golden`` path that does
@@ -62,7 +72,8 @@ def column(name: str, columns: list[str], rows: list[list[float]]) -> list[float
     return [row[idx] for row in rows]
 
 
-def compare_golden(produced: Path, golden: Path, rtol: float, atol: float) -> int:
+def compare_golden(produced: Path, golden: Path, rtol: float, atol: float,
+                   ceilings: dict[str, float]) -> int:
     prod_cols, prod_rows = read_monitoring(produced)
     gold_cols, gold_rows = read_monitoring(golden)
 
@@ -88,6 +99,15 @@ def compare_golden(produced: Path, golden: Path, rtol: float, atol: float) -> in
                 )
                 return 1
 
+    unknown = [c for c in ceilings if c not in prod_cols]
+    if unknown:
+        print(
+            "FAIL: --ceiling names column(s) not in the produced output: "
+            + ", ".join(unknown),
+            file=sys.stderr,
+        )
+        return 1
+
     missing = [c for c in gold_cols if c not in prod_cols]
     if missing:
         print(
@@ -99,7 +119,37 @@ def compare_golden(produced: Path, golden: Path, rtol: float, atol: float) -> in
 
     failures = 0
     worst = (0.0, "", -1)  # (excess, column, row)
+
+    # Ceiling columns assert "this stayed at round-off" rather than "this
+    # reproduces a stored value", so they are never diffed against the golden.
+    for name, limit in ceilings.items():
+        for i, p in enumerate(column(name, prod_cols, prod_rows)):
+            if math.isfinite(p) and abs(p) <= limit:
+                continue
+            failures += 1
+            if not math.isfinite(p):
+                if worst[2] == -1:
+                    worst = (math.inf, name, i)
+                if failures <= 10:
+                    print(
+                        f"FAIL: {name} row {i}: non-finite value "
+                        f"(produced={p})",
+                        file=sys.stderr,
+                    )
+                continue
+            excess = abs(p) - limit
+            if excess > worst[0]:
+                worst = (excess, name, i)
+            if failures <= 10:
+                print(
+                    f"FAIL: {name} row {i}: produced={p:.12e} exceeds "
+                    f"ceiling {limit:.3e}",
+                    file=sys.stderr,
+                )
+
     for name in gold_cols:
+        if name in ceilings:
+            continue
         prod = column(name, prod_cols, prod_rows)
         gold = column(name, gold_cols, gold_rows)
         for i, (p, g) in enumerate(zip(prod, gold)):
@@ -130,17 +180,22 @@ def compare_golden(produced: Path, golden: Path, rtol: float, atol: float) -> in
 
     if failures:
         print(
-            f"FAIL: {failures} value(s) exceeded tolerance "
+            f"FAIL: {failures} value(s) exceeded tolerance or ceiling "
             f"(rtol={rtol:g}, atol={atol:g}); worst: column '{worst[1]}' "
             f"row {worst[2]}",
             file=sys.stderr,
         )
         return 1
 
-    print(
-        f"PASS: {len(gold_cols)} column(s) x {len(prod_rows)} row(s) "
+    diffed = [c for c in gold_cols if c not in ceilings]
+    summary = (
+        f"PASS: {len(diffed)} column(s) x {len(prod_rows)} row(s) "
         f"within tolerance (rtol={rtol:g}, atol={atol:g})"
     )
+    if ceilings:
+        bounds = ", ".join(f"{n}<={v:g}" for n, v in ceilings.items())
+        summary += f"; {len(ceilings)} within ceiling ({bounds})"
+    print(summary)
     return 0
 
 
@@ -154,6 +209,10 @@ def main(argv: list[str] | None = None) -> int:
     g.add_argument("--golden", type=Path, required=True)
     g.add_argument("--rtol", type=float, default=1e-4)
     g.add_argument("--atol", type=float, default=1e-10)
+    g.add_argument(
+        "--ceiling", action="append", default=[], metavar="COLUMN=VALUE",
+        help="bound COLUMN absolutely instead of diffing it against the golden"
+    )
     g.add_argument("--bless", action="store_true", help="write produced as golden")
 
     args = parser.parse_args(argv)
@@ -175,7 +234,29 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    return compare_golden(args.produced, args.golden, args.rtol, args.atol)
+    ceilings: dict[str, float] = {}
+    for item in args.ceiling:
+        name, sep, value = item.partition("=")
+        name = name.strip()
+        if not sep or not name:
+            print(
+                f"FAIL: --ceiling expects COLUMN=VALUE, got {item!r}",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            ceilings[name] = float(value)
+        except ValueError:
+            print(
+                f"FAIL: --ceiling value for {name!r} is not a number: "
+                f"{value!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+    return compare_golden(
+        args.produced, args.golden, args.rtol, args.atol, ceilings
+    )
 
 
 if __name__ == "__main__":

--- a/tests/regression/compare_monitoring.py
+++ b/tests/regression/compare_monitoring.py
@@ -11,8 +11,10 @@ commit change the numbers" guard. Physics validation against reference data is
 performed separately and manually.
 
 Blessing
-    Passing ``--bless`` (or pointing ``--golden`` at a non-existent file in
-    ``golden`` mode) copies the produced file to the golden path and exits 0.
+    Passing ``--bless`` copies the produced file to the golden path and exits
+    0. This is the *only* way to write a golden: a ``--golden`` path that does
+    not exist is a failure, so a typo or a rename cannot quietly turn the
+    regression guard off.
     Use this to (re)generate the reference in the *same* environment that CI
     runs in — golden files are only reproducible for a fixed
     compiler/precision/rank-count. New columns are compared only once they
@@ -156,11 +158,23 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    if args.bless or not args.golden.exists():
+    if args.bless:
         args.golden.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(args.produced, args.golden)
         print(f"BLESSED: wrote golden {args.golden}")
         return 0
+
+    # Never bless implicitly: under CTest a missing golden would otherwise be
+    # an unconditional pass that also writes a new reference into the source
+    # tree, leaving a permanently green test that compares nothing.
+    if not args.golden.exists():
+        print(
+            f"FAIL: golden file not found: {args.golden}\n"
+            "      Check the path, or pass --bless to create it deliberately.",
+            file=sys.stderr,
+        )
+        return 1
+
     return compare_golden(args.produced, args.golden, args.rtol, args.atol)
 
 

--- a/tests/unit/test_les.f90
+++ b/tests/unit/test_les.f90
@@ -42,7 +42,7 @@ program test_les
   length = wall_damped_mixing_length(1._dp, 1.0e6_dp, 0.2_dp, &
                                       0.4_dp, 3._dp, 0._dp)
   call check_close('wall damping far from wall', length, 0.2_dp, &
-                   1.0e-14_dp, all_pass)
+                   tol, all_pass)
 
   if (.not. all_pass) error stop 'FAIL'
   print *, 'PASS'


### PR DESCRIPTION
The regression suite added by #341 works in the configuration CI runs, but it had surfaced some bugs which were invisible because of gaps in how CI runs tests.

#### Regression suite

- `div_u_max/div_u_mean` are essentially zero plus round-odff, so checking them against a stored number was just comparing noise. They're now checked against an upper bound
- The suit now runs in single-precision too, against the same reference file as double-precision. The only thing locking it was a hardcoded tolerance on the time column, too light for float32, which can't represent 0.05 exactly. A single-precision reference would actually be worse: 2 single-precision builds differ from each other more than either differs from the double-precision one. 
- Tightened tolerance from `1e-4` to `1e-10` in double-precision. Single-precision needs looser limits because its round-off accumulates over the run: 1e-4 for the short case and 1e-3 for the nightly.
- The hardcoded `mpirun`, which doesn't exist on Cray machines like ARCHER2. It now uses `srun` there
- Overwriting the reference ("blessing") now needs an explicit `--bless`. Before, a mistyped path was read as a request to create a new reference - so the test passed without comparing anything.

#### CI
- `ctest` now runs via `--test-dir` instead of `ccd build && ctest && cd ..`. When a test failed, the `cd ..` was skipped and the next command failed with an unrelated CMake error - so every GitLab test failure looked like a broken build
- Test results are published as a JUnit report, so failures show in the pipeline's Tests tab instead of only deep in the raw log
- Single-precision builds now run their tests; they were only being compiled before. One fix was needed first: `test_les.f90` used a hardcoded tolerance instead of  that adaps to precision

