### PR TITLE
Set OMP TGT SZ parameter value based on vendor (AMD vs. CUDA)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(cmake_minimum_version 3.13)
 cmake_minimum_required(VERSION ${cmake_minimum_version})
 project(x3d2 LANGUAGES Fortran CXX C)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,9 @@ if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
   target_link_options(x3d2 INTERFACE "-cudalib=cufftmp")
 
   target_compile_options(xcompact PRIVATE "-DCUDA")
+  if (OMP_TGT)
+    add_definitions("-DOMP_TGT_NVIDIA")
+  endif()
 
 elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" OR
        ${CMAKE_Fortran_COMPILER_ID} STREQUAL "LLVMFlang" OR
@@ -155,6 +158,7 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" OR
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ffast-math -funroll-loops -floop-optimize -march=native")
   if (OMP_TGT)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp --offload-arch=${OMP_TGT_ARCH}")
+    add_definitions("-DOMP_TGT_AMD")
   endif()
 elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray")
   set(CMAKE_Fortran_FLAGS "-eF -M878") # -M878 suppresses WARNING multiple module includes (not useful)
@@ -162,6 +166,9 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL "Cray")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
   target_link_options(x3d2 INTERFACE -h omp)
   target_link_options(x3d2_backends INTERFACE -h omp)
+  if (OMP_TGT)
+    add_definitions("-DOMP_TGT_AMD")
+  endif()
 endif()
 
 if(WITH_2DECOMPFFT)

--- a/src/backend/omp/common.f90
+++ b/src/backend/omp/common.f90
@@ -1,6 +1,12 @@
 module m_omp_common
   implicit none
 
-  integer, parameter :: SZ = 16
+#if defined(OMP_TGT_AMD)
+  integer, parameter :: SZ = 64
+#elif defined(OMP_TGT_NVIDIA)
+  integer, parameter :: SZ = 32
+#else
+   integer, parameter :: SZ = 16
+#endif
 
 end module m_omp_common

--- a/src/backend/omp/common.f90
+++ b/src/backend/omp/common.f90
@@ -6,7 +6,7 @@ module m_omp_common
 #elif defined(OMP_TGT_NVIDIA)
   integer, parameter :: SZ = 32
 #else
-   integer, parameter :: SZ = 16
+  integer, parameter :: SZ = 16
 #endif
 
 end module m_omp_common

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -272,7 +272,7 @@ unset(_cpu_omp_backend)
 
 if(${OMP_TGT})
   # OMP TGT unit tests
-  # define_test(unit/test_reordering.f90 1 omp_tgt)
+  define_test(unit/test_reordering.f90 1 omp_tgt)
   define_test(unit/test_vecadd.f90 1 omp_tgt)
   # define_test(unit/test_kinetic_energy.f90 1 omp_tgt)
   define_test(unit/test_setget_field.f90 1 omp_tgt)
@@ -305,7 +305,7 @@ if((${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI" OR
   define_verification_test(verification/test_thom.f90 1 cuda)
   define_verification_test(verification/test_time_integrator.f90 1 cuda)
   define_verification_test(verification/test_fft.f90 1 cuda)
-    define_verification_test(verification/test_poisson_bc.f90 1 cuda)
+  define_verification_test(verification/test_poisson_bc.f90 1 cuda)
   define_verification_test(verification/test_poisson_bc.f90 2 cuda --config 100)
   define_verification_test(verification/test_cuda_tridiag.f90 ${CMAKE_CTEST_NPROCS} cuda)
   define_verification_test(verification/test_cuda_penta.f90 ${CMAKE_CTEST_NPROCS} cuda)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 set(CMAKE_CTEST_ARGUMENTS "--output-on-failure" CACHE STRING "comma separated list of arguments to pass to ctest")
 set(CMAKE_CTEST_NPROCS "4" CACHE STRING "number of process used in tests")
 


### PR DESCRIPTION
CUDA GPUs have a warpsize of 32 while AMD GPUs have a wavefront size of 64. This PR set the SZ value based on the compiler type (NVHPC/PGI for CUDA and CRAY/FLANG for AMD).

Also enable OMP TGT reordering tests.